### PR TITLE
docs: bridge-test marker (sugar slash bridge 0.7.1+0.3.0 validation)

### DIFF
--- a/BRIDGE-TEST-2026-05-05.md
+++ b/BRIDGE-TEST-2026-05-05.md
@@ -1,0 +1,7 @@
+# polyforge sugar-bridge validation marker — 2026-05-05
+
+Non-functional file confirming /pf2-* slash commands now work end-to-end via
+polyforge-v2 0.7.1's pf-v2 sugar bridge + polyforge-coding 0.3.0's slash defs.
+
+Prior dogfood (PR #35/36) drove dispatcher manually via JSON pipe; this run
+exercises the user-facing UX path. Safe to delete after merge.


### PR DESCRIPTION
Non-functional marker validating /pf2-* slash UX after sugar bridge ship. Safe to merge + delete.