### PR TITLE
feat(cc): version detection + hook HTTP server + cc settings.json gen (gh-3 PR-2)

### DIFF
--- a/internal/cc/doc.go
+++ b/internal/cc/doc.go
@@ -1,0 +1,12 @@
+// Package cc collects the cc-binary integration helpers used by the
+// ClaudeCodeProvider in internal/agent: version detection, hook
+// settings.json generation, hook HTTP server, JSONL path encoding /
+// session lookup, JSONL watcher + envelope mapper, and (in later PRs)
+// special-command translation.
+//
+// Files in this package are ports / re-implementations of happy-cli's
+// claudeLocal.ts / generateHookSettings.ts / startHookServer.ts /
+// claudeFindLastSession.ts / path.ts modules. The agent package depends
+// on this package; daemon code paths NEVER import this package directly
+// (D-17 seam — they go through internal/agent.AgentProvider).
+package cc

--- a/internal/cc/hooks.go
+++ b/internal/cc/hooks.go
@@ -1,0 +1,165 @@
+package cc
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// hookEvents lists the cc hook events tether subscribes to. Order is
+// stable but not semantically meaningful — settings.json is keyed by
+// event name.
+var hookEvents = []struct {
+	name string // cc canonical EventName (settings.json key)
+	path string // URL path under baseURL
+}{
+	{"PreToolUse", "/hooks/pre-tool-use"},
+	{"PostToolUse", "/hooks/post-tool-use"},
+	{"SessionStart", "/hooks/session-start"},
+	{"UserPromptSubmit", "/hooks/user-prompt-submit"},
+	{"Stop", "/hooks/stop"},
+}
+
+// HookURLs returns the per-event endpoint URLs the cc settings.json will
+// invoke. Exposed for testability — callers verifying end-to-end wiring
+// against a live HookServer can use this directly instead of parsing the
+// curl command string out of SettingsForCC's output.
+//
+// Validates baseURL the same way SettingsForCC does (no trailing slash,
+// loopback host only).
+func HookURLs(baseURL string) (map[string]string, error) {
+	if err := validateBaseURL(baseURL); err != nil {
+		return nil, err
+	}
+	out := make(map[string]string, len(hookEvents))
+	for _, ev := range hookEvents {
+		out[ev.name] = baseURL + ev.path
+	}
+	return out, nil
+}
+
+// validateBaseURL enforces the cc-settings invariants: non-empty,
+// no trailing slash (would produce // in hook URLs), loopback host only
+// (settings.json is locally-scoped — a remote URL would leak hook events
+// off-machine; defense-in-depth against misconfig).
+func validateBaseURL(baseURL string) error {
+	if baseURL == "" {
+		return errors.New("hooks: baseURL required")
+	}
+	if strings.HasSuffix(baseURL, "/") {
+		return errors.New("hooks: baseURL must not have trailing slash (would produce // in hook URL)")
+	}
+	u, err := url.Parse(baseURL)
+	if err != nil {
+		return fmt.Errorf("hooks: parse baseURL: %w", err)
+	}
+	host := u.Hostname()
+	if host != "127.0.0.1" && host != "::1" && host != "localhost" {
+		return fmt.Errorf("hooks: baseURL host must be loopback (127.0.0.1 / ::1 / localhost); got %q", host)
+	}
+	return nil
+}
+
+// SettingsForCC produces a cc settings.json document configured to invoke
+// the tether hookserver at baseURL for the 5 hook events the daemon cares
+// about. The shape matches cc's settings hooks contract: each event maps
+// to a list with one matcher whose `hooks` field is a list of {type,
+// command}; type=command means cc execs the command, piping the hook
+// payload to its stdin and reading the JSON response from its stdout.
+//
+// We use `curl --data-binary @-` so the bytes round-trip without
+// transformation; -sf silences progress and fails non-2xx; --max-time 30
+// gives the daemon a chance to ask the user (cc's hook timeout default
+// is 60s — we cap below to surface failures earlier).
+//
+// baseURL must be a loopback URL with no trailing slash (typically
+// "http://127.0.0.1:NNNN" from HookServer.Addr()).
+func SettingsForCC(baseURL string) ([]byte, error) {
+	urls, err := HookURLs(baseURL)
+	if err != nil {
+		return nil, err
+	}
+
+	hooksMap := make(map[string]any, len(hookEvents))
+	for _, ev := range hookEvents {
+		url := urls[ev.name]
+		hooksMap[ev.name] = []map[string]any{
+			{
+				"hooks": []map[string]any{
+					{
+						"type":    "command",
+						"command": curlCommand(url),
+					},
+				},
+			},
+		}
+	}
+
+	doc := map[string]any{
+		"hooks": hooksMap,
+	}
+	out, err := json.MarshalIndent(doc, "", "  ")
+	if err != nil {
+		return nil, fmt.Errorf("hooks: marshal settings: %w", err)
+	}
+	return out, nil
+}
+
+// curlCommand renders the cc-canonical curl invocation that pipes its
+// stdin into a POST to url and prints the response body. cc captures
+// stdout as the hook reply.
+//
+//   - -s silences progress
+//   - -f returns non-zero on HTTP 4xx/5xx (so cc treats the hook as
+//     failed instead of trusting an error body)
+//   - --max-time 30 caps wall time
+//   - -X POST forces the method
+//   - -H 'content-type: application/json' matches what the server expects
+//   - --data-binary @- pipes stdin verbatim (no chunking, no transform)
+func curlCommand(url string) string {
+	return fmt.Sprintf(
+		"curl -sf --max-time 30 -X POST -H 'content-type: application/json' --data-binary @- '%s'",
+		url,
+	)
+}
+
+// WriteSettingsFile generates SettingsForCC(baseURL) and writes it to
+// dir/settings.json, returning the absolute path. File mode is 0600 —
+// the URL is loopback-only but still treat as sensitive (port could be
+// reused by an unrelated process). Errors propagate from filepath /
+// SettingsForCC / os.WriteFile verbatim.
+//
+// **Overwrites silently** — the daemon owns the dir (typically
+// `<workspace>/.tether/cc-settings/` per D-18) so prior settings.json
+// content is expected to be a stale copy from a previous spawn. Caller
+// MUST NOT pass a user-managed dir (e.g. `~/.claude/`); doing so will
+// clobber the user's own cc settings.
+func WriteSettingsFile(dir, baseURL string) (string, error) {
+	body, err := SettingsForCC(baseURL)
+	if err != nil {
+		return "", err
+	}
+	if dir == "" {
+		return "", errors.New("hooks: dir required")
+	}
+	abs, err := filepath.Abs(dir)
+	if err != nil {
+		return "", fmt.Errorf("hooks: abs dir: %w", err)
+	}
+	stat, err := os.Stat(abs)
+	if err != nil {
+		return "", fmt.Errorf("hooks: stat dir: %w", err)
+	}
+	if !stat.IsDir() {
+		return "", fmt.Errorf("hooks: %s is not a directory", abs)
+	}
+	path := filepath.Join(abs, "settings.json")
+	if err := os.WriteFile(path, body, 0o600); err != nil {
+		return "", fmt.Errorf("hooks: write settings: %w", err)
+	}
+	return path, nil
+}

--- a/internal/cc/hooks_test.go
+++ b/internal/cc/hooks_test.go
@@ -1,0 +1,240 @@
+package cc
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"os"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestSettingsForCC_AllFiveHooksPresent(t *testing.T) {
+	out, err := SettingsForCC("http://127.0.0.1:54321")
+	if err != nil {
+		t.Fatalf("SettingsForCC: %v", err)
+	}
+	var doc map[string]any
+	if err := json.Unmarshal(out, &doc); err != nil {
+		t.Fatalf("not valid JSON: %v\n%s", err, out)
+	}
+	hooks, ok := doc["hooks"].(map[string]any)
+	if !ok {
+		t.Fatalf("missing hooks key: %s", out)
+	}
+	for _, ev := range []string{"PreToolUse", "PostToolUse", "SessionStart", "UserPromptSubmit", "Stop"} {
+		if _, ok := hooks[ev]; !ok {
+			t.Errorf("hooks.%s missing", ev)
+		}
+	}
+}
+
+func TestSettingsForCC_URLsContainBaseAndPath(t *testing.T) {
+	const base = "http://127.0.0.1:99999"
+	out, err := SettingsForCC(base)
+	if err != nil {
+		t.Fatal(err)
+	}
+	s := string(out)
+	for _, suffix := range []string{
+		"/hooks/pre-tool-use",
+		"/hooks/post-tool-use",
+		"/hooks/session-start",
+		"/hooks/user-prompt-submit",
+		"/hooks/stop",
+	} {
+		want := base + suffix
+		if !strings.Contains(s, want) {
+			t.Errorf("settings.json missing URL %q", want)
+		}
+	}
+}
+
+func TestSettingsForCC_RejectsEmptyBaseURL(t *testing.T) {
+	if _, err := SettingsForCC(""); err == nil {
+		t.Fatal("SettingsForCC(\"\"): expected error")
+	}
+}
+
+func TestSettingsForCC_RejectsTrailingSlash(t *testing.T) {
+	// Trailing slash on baseURL would produce // in hook URL — reject up
+	// front so the misconfiguration surfaces clearly.
+	_, err := SettingsForCC("http://127.0.0.1:1234/")
+	if err == nil {
+		t.Fatal("trailing slash baseURL: expected error")
+	}
+	if !strings.Contains(err.Error(), "trailing slash") {
+		t.Errorf("error should mention trailing slash: got %q", err.Error())
+	}
+}
+
+func TestSettingsForCC_HookCommandsUseCurlPOST(t *testing.T) {
+	out, err := SettingsForCC("http://127.0.0.1:54321")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var doc struct {
+		Hooks map[string][]struct {
+			Hooks []struct {
+				Type    string `json:"type"`
+				Command string `json:"command"`
+			} `json:"hooks"`
+		} `json:"hooks"`
+	}
+	if err := json.Unmarshal(out, &doc); err != nil {
+		t.Fatalf("structure mismatch: %v", err)
+	}
+	for ev, entries := range doc.Hooks {
+		if len(entries) == 0 || len(entries[0].Hooks) == 0 {
+			t.Errorf("hooks.%s structure: %+v", ev, entries)
+			continue
+		}
+		h := entries[0].Hooks[0]
+		if h.Type != "command" {
+			t.Errorf("hooks.%s.type: got %q want command", ev, h.Type)
+		}
+		// curl POST with stdin pipe is the cc-canonical pattern.
+		for _, mustContain := range []string{"curl", "-X", "POST", "@-"} {
+			if !strings.Contains(h.Command, mustContain) {
+				t.Errorf("hooks.%s.command missing %q: %q", ev, mustContain, h.Command)
+			}
+		}
+	}
+}
+
+func TestWriteSettingsFile_WritesToDir(t *testing.T) {
+	dir := t.TempDir()
+	path, err := WriteSettingsFile(dir, "http://127.0.0.1:54321")
+	if err != nil {
+		t.Fatalf("WriteSettingsFile: %v", err)
+	}
+	if !strings.HasPrefix(path, dir) {
+		t.Errorf("path %q not under dir %q", path, dir)
+	}
+	body, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("readback: %v", err)
+	}
+	if !strings.Contains(string(body), "PreToolUse") {
+		t.Errorf("settings file missing hook content: %s", body)
+	}
+	// File must be writeable but only by user (sensitive — contains URL).
+	stat, _ := os.Stat(path)
+	if stat.Mode().Perm()&0o077 != 0 {
+		t.Errorf("settings file too permissive: %v", stat.Mode())
+	}
+}
+
+func TestWriteSettingsFile_RejectsBadDir(t *testing.T) {
+	if _, err := WriteSettingsFile("/nonexistent/path/that/does/not/exist", "http://x:1"); err == nil {
+		t.Fatal("WriteSettingsFile bad dir: expected error")
+	}
+}
+
+// --- end-to-end: settings → cc-shaped curl → hookserver round-trip --
+
+// TestEndToEnd_SettingsRoundTripToHookServer uses HookURLs (review fix
+// m12) instead of parsing the curl command string — much more robust to
+// future format changes.
+func TestEndToEnd_SettingsRoundTripToHookServer(t *testing.T) {
+	h := &stubHandlers{preToolDecision: HookResponse{Decision: "allow", Reason: "round-trip"}}
+	srv, _ := startTestServer(t, h)
+	base := "http://" + srv.Addr()
+
+	urls, err := HookURLs(base)
+	if err != nil {
+		t.Fatalf("HookURLs: %v", err)
+	}
+	preToolURL := urls["PreToolUse"]
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	req, _ := http.NewRequestWithContext(ctx, "POST", preToolURL, strings.NewReader(`{"tool_name":"E2E"}`))
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("post: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != 200 {
+		t.Errorf("end-to-end POST: got %d", resp.StatusCode)
+	}
+	if len(h.preToolPayloads) != 1 {
+		t.Errorf("handler not invoked: %d hits", len(h.preToolPayloads))
+	}
+}
+
+// --- review fix: HookURLs API exposed for tests + non-loopback gate
+
+func TestHookURLs_AllFiveEvents(t *testing.T) {
+	urls, err := HookURLs("http://127.0.0.1:54321")
+	if err != nil {
+		t.Fatal(err)
+	}
+	wantPaths := map[string]string{
+		"PreToolUse":       "/hooks/pre-tool-use",
+		"PostToolUse":      "/hooks/post-tool-use",
+		"SessionStart":     "/hooks/session-start",
+		"UserPromptSubmit": "/hooks/user-prompt-submit",
+		"Stop":             "/hooks/stop",
+	}
+	for ev, p := range wantPaths {
+		got, ok := urls[ev]
+		if !ok {
+			t.Errorf("HookURLs missing %s", ev)
+			continue
+		}
+		if got != "http://127.0.0.1:54321"+p {
+			t.Errorf("HookURLs[%s]: got %q, want suffix %q", ev, got, p)
+		}
+	}
+}
+
+func TestHookURLs_RejectsNonLoopback(t *testing.T) {
+	for _, baseURL := range []string{
+		"http://example.com:8080",
+		"http://192.168.1.5:8080",
+		"https://malicious.example.org:443",
+	} {
+		if _, err := HookURLs(baseURL); err == nil {
+			t.Errorf("HookURLs(%q): expected error, got nil", baseURL)
+		}
+	}
+}
+
+func TestHookURLs_AcceptsLoopbackVariants(t *testing.T) {
+	for _, baseURL := range []string{
+		"http://127.0.0.1:1",
+		"http://localhost:9999",
+		"http://[::1]:8080",
+	} {
+		if _, err := HookURLs(baseURL); err != nil {
+			t.Errorf("HookURLs(%q): unexpected error %v", baseURL, err)
+		}
+	}
+}
+
+// --- review fix: WriteSettingsFile overwrite semantics is documented behavior
+
+func TestWriteSettingsFile_OverwritesExisting(t *testing.T) {
+	dir := t.TempDir()
+	path1, err := WriteSettingsFile(dir, "http://127.0.0.1:1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	path2, err := WriteSettingsFile(dir, "http://127.0.0.1:2")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if path1 != path2 {
+		t.Errorf("path drift across calls: %q vs %q", path1, path2)
+	}
+	body, _ := os.ReadFile(path2)
+	if !strings.Contains(string(body), "127.0.0.1:2") {
+		t.Errorf("second WriteSettingsFile didn't overwrite: %s", body)
+	}
+	if strings.Contains(string(body), "127.0.0.1:1") {
+		t.Errorf("first call's URL still present: %s", body)
+	}
+}

--- a/internal/cc/hookserver.go
+++ b/internal/cc/hookserver.go
@@ -1,0 +1,294 @@
+package cc
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"sync"
+	"sync/atomic"
+	"time"
+)
+
+// HookHandlers is the dependency-injection seam for the HTTP server: the
+// daemon plugs in its own handlers, the server owns the wire-protocol
+// shape (request method, path mapping, response schema). The two
+// "decision" hooks (PreToolUse, UserPromptSubmit) return HookResponse so
+// the server can render cc's hookSpecificOutput envelope; the three
+// observer hooks (PostToolUse, SessionStart, Stop) return only error.
+//
+// All methods receive the raw JSON body (json.RawMessage) verbatim — the
+// daemon decides how / whether to decode. This matches the seam invariant
+// "daemon doesn't interpret event content" (spec §5.0).
+//
+// Concurrency: implementations MUST be safe for concurrent invocation.
+// cc emits hooks in parallel for parallel tool calls; net/http serves
+// each request on its own goroutine.
+type HookHandlers interface {
+	PreToolUse(ctx context.Context, payload json.RawMessage) (HookResponse, error)
+	PostToolUse(ctx context.Context, payload json.RawMessage) error
+	SessionStart(ctx context.Context, payload json.RawMessage) error
+	UserPromptSubmit(ctx context.Context, payload json.RawMessage) (HookResponse, error)
+	Stop(ctx context.Context, payload json.RawMessage) error
+}
+
+// HookResponse is the daemon's decision for a "decision" hook. Decision
+// must be one of "allow" / "deny" / "ask" (cc's permissionDecision enum,
+// spec §5.2 F-05); Reason is surfaced in the cc UI when the hook denies.
+type HookResponse struct {
+	Decision string
+	Reason   string
+}
+
+// HookServer is the local HTTP server cc POSTs hook callbacks into. cc is
+// configured with the server's URLs at spawn time (see hooks.go for the
+// settings.json generation that wires this up). The server binds on
+// 127.0.0.1:0 (kernel picks a free port); the assigned port is read via
+// Addr() after Start succeeds.
+type HookServer struct {
+	handlers HookHandlers
+
+	mu       sync.Mutex
+	listener net.Listener
+	server   *http.Server
+	addr     string
+	stopped  bool
+	// done is closed by the Serve goroutine on exit (after server.Serve
+	// returns http.ErrServerClosed or any other error). Stop awaits done
+	// before returning so callers can rely on "Stop returned == server
+	// goroutine fully exited".
+	done chan struct{}
+	// serveErr captures the non-ErrServerClosed error (if any) from the
+	// Serve goroutine. Read via ServeErr() after Stop returns.
+	serveErr atomic.Pointer[error]
+}
+
+// MaxRequestBodyBytes caps the per-request body size cc may post. cc
+// payloads are typically <100KB (tool inputs / outputs); 8 MiB gives
+// 80x headroom while preventing unbounded memory growth from a
+// misbehaving local client.
+const MaxRequestBodyBytes = 8 << 20 // 8 MiB
+
+// NewHookServer constructs a server with the given handlers. handlers may
+// be nil to install no-op observers (every endpoint returns 204 with a
+// safe-default decision); useful for early bring-up before daemon wiring.
+func NewHookServer(h HookHandlers) *HookServer {
+	if h == nil {
+		h = noopHandlers{}
+	}
+	return &HookServer{handlers: h}
+}
+
+// Start binds the listener on 127.0.0.1:0 and launches the serving
+// goroutine. Returns once the listener is ready (Addr is callable);
+// error if the bind fails. Idempotent: re-Start of a stopped server
+// returns ErrServerStopped.
+func (s *HookServer) Start(_ context.Context) error {
+	s.mu.Lock()
+	if s.stopped {
+		s.mu.Unlock()
+		return ErrServerStopped
+	}
+	if s.listener != nil {
+		s.mu.Unlock()
+		return errors.New("hookserver: already started")
+	}
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		s.mu.Unlock()
+		return fmt.Errorf("hookserver: listen: %w", err)
+	}
+	s.listener = ln
+	s.addr = ln.Addr().String()
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/hooks/pre-tool-use", s.handleDecision("PreToolUse", s.handlers.PreToolUse))
+	mux.HandleFunc("/hooks/post-tool-use", s.handleObserver(s.handlers.PostToolUse))
+	mux.HandleFunc("/hooks/session-start", s.handleObserver(s.handlers.SessionStart))
+	mux.HandleFunc("/hooks/user-prompt-submit", s.handleDecision("UserPromptSubmit", s.handlers.UserPromptSubmit))
+	mux.HandleFunc("/hooks/stop", s.handleObserver(s.handlers.Stop))
+	mux.HandleFunc("/blob/", handleBlobNotImplemented)
+
+	s.server = &http.Server{
+		Handler:           mux,
+		ReadHeaderTimeout: 5 * time.Second,
+	}
+	s.done = make(chan struct{})
+	srv := s.server
+	doneCh := s.done
+	s.mu.Unlock()
+
+	go func() {
+		defer close(doneCh)
+		err := srv.Serve(ln)
+		// http.ErrServerClosed is the expected sentinel from a successful
+		// Shutdown — never treat as failure. Any other error indicates the
+		// listener died unexpectedly (fd exhaustion, kernel-killed, etc.).
+		// Capture for ServeErr() so daemon health checks can detect.
+		if err != nil && !errors.Is(err, http.ErrServerClosed) {
+			s.serveErr.Store(&err)
+		}
+	}()
+	return nil
+}
+
+// Addr returns the assigned 127.0.0.1:NNNN endpoint after Start. Empty
+// string before Start or after Stop has cleared the listener.
+func (s *HookServer) Addr() string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.addr
+}
+
+// Stop gracefully shuts down the server and waits for the Serve
+// goroutine to exit. Returning means: (a) Shutdown completed (in-flight
+// requests drained or ctx-canceled), AND (b) the goroutine that ran
+// http.Server.Serve has fully exited. Callers can rely on this for
+// teardown ordering. Idempotent: a stopped server's second Stop returns
+// nil.
+func (s *HookServer) Stop(ctx context.Context) error {
+	s.mu.Lock()
+	if s.stopped {
+		s.mu.Unlock()
+		return nil
+	}
+	s.stopped = true
+	srv := s.server
+	doneCh := s.done
+	s.mu.Unlock()
+	if srv == nil {
+		return nil
+	}
+	shutdownErr := srv.Shutdown(ctx)
+	// Wait for Serve goroutine to exit. Shutdown returns when active
+	// connections drain; the goroutine's `Serve` call returns slightly
+	// after that. Bound the wait to ctx so a stuck Serve doesn't hang
+	// us (would be a bug, but defense-in-depth).
+	if doneCh != nil {
+		select {
+		case <-doneCh:
+		case <-ctx.Done():
+			// ctx exhausted; Shutdown error already captured. Goroutine
+			// will eventually exit on its own; we lose the wait promise
+			// here but Shutdown's error chain reflects the timeout.
+		}
+	}
+	return shutdownErr
+}
+
+// ServeErr returns the non-ErrServerClosed error captured from the Serve
+// goroutine, or nil. Useful for daemon health checks: if non-nil, the
+// hook path is offline and supervisor should re-spawn / alert. Safe to
+// call any time after Start.
+func (s *HookServer) ServeErr() error {
+	if e := s.serveErr.Load(); e != nil {
+		return *e
+	}
+	return nil
+}
+
+// ErrServerStopped is returned when Start is called on a server that's
+// already been Stop'd. The server is single-use; callers should construct
+// a fresh HookServer rather than reuse.
+var ErrServerStopped = errors.New("hookserver: server already stopped")
+
+// --- handler glue ---------------------------------------------------
+
+// handleDecision wraps a HookHandlers decision-style method into an
+// http.HandlerFunc. Reads body, calls handler, renders cc's
+// hookSpecificOutput envelope shape (spec §5.2 F-05).
+func (s *HookServer) handleDecision(eventName string, fn func(context.Context, json.RawMessage) (HookResponse, error)) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+		body, err := io.ReadAll(http.MaxBytesReader(w, r.Body, MaxRequestBodyBytes))
+		if err != nil {
+			if _, ok := err.(*http.MaxBytesError); ok {
+				http.Error(w, "request body exceeds limit", http.StatusRequestEntityTooLarge)
+				return
+			}
+			http.Error(w, "read body: "+err.Error(), http.StatusBadRequest)
+			return
+		}
+		resp, err := fn(r.Context(), body)
+		if err != nil {
+			http.Error(w, "handler: "+err.Error(), http.StatusInternalServerError)
+			return
+		}
+		out := map[string]any{
+			"hookSpecificOutput": map[string]any{
+				"hookEventName":            eventName,
+				"permissionDecision":       resp.Decision,
+				"permissionDecisionReason": resp.Reason,
+			},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(out)
+	}
+}
+
+// handleObserver wraps an observer HookHandlers method (no decision body).
+// Returns 204 No Content on success; 500 on handler error.
+func (s *HookServer) handleObserver(fn func(context.Context, json.RawMessage) error) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+		body, err := io.ReadAll(http.MaxBytesReader(w, r.Body, MaxRequestBodyBytes))
+		if err != nil {
+			if _, ok := err.(*http.MaxBytesError); !ok {
+				http.Error(w, "read body: "+err.Error(), http.StatusBadRequest)
+			}
+			return
+		}
+		if err := fn(r.Context(), body); err != nil {
+			http.Error(w, "handler: "+err.Error(), http.StatusInternalServerError)
+			return
+		}
+		w.WriteHeader(http.StatusNoContent)
+	}
+}
+
+// handleBlobNotImplemented holds the /blob/* path namespace reserved for
+// v0.2 Phase 1 (D-18 forward-compat seam, spec §5.2). Returns 501 so any
+// caller hitting it knows the endpoint exists but is not yet implemented;
+// reserving the path now prevents another handler from squatting later.
+func handleBlobNotImplemented(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusNotImplemented)
+	_ = json.NewEncoder(w).Encode(map[string]string{
+		"error":   "not_implemented",
+		"reason":  "/blob/* is reserved for v0.2 Phase 1 (D-18); not implemented in v0.1",
+		"path":    r.URL.Path,
+	})
+}
+
+// --- noop handlers (default when handlers=nil) ---------------------
+
+// noopHandlers is the safe-default fallback when NewHookServer is called
+// with handlers=nil. Critically, the two decision hooks DENY rather than
+// allow — this is fail-CLOSED security: a daemon that forgot to wire
+// real handlers must NOT silently auto-approve every tool call. The deny
+// reason surfaces clearly in cc's UI ("hook denied: …") so the
+// misconfiguration is visible.
+//
+// For actual no-decision behavior in tests, construct a stub explicitly
+// rather than relying on noopHandlers.
+type noopHandlers struct{}
+
+func (noopHandlers) PreToolUse(_ context.Context, _ json.RawMessage) (HookResponse, error) {
+	return HookResponse{Decision: "deny", Reason: "tether handlers not configured (fail-closed default; wire HookHandlers to allow)"}, nil
+}
+func (noopHandlers) PostToolUse(_ context.Context, _ json.RawMessage) error      { return nil }
+func (noopHandlers) SessionStart(_ context.Context, _ json.RawMessage) error     { return nil }
+func (noopHandlers) UserPromptSubmit(_ context.Context, _ json.RawMessage) (HookResponse, error) {
+	return HookResponse{Decision: "deny", Reason: "tether handlers not configured (fail-closed default; wire HookHandlers to allow)"}, nil
+}
+func (noopHandlers) Stop(_ context.Context, _ json.RawMessage) error             { return nil }

--- a/internal/cc/hookserver_test.go
+++ b/internal/cc/hookserver_test.go
@@ -1,0 +1,492 @@
+package cc
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net"
+	"net/http"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+// --- handler stub for tests ----------------------------------------
+
+type stubHandlers struct {
+	mu               sync.Mutex
+	preToolDecision  HookResponse
+	preToolErr       error
+	preToolPayloads  []json.RawMessage
+	postToolPayloads []json.RawMessage
+	sessionStartHits int
+	userPromptDecision HookResponse
+	userPromptErr    error
+	stopHits         int
+}
+
+func (h *stubHandlers) PreToolUse(_ context.Context, payload json.RawMessage) (HookResponse, error) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.preToolPayloads = append(h.preToolPayloads, payload)
+	return h.preToolDecision, h.preToolErr
+}
+func (h *stubHandlers) PostToolUse(_ context.Context, payload json.RawMessage) error {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.postToolPayloads = append(h.postToolPayloads, payload)
+	return nil
+}
+func (h *stubHandlers) SessionStart(_ context.Context, _ json.RawMessage) error {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.sessionStartHits++
+	return nil
+}
+func (h *stubHandlers) UserPromptSubmit(_ context.Context, _ json.RawMessage) (HookResponse, error) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	return h.userPromptDecision, h.userPromptErr
+}
+func (h *stubHandlers) Stop(_ context.Context, _ json.RawMessage) error {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.stopHits++
+	return nil
+}
+
+// startTestServer boots a hookserver on 127.0.0.1:0 and returns its base URL.
+// Caller defers stop.
+func startTestServer(t *testing.T, h *stubHandlers) (*HookServer, string) {
+	t.Helper()
+	srv := NewHookServer(h)
+	if err := srv.Start(context.Background()); err != nil {
+		t.Fatalf("start: %v", err)
+	}
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+		_ = srv.Stop(ctx)
+	})
+	return srv, "http://" + srv.Addr()
+}
+
+func postJSON(t *testing.T, url string, body any) *http.Response {
+	t.Helper()
+	buf := &bytes.Buffer{}
+	if body != nil {
+		if err := json.NewEncoder(buf).Encode(body); err != nil {
+			t.Fatalf("encode: %v", err)
+		}
+	}
+	resp, err := http.Post(url, "application/json", buf)
+	if err != nil {
+		t.Fatalf("POST %s: %v", url, err)
+	}
+	return resp
+}
+
+// --- listener / addr ----------------------------------------------
+
+func TestHookServer_StartAssignsLoopbackPort(t *testing.T) {
+	srv, _ := startTestServer(t, &stubHandlers{})
+	addr := srv.Addr()
+	if !strings.HasPrefix(addr, "127.0.0.1:") {
+		t.Errorf("Addr should be on loopback only, got %q", addr)
+	}
+	port := strings.TrimPrefix(addr, "127.0.0.1:")
+	if port == "0" || port == "" {
+		t.Errorf("Addr port not assigned: %q", addr)
+	}
+}
+
+// --- /hooks/* paths ------------------------------------------------
+
+func TestHookServer_PreToolUse_Allow(t *testing.T) {
+	h := &stubHandlers{
+		preToolDecision: HookResponse{Decision: "allow", Reason: "test ok"},
+	}
+	_, base := startTestServer(t, h)
+	resp := postJSON(t, base+"/hooks/pre-tool-use", map[string]any{
+		"tool_name": "Bash",
+		"input":     map[string]string{"command": "echo hi"},
+	})
+	defer resp.Body.Close()
+	if resp.StatusCode != 200 {
+		t.Errorf("status: %d, want 200", resp.StatusCode)
+	}
+	var body map[string]any
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	hso, ok := body["hookSpecificOutput"].(map[string]any)
+	if !ok {
+		t.Fatalf("response missing hookSpecificOutput: %+v", body)
+	}
+	if hso["hookEventName"] != "PreToolUse" {
+		t.Errorf("hookEventName: got %v, want PreToolUse", hso["hookEventName"])
+	}
+	if hso["permissionDecision"] != "allow" {
+		t.Errorf("permissionDecision: got %v, want allow", hso["permissionDecision"])
+	}
+	if hso["permissionDecisionReason"] != "test ok" {
+		t.Errorf("permissionDecisionReason: got %v", hso["permissionDecisionReason"])
+	}
+	if len(h.preToolPayloads) != 1 {
+		t.Errorf("handler invocation count: got %d, want 1", len(h.preToolPayloads))
+	}
+}
+
+func TestHookServer_PreToolUse_Deny(t *testing.T) {
+	h := &stubHandlers{preToolDecision: HookResponse{Decision: "deny", Reason: "danger"}}
+	_, base := startTestServer(t, h)
+	resp := postJSON(t, base+"/hooks/pre-tool-use", map[string]any{"tool_name": "Bash"})
+	defer resp.Body.Close()
+	var body map[string]any
+	_ = json.NewDecoder(resp.Body).Decode(&body)
+	hso := body["hookSpecificOutput"].(map[string]any)
+	if hso["permissionDecision"] != "deny" {
+		t.Errorf("decision: %v", hso["permissionDecision"])
+	}
+}
+
+func TestHookServer_PreToolUse_HandlerError(t *testing.T) {
+	h := &stubHandlers{preToolErr: errors.New("upstream gone")}
+	_, base := startTestServer(t, h)
+	resp := postJSON(t, base+"/hooks/pre-tool-use", map[string]any{"tool_name": "X"})
+	defer resp.Body.Close()
+	if resp.StatusCode != 500 {
+		t.Errorf("handler error → status: got %d, want 500", resp.StatusCode)
+	}
+}
+
+func TestHookServer_PostToolUse_ObserverNoBody(t *testing.T) {
+	h := &stubHandlers{}
+	_, base := startTestServer(t, h)
+	resp := postJSON(t, base+"/hooks/post-tool-use", map[string]any{"tool_name": "Bash", "duration_ms": 42})
+	defer resp.Body.Close()
+	if resp.StatusCode != 204 {
+		t.Errorf("PostToolUse: got %d, want 204 (observer hook, no decision body)", resp.StatusCode)
+	}
+	if len(h.postToolPayloads) != 1 {
+		t.Errorf("PostToolUse handler invocation count: got %d", len(h.postToolPayloads))
+	}
+}
+
+func TestHookServer_SessionStart(t *testing.T) {
+	h := &stubHandlers{}
+	_, base := startTestServer(t, h)
+	resp := postJSON(t, base+"/hooks/session-start", map[string]any{"session_id": "x"})
+	defer resp.Body.Close()
+	if resp.StatusCode != 204 {
+		t.Errorf("SessionStart: got %d, want 204", resp.StatusCode)
+	}
+	if h.sessionStartHits != 1 {
+		t.Errorf("hits: got %d", h.sessionStartHits)
+	}
+}
+
+func TestHookServer_UserPromptSubmit_Allow(t *testing.T) {
+	h := &stubHandlers{userPromptDecision: HookResponse{Decision: "allow"}}
+	_, base := startTestServer(t, h)
+	resp := postJSON(t, base+"/hooks/user-prompt-submit", map[string]any{"prompt": "hi"})
+	defer resp.Body.Close()
+	if resp.StatusCode != 200 {
+		t.Errorf("status: %d", resp.StatusCode)
+	}
+	var body map[string]any
+	_ = json.NewDecoder(resp.Body).Decode(&body)
+	hso := body["hookSpecificOutput"].(map[string]any)
+	if hso["hookEventName"] != "UserPromptSubmit" {
+		t.Errorf("hookEventName: %v", hso["hookEventName"])
+	}
+}
+
+func TestHookServer_Stop(t *testing.T) {
+	h := &stubHandlers{}
+	_, base := startTestServer(t, h)
+	resp := postJSON(t, base+"/hooks/stop", nil)
+	defer resp.Body.Close()
+	if resp.StatusCode != 204 {
+		t.Errorf("Stop: got %d, want 204", resp.StatusCode)
+	}
+	if h.stopHits != 1 {
+		t.Errorf("hits: got %d", h.stopHits)
+	}
+}
+
+// --- /blob/* — 501 not implemented in v0.1 -------------------------
+
+func TestHookServer_BlobReturns501(t *testing.T) {
+	_, base := startTestServer(t, &stubHandlers{})
+	resp := postJSON(t, base+"/blob/some-sha256", map[string]any{"file": "x"})
+	defer resp.Body.Close()
+	if resp.StatusCode != 501 {
+		t.Errorf("/blob/* should be 501 (D-18 reserved namespace, v0.2 Phase 1): got %d", resp.StatusCode)
+	}
+}
+
+// --- prefix invariant + 404 ---------------------------------------
+
+func TestHookServer_HookPathRequiresPrefix(t *testing.T) {
+	// /pre-tool-use without /hooks/ prefix → 404 (D-18: hooks live under /hooks/).
+	_, base := startTestServer(t, &stubHandlers{})
+	resp := postJSON(t, base+"/pre-tool-use", nil)
+	defer resp.Body.Close()
+	if resp.StatusCode != 404 {
+		t.Errorf("/pre-tool-use without /hooks/ prefix: got %d, want 404", resp.StatusCode)
+	}
+}
+
+func TestHookServer_UnknownHookSubpath(t *testing.T) {
+	_, base := startTestServer(t, &stubHandlers{})
+	resp := postJSON(t, base+"/hooks/unknown-event", nil)
+	defer resp.Body.Close()
+	if resp.StatusCode != 404 {
+		t.Errorf("/hooks/unknown-event: got %d, want 404", resp.StatusCode)
+	}
+}
+
+func TestHookServer_RootPath(t *testing.T) {
+	_, base := startTestServer(t, &stubHandlers{})
+	resp := postJSON(t, base+"/", nil)
+	defer resp.Body.Close()
+	if resp.StatusCode != 404 {
+		t.Errorf("/ (root): got %d, want 404", resp.StatusCode)
+	}
+}
+
+// --- payload preserved verbatim ------------------------------------
+
+func TestHookServer_PayloadPassthrough(t *testing.T) {
+	h := &stubHandlers{preToolDecision: HookResponse{Decision: "allow"}}
+	_, base := startTestServer(t, h)
+	originalBody := `{"tool_name":"Read","input":{"file_path":"/etc/passwd"},"extra_unknown":42}`
+	resp, err := http.Post(base+"/hooks/pre-tool-use", "application/json", strings.NewReader(originalBody))
+	if err != nil {
+		t.Fatalf("post: %v", err)
+	}
+	defer resp.Body.Close()
+	_, _ = io.Copy(io.Discard, resp.Body)
+
+	if len(h.preToolPayloads) != 1 {
+		t.Fatalf("payload count: %d", len(h.preToolPayloads))
+	}
+	got := string(h.preToolPayloads[0])
+	// Whitespace tolerated by json (we receive verbatim bytes), but content
+	// must be intact — including unknown field.
+	if !strings.Contains(got, `"extra_unknown":42`) {
+		t.Errorf("payload lost extra_unknown: %q", got)
+	}
+}
+
+// --- Stop / lifecycle ---------------------------------------------
+
+func TestHookServer_StopBlocksUntilDone(t *testing.T) {
+	srv := NewHookServer(&stubHandlers{})
+	if err := srv.Start(context.Background()); err != nil {
+		t.Fatalf("start: %v", err)
+	}
+	stopCtx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	if err := srv.Stop(stopCtx); err != nil {
+		t.Errorf("Stop: %v", err)
+	}
+	// Second Stop should be idempotent.
+	if err := srv.Stop(stopCtx); err != nil {
+		t.Errorf("double-Stop: %v", err)
+	}
+}
+
+func TestHookServer_PostStartAddrStable(t *testing.T) {
+	srv, _ := startTestServer(t, &stubHandlers{})
+	a1 := srv.Addr()
+	a2 := srv.Addr()
+	if a1 != a2 {
+		t.Errorf("Addr changed across calls: %q vs %q", a1, a2)
+	}
+}
+
+// --- method gating: cc only POSTs to hooks ------------------------
+
+func TestHookServer_GETOnHookReturns405(t *testing.T) {
+	_, base := startTestServer(t, &stubHandlers{})
+	resp, err := http.Get(base + "/hooks/pre-tool-use")
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusMethodNotAllowed {
+		t.Errorf("GET /hooks/pre-tool-use: got %d, want 405", resp.StatusCode)
+	}
+}
+
+// --- review fix: oversize body returns 413 -------------------------
+
+func TestHookServer_OversizeBodyReturns413(t *testing.T) {
+	_, base := startTestServer(t, &stubHandlers{preToolDecision: HookResponse{Decision: "allow"}})
+	// 9 MiB > MaxRequestBodyBytes (8 MiB).
+	body := bytes.Repeat([]byte("x"), 9<<20)
+	resp, err := http.Post(base+"/hooks/pre-tool-use", "application/json", bytes.NewReader(body))
+	if err != nil {
+		t.Fatalf("post: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusRequestEntityTooLarge {
+		t.Errorf("oversize body: got %d, want 413", resp.StatusCode)
+	}
+}
+
+// --- review fix: noopHandlers fail-closed --------------------------
+
+func TestNoopHandlers_PreToolUse_FailClosed(t *testing.T) {
+	srv := NewHookServer(nil) // explicit nil → noopHandlers default
+	if err := srv.Start(context.Background()); err != nil {
+		t.Fatalf("start: %v", err)
+	}
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+		defer cancel()
+		_ = srv.Stop(ctx)
+	})
+	resp := postJSON(t, "http://"+srv.Addr()+"/hooks/pre-tool-use", map[string]any{"tool_name": "Bash"})
+	defer resp.Body.Close()
+	var body map[string]any
+	_ = json.NewDecoder(resp.Body).Decode(&body)
+	hso, _ := body["hookSpecificOutput"].(map[string]any)
+	if hso["permissionDecision"] != "deny" {
+		t.Errorf("noopHandlers PreToolUse: got %v, want deny (fail-closed default)", hso["permissionDecision"])
+	}
+	if !strings.Contains(hso["permissionDecisionReason"].(string), "not configured") {
+		t.Errorf("noop deny reason should explain misconfig: %v", hso["permissionDecisionReason"])
+	}
+}
+
+func TestNoopHandlers_UserPromptSubmit_FailClosed(t *testing.T) {
+	srv := NewHookServer(nil)
+	if err := srv.Start(context.Background()); err != nil {
+		t.Fatalf("start: %v", err)
+	}
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+		defer cancel()
+		_ = srv.Stop(ctx)
+	})
+	resp := postJSON(t, "http://"+srv.Addr()+"/hooks/user-prompt-submit", map[string]any{"prompt": "hi"})
+	defer resp.Body.Close()
+	var body map[string]any
+	_ = json.NewDecoder(resp.Body).Decode(&body)
+	hso, _ := body["hookSpecificOutput"].(map[string]any)
+	if hso["permissionDecision"] != "deny" {
+		t.Errorf("noopHandlers UserPromptSubmit: got %v, want deny", hso["permissionDecision"])
+	}
+}
+
+// --- review fix: Stop awaits Serve goroutine -----------------------
+
+func TestHookServer_StopAwaitsServeGoroutineExit(t *testing.T) {
+	srv := NewHookServer(&stubHandlers{})
+	if err := srv.Start(context.Background()); err != nil {
+		t.Fatalf("start: %v", err)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	if err := srv.Stop(ctx); err != nil {
+		t.Errorf("stop: %v", err)
+	}
+	// After Stop returns, the listener address must be unreachable —
+	// confirms the Serve goroutine has fully exited (closed the listener).
+	addr := srv.Addr()
+	conn, err := net.DialTimeout("tcp", addr, 100*time.Millisecond)
+	if err == nil {
+		_ = conn.Close()
+		t.Errorf("listener still accepting connections after Stop: addr=%s", addr)
+	}
+}
+
+// --- review fix: Stop-before-Start poisons subsequent Start --------
+
+func TestHookServer_StopBeforeStart_PoisonsStart(t *testing.T) {
+	srv := NewHookServer(&stubHandlers{})
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	// Stop on a never-started server is a no-op (returns nil) but
+	// poisons the server.
+	if err := srv.Stop(ctx); err != nil {
+		t.Errorf("stop before start: got %v want nil", err)
+	}
+	if err := srv.Start(ctx); !errors.Is(err, ErrServerStopped) {
+		t.Errorf("Start after Stop: got %v, want ErrServerStopped", err)
+	}
+}
+
+// --- review fix: ServeErr() reports nil for clean shutdown --------
+
+func TestHookServer_ServeErr_NilForCleanShutdown(t *testing.T) {
+	srv, _ := startTestServer(t, &stubHandlers{})
+	// Wait briefly so server is fully up before stop.
+	time.Sleep(20 * time.Millisecond)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	_ = srv.Stop(ctx)
+	if err := srv.ServeErr(); err != nil {
+		t.Errorf("ServeErr after clean shutdown: got %v want nil", err)
+	}
+}
+
+// --- review fix: concurrent POST safety ---------------------------
+
+func TestHookServer_ConcurrentPOSTs(t *testing.T) {
+	h := &stubHandlers{preToolDecision: HookResponse{Decision: "allow"}}
+	_, base := startTestServer(t, h)
+	const N = 50
+	var wg sync.WaitGroup
+	wg.Add(N)
+	for i := 0; i < N; i++ {
+		go func() {
+			defer wg.Done()
+			resp := postJSON(t, base+"/hooks/pre-tool-use", map[string]any{"tool_name": "Bash"})
+			_, _ = io.Copy(io.Discard, resp.Body)
+			resp.Body.Close()
+		}()
+	}
+	wg.Wait()
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	if len(h.preToolPayloads) != N {
+		t.Errorf("concurrent POSTs: got %d invocations, want %d", len(h.preToolPayloads), N)
+	}
+}
+
+// --- review fix: /blob and /blob/ edge cases ----------------------
+
+func TestHookServer_BlobNoTrailingSlash_Redirected(t *testing.T) {
+	// http.ServeMux registered "/blob/" — a request to "/blob" gets a
+	// 301 redirect to "/blob/". Verify the redirect target hits 501.
+	_, base := startTestServer(t, &stubHandlers{})
+	client := &http.Client{
+		CheckRedirect: func(req *http.Request, via []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
+	}
+	resp, err := client.Post(base+"/blob", "application/json", strings.NewReader("{}"))
+	if err != nil {
+		t.Fatalf("post: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusMovedPermanently && resp.StatusCode != http.StatusTemporaryRedirect && resp.StatusCode != http.StatusPermanentRedirect && resp.StatusCode != http.StatusNotImplemented {
+		t.Errorf("/blob (no slash): got %d, want 301/307/308 redirect or direct 501", resp.StatusCode)
+	}
+}
+
+func TestHookServer_BlobBareSlash_Returns501(t *testing.T) {
+	_, base := startTestServer(t, &stubHandlers{})
+	resp := postJSON(t, base+"/blob/", nil)
+	defer resp.Body.Close()
+	if resp.StatusCode != 501 {
+		t.Errorf("/blob/ (bare slash): got %d, want 501", resp.StatusCode)
+	}
+}

--- a/internal/cc/version.go
+++ b/internal/cc/version.go
@@ -1,0 +1,132 @@
+package cc
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os/exec"
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// detectWaitDelay forces exec.CommandContext to close subprocess pipes
+// this long after ctx cancel even if a stuck grandchild keeps stdin/stdout
+// fds open. Without this, `cmd.Output()` can wait indefinitely for EOF
+// even after SIGKILL on the bash wrapper. Go 1.20+ feature.
+const detectWaitDelay = 200 * time.Millisecond
+
+// Version is a parsed semver triple from `claude --version`. Raw preserves
+// the original output for diagnostics (cc decorates with " (Claude Code)").
+type Version struct {
+	Major int
+	Minor int
+	Patch int
+	Raw   string
+}
+
+// String renders the parsed triple (without Raw decoration).
+func (v Version) String() string {
+	return fmt.Sprintf("%d.%d.%d", v.Major, v.Minor, v.Patch)
+}
+
+// SupportedRange is the cc compatibility window. The data plane (stream-json
+// keys, hook callback shape, JSONL torn-write tolerance) is verified within
+// this range; outside it we hard-fail at startup rather than risk silent
+// drift. Currently a single-minor window: cc's contract churns at minor
+// bumps in practice.
+type SupportedRange struct {
+	Major    int // exact match required
+	Minor    int // exact match required
+	MinPatch int // inclusive floor (no upper bound — patches are usually safe)
+}
+
+// DefaultSupported is the cc range the v0.1 daemon is verified against.
+// Per gh-13 retro § "Held assumptions": stream-json data plane verified
+// across cc 2.1.120 → 2.1.123; .120 set as the floor. Bumping the floor
+// requires a fresh PoC-1 run to confirm hook payload + JSONL keys.
+var DefaultSupported = SupportedRange{
+	Major:    2,
+	Minor:    1,
+	MinPatch: 120,
+}
+
+// ErrVersionUnsupported is returned by Verify (and the convenience
+// DetectAndVerify) when the detected cc version is outside the supported
+// range. errors.Is matches the chain.
+var ErrVersionUnsupported = errors.New("cc: detected version is outside supported range")
+
+// ErrVersionUnparseable is returned when the output of `claude --version`
+// doesn't contain a recognizable major.minor.patch triple.
+var ErrVersionUnparseable = errors.New("cc: failed to parse `claude --version` output")
+
+// versionRegex extracts the first major.minor.patch occurrence in the
+// `claude --version` output. cc currently emits "X.Y.Z (Claude Code)";
+// the regex tolerates leading "v" / whitespace / trailing build metadata
+// without coupling to the exact format.
+var versionRegex = regexp.MustCompile(`(\d+)\.(\d+)\.(\d+)`)
+
+// ParseVersion parses a cc --version output line into a Version. The Raw
+// field preserves the input (trimmed) for diagnostic reporting.
+func ParseVersion(s string) (Version, error) {
+	trimmed := strings.TrimSpace(s)
+	m := versionRegex.FindStringSubmatch(trimmed)
+	if m == nil {
+		return Version{}, fmt.Errorf("%w: %q", ErrVersionUnparseable, trimmed)
+	}
+	major, _ := strconv.Atoi(m[1])
+	minor, _ := strconv.Atoi(m[2])
+	patch, _ := strconv.Atoi(m[3])
+	return Version{Major: major, Minor: minor, Patch: patch, Raw: trimmed}, nil
+}
+
+// Detect runs `claude --version` (or the binary at binaryPath if non-empty)
+// and parses its output. Subprocess errors propagate verbatim; parse errors
+// chain to ErrVersionUnparseable.
+func Detect(ctx context.Context, binaryPath string) (Version, error) {
+	bin := binaryPath
+	if bin == "" {
+		bin = "claude"
+	}
+	cmd := exec.CommandContext(ctx, bin, "--version")
+	cmd.WaitDelay = detectWaitDelay
+	out, err := cmd.Output()
+	if err != nil {
+		return Version{}, fmt.Errorf("cc: %s --version failed: %w", bin, err)
+	}
+	return ParseVersion(string(out))
+}
+
+// Verify hard-fails when v is outside r. Returns nil when v is within
+// the range.
+//
+// The contract is exact-major + exact-minor + min-patch: a different major
+// or minor is unsupported even if numerically newer. Patch versions ≥ floor
+// are accepted. This matches the gh-13 verification shape (one minor
+// stream verified as a unit; bumps must be re-verified).
+func Verify(v Version, r SupportedRange) error {
+	if v.Major != r.Major || v.Minor != r.Minor {
+		return fmt.Errorf("%w: detected %s, supported %d.%d.x (≥ %d.%d.%d)",
+			ErrVersionUnsupported, v.String(), r.Major, r.Minor, r.Major, r.Minor, r.MinPatch)
+	}
+	if v.Patch < r.MinPatch {
+		return fmt.Errorf("%w: detected %s, supported ≥ %d.%d.%d",
+			ErrVersionUnsupported, v.String(), r.Major, r.Minor, r.MinPatch)
+	}
+	return nil
+}
+
+// DetectAndVerify is the convenience wrapper for daemon startup: runs
+// Detect then Verify against r, returning the parsed version on success
+// or a wrapped error suitable for hard-failing the process.
+func DetectAndVerify(ctx context.Context, binaryPath string, r SupportedRange) (Version, error) {
+	v, err := Detect(ctx, binaryPath)
+	if err != nil {
+		return v, err
+	}
+	if err := Verify(v, r); err != nil {
+		return v, err
+	}
+	return v, nil
+}

--- a/internal/cc/version_test.go
+++ b/internal/cc/version_test.go
@@ -1,0 +1,232 @@
+package cc
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// --- Version.String formatter --------------------------------------
+
+func TestVersion_String(t *testing.T) {
+	cases := []struct {
+		v    Version
+		want string
+	}{
+		{Version{Major: 1, Minor: 2, Patch: 3}, "1.2.3"},
+		{Version{Major: 2, Minor: 1, Patch: 126}, "2.1.126"},
+		{Version{Major: 0, Minor: 0, Patch: 0}, "0.0.0"},
+	}
+	for _, tc := range cases {
+		if got := tc.v.String(); got != tc.want {
+			t.Errorf("(%d.%d.%d).String(): got %q want %q", tc.v.Major, tc.v.Minor, tc.v.Patch, got, tc.want)
+		}
+	}
+}
+
+// --- pure parser ----------------------------------------------------
+
+func TestParseVersion_KnownShapes(t *testing.T) {
+	cases := []struct {
+		name      string
+		raw       string
+		wantMajor int
+		wantMinor int
+		wantPatch int
+	}{
+		{"cc canonical with suffix", "2.1.126 (Claude Code)", 2, 1, 126},
+		{"cc no suffix", "2.1.123", 2, 1, 123},
+		{"leading whitespace", "   1.0.5\n", 1, 0, 5},
+		{"v-prefix tolerated", "v3.4.5", 3, 4, 5},
+		{"trailing build metadata", "2.1.120-rc1+build.42", 2, 1, 120},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			v, err := ParseVersion(tc.raw)
+			if err != nil {
+				t.Fatalf("unexpected parse error: %v", err)
+			}
+			if v.Major != tc.wantMajor || v.Minor != tc.wantMinor || v.Patch != tc.wantPatch {
+				t.Errorf("parsed: %+v want %d.%d.%d", v, tc.wantMajor, tc.wantMinor, tc.wantPatch)
+			}
+		})
+	}
+}
+
+func TestParseVersion_Unparseable(t *testing.T) {
+	cases := []string{"", "no digits here", "1.2", "1", "x.y.z"}
+	for _, raw := range cases {
+		if _, err := ParseVersion(raw); err == nil {
+			t.Errorf("ParseVersion(%q): expected ErrVersionUnparseable, got nil", raw)
+		} else if !errors.Is(err, ErrVersionUnparseable) {
+			t.Errorf("ParseVersion(%q): got %v, want chain to ErrVersionUnparseable", raw, err)
+		}
+	}
+}
+
+// --- Verify range gate ----------------------------------------------
+
+func TestVerify_WithinRange(t *testing.T) {
+	r := SupportedRange{Major: 2, Minor: 1, MinPatch: 120}
+	for _, v := range []Version{
+		{Major: 2, Minor: 1, Patch: 120},
+		{Major: 2, Minor: 1, Patch: 123},
+		{Major: 2, Minor: 1, Patch: 999},
+	} {
+		if err := Verify(v, r); err != nil {
+			t.Errorf("Verify(%+v): unexpected %v", v, err)
+		}
+	}
+}
+
+func TestVerify_BelowMinPatch(t *testing.T) {
+	r := SupportedRange{Major: 2, Minor: 1, MinPatch: 120}
+	v := Version{Major: 2, Minor: 1, Patch: 119}
+	err := Verify(v, r)
+	if !errors.Is(err, ErrVersionUnsupported) {
+		t.Errorf("Verify(2.1.119, ≥2.1.120): got %v, want ErrVersionUnsupported chain", err)
+	}
+	if !strings.Contains(err.Error(), "2.1.119") || !strings.Contains(err.Error(), "2.1.120") {
+		t.Errorf("error should reference both detected and required: got %q", err.Error())
+	}
+}
+
+func TestVerify_WrongMinor(t *testing.T) {
+	r := SupportedRange{Major: 2, Minor: 1, MinPatch: 120}
+	for _, v := range []Version{
+		{Major: 2, Minor: 0, Patch: 999}, // older minor
+		{Major: 2, Minor: 2, Patch: 0},   // newer minor — explicit re-verification needed
+	} {
+		err := Verify(v, r)
+		if !errors.Is(err, ErrVersionUnsupported) {
+			t.Errorf("Verify(%+v): want ErrVersionUnsupported chain, got %v", v, err)
+		}
+	}
+}
+
+func TestVerify_WrongMajor(t *testing.T) {
+	r := SupportedRange{Major: 2, Minor: 1, MinPatch: 120}
+	v := Version{Major: 1, Minor: 1, Patch: 200}
+	if err := Verify(v, r); !errors.Is(err, ErrVersionUnsupported) {
+		t.Errorf("Verify(1.1.200, range 2.1.x): got %v, want ErrVersionUnsupported", err)
+	}
+}
+
+// --- DefaultSupported sanity ---------------------------------------
+
+func TestDefaultSupported_StableValues(t *testing.T) {
+	// gh-13 retro § "Held assumptions": stream-json data plane verified
+	// across 2.1.120 → 2.1.123. Floor was set to .120; do not silently
+	// move it without retro evidence.
+	if DefaultSupported.Major != 2 || DefaultSupported.Minor != 1 || DefaultSupported.MinPatch != 120 {
+		t.Errorf("DefaultSupported drifted: %+v want {2 1 120}", DefaultSupported)
+	}
+}
+
+// --- Detect against fake binary -------------------------------------
+
+// makeFakeClaudeBinary writes a small bash script that echoes the given
+// version string on --version and returns its path. Cleaned up via t.Cleanup.
+func makeFakeClaudeBinary(t *testing.T, output string) string {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "fake-claude")
+	script := "#!/bin/bash\nif [[ \"$1\" == \"--version\" ]]; then\n  echo " + shellEscape(output) + "\n  exit 0\nfi\nexit 1\n"
+	if err := os.WriteFile(path, []byte(script), 0o755); err != nil {
+		t.Fatalf("write fake binary: %v", err)
+	}
+	return path
+}
+
+func shellEscape(s string) string {
+	return "'" + strings.ReplaceAll(s, "'", `'\''`) + "'"
+}
+
+func TestDetect_FakeBinary_Success(t *testing.T) {
+	bin := makeFakeClaudeBinary(t, "2.1.126 (Claude Code)")
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	v, err := Detect(ctx, bin)
+	if err != nil {
+		t.Fatalf("Detect: %v", err)
+	}
+	if v.Major != 2 || v.Minor != 1 || v.Patch != 126 {
+		t.Errorf("parsed: %+v want 2.1.126", v)
+	}
+	if v.Raw != "2.1.126 (Claude Code)" {
+		t.Errorf("Raw: got %q want %q", v.Raw, "2.1.126 (Claude Code)")
+	}
+}
+
+func TestDetect_FakeBinary_BadOutput(t *testing.T) {
+	bin := makeFakeClaudeBinary(t, "no version here")
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	_, err := Detect(ctx, bin)
+	if err == nil || !errors.Is(err, ErrVersionUnparseable) {
+		t.Errorf("Detect with bad output: got %v, want ErrVersionUnparseable chain", err)
+	}
+}
+
+func TestDetect_NonExistentBinary(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	_, err := Detect(ctx, "/nonexistent/claude-binary-xyz")
+	if err == nil {
+		t.Fatal("Detect with nonexistent binary: expected error")
+	}
+	// Should NOT be ErrVersionUnparseable — that's a parse error, not a
+	// subprocess error. Should NOT be ErrVersionUnsupported either.
+	if errors.Is(err, ErrVersionUnparseable) || errors.Is(err, ErrVersionUnsupported) {
+		t.Errorf("non-existent binary should produce subprocess error, got: %v", err)
+	}
+}
+
+func TestDetectAndVerify_FakeBinary_Pass(t *testing.T) {
+	bin := makeFakeClaudeBinary(t, "2.1.126 (Claude Code)")
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	v, err := DetectAndVerify(ctx, bin, DefaultSupported)
+	if err != nil {
+		t.Fatalf("DetectAndVerify: %v", err)
+	}
+	if v.Patch != 126 {
+		t.Errorf("DetectAndVerify version: %+v", v)
+	}
+}
+
+func TestDetectAndVerify_FakeBinary_BelowFloor(t *testing.T) {
+	bin := makeFakeClaudeBinary(t, "2.1.100")
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	_, err := DetectAndVerify(ctx, bin, DefaultSupported)
+	if !errors.Is(err, ErrVersionUnsupported) {
+		t.Errorf("DetectAndVerify(2.1.100, default): got %v, want ErrVersionUnsupported", err)
+	}
+}
+
+// --- ctx cancel propagation ----------------------------------------
+
+func TestDetect_CtxCancel(t *testing.T) {
+	// Fake binary that sleeps forever — verify ctx cancel kills it.
+	dir := t.TempDir()
+	bin := filepath.Join(dir, "slow-claude")
+	if err := os.WriteFile(bin, []byte("#!/bin/bash\nsleep 30\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	defer cancel()
+	start := time.Now()
+	_, err := Detect(ctx, bin)
+	elapsed := time.Since(start)
+	if err == nil {
+		t.Fatal("expected ctx cancel error")
+	}
+	if elapsed > 2*time.Second {
+		t.Errorf("ctx cancel slow: took %v", elapsed)
+	}
+}


### PR DESCRIPTION
## Summary

PR-2 of gh-3 epic. Adds **internal/cc/** — cc-binary integration layer that ClaudeCodeProvider (PR-1) will consume in PR-5 once daemon orchestration wires the Hook server into Spawn.

- **S3** `internal/cc/version.go` — startup `claude --version` parse + range gate (F-08); `cmd.WaitDelay` fix for bash-grandchild pipe-hold
- **S4** `internal/cc/hookserver.go` — HTTP server on 127.0.0.1:0 with 5 hook handlers; `/blob/*` reserved namespace (D-18); `HookHandlers` DI seam; F-05 response schema; 8 MiB body cap; concurrent-safe
- **S5** `internal/cc/hooks.go` — generates cc `settings.json` wiring hooks to URLs; `HookURLs(baseURL)` exposed for testability; loopback-only gate

## Review fixes (multi-agent: concurrency + coverage in parallel)

### Critical
- **Stop didn't await Serve goroutine exit** — Stop returned before goroutine had cleaned up listener; supervisor couldn't tell when shutdown completed → `done chan` + `Stop` awaits + `TestHookServer_StopAwaitsServeGoroutineExit`
- **noopHandlers fail-OPEN on permission decisions** — if handlers=nil, PreToolUse + UserPromptSubmit returned `allow`; a daemon that forgot to wire handlers would silently auto-approve every tool call → flipped to fail-CLOSED `deny` with explanatory reason

### Major
- Serve goroutine error swallowed → `serveErr atomic.Pointer` + `ServeErr()` for daemon health checks
- No request body cap → 8 MiB `MaxBytesReader` + explicit 413
- Concurrent POST safety not asserted → 50-goroutine test + `HookHandlers` godoc concurrency contract
- `WriteSettingsFile` silently overwrote → documented + regression test
- `Stop-before-Start` poisoning untested → regression test
- End-to-end test parsed URL from curl string (fragile) → `HookURLs(baseURL)` exposed; test uses it directly
- `SettingsForCC` allowed non-loopback URLs → loopback-only validation

### Minor
- `Version.String()` test
- `/blob` (no slash) and `/blob/` (bare slash) edge case tests

## Test summary

```
go test -race ./internal/cc/...   → 51/51 PASS
go test -race ./...                → all repo PASS
go vet ./...                        → clean
```

LOC: 603 impl + 964 tests = 1567 total (test:impl 1.60)

## Skipped gates

- `[!] M-1 SKIPPED` — `verify_cmd: ""` in workspace.yaml (still no Makefile in tether)
- `[!] M2 SKIPPED — reason="PR-2 adds cc integration helpers but no daemon caller wires Hook server yet; E2E surface arrives in PR-5 (daemon orchestration). Internal handler tests + concurrent POST + end-to-end settings→handler round-trip cover the package's contracts."` (logged to `.polyforge.exceptions.log`)
- M5 not triggered (no `api/**/*.go`)

## Test plan

- [x] `go test -race ./internal/cc/...` PASS (51 tests)
- [x] `go test -race ./...` full repo PASS
- [x] `go vet ./...` clean
- [x] Concurrency review (subagent) — 2 critical + 4 major caught + fixed
- [x] Coverage review (subagent) — confirmed contract gaps caught
- [ ] Real cc subprocess integration deferred to PR-5 (daemon orchestration)

## Spec / plan refs

- Spec: `tether-doc/wiki/specs/2026-04-26-tether-go-quic-design.md` §5.2 (Hook + JSONL channels, F-05 response schema)
- Plan: `tether-doc/wiki/plans/2026-05-02-tether-go-quic-design.md` PR-2 (S3 + S4 + S5)

Refs: #3, depends on #24 (PR-1 merged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)