### PR TITLE
ops-concerns: 5 operational hardening fixes (gh-13 round-1 Tier-4)

### DIFF
--- a/BRIDGE-TEST-2026-05-05.md
+++ b/BRIDGE-TEST-2026-05-05.md
@@ -1,7 +1,0 @@
-# polyforge sugar-bridge validation marker — 2026-05-05
-
-Non-functional file confirming /pf2-* slash commands now work end-to-end via
-polyforge-v2 0.7.1's pf-v2 sugar bridge + polyforge-coding 0.3.0's slash defs.
-
-Prior dogfood (PR #35/36) drove dispatcher manually via JSON pipe; this run
-exercises the user-facing UX path. Safe to delete after merge.

--- a/DOGFOOD-2026-05-05.md
+++ b/DOGFOOD-2026-05-05.md
@@ -1,9 +1,0 @@
-# polyforge dogfood marker — 2026-05-05
-
-This is a non-functional file added by an end-to-end dogfood run validating
-polyforge-v2 0.7.0 + polyforge-coding 0.2.2 against the 3-repo tether stack.
-
-Workflow exercised:
-materialize → commit → rebase → push (dry) → push (real) → pr → merge → wrap
-
-Safe to delete after the loop completes.

--- a/internal/backend/claude/message.go
+++ b/internal/backend/claude/message.go
@@ -75,6 +75,58 @@ func (e Envelope) DecodeSystemInit() (SystemInit, error) {
 	return s, nil
 }
 
+// RateLimitInfo is the `rate_limit_info` object inside a `type=rate_limit_event`
+// envelope. Schema observed in cc SDK NDJSON stream (sample in
+// testdata/stream1.ndjson).
+//
+// All fields are JSON-tagged with the cc SDK's exact wire names (camelCase),
+// not Go-idiomatic names. resetsAt / overageResetsAt are unix epoch seconds.
+type RateLimitInfo struct {
+	// Status of the primary rate limit. Observed values: "allowed". Other
+	// statuses (e.g. "exceeded") are inferred from semantics; treat any
+	// non-"allowed" value as a refuse signal in EvaluateRateLimit.
+	Status string `json:"status,omitempty"`
+
+	// ResetsAt is when the primary limit resets (unix seconds).
+	ResetsAt int64 `json:"resetsAt,omitempty"`
+
+	// RateLimitType describes which tier this event refers to. Observed:
+	// "overage". Distinguishes primary vs overage budget reports.
+	RateLimitType string `json:"rateLimitType,omitempty"`
+
+	// OverageStatus is the status of the overage tier. Observed: "allowed".
+	OverageStatus string `json:"overageStatus,omitempty"`
+
+	// OverageResetsAt is when the overage tier resets (unix seconds).
+	OverageResetsAt int64 `json:"overageResetsAt,omitempty"`
+
+	// IsUsingOverage is true when the user is currently consuming overage
+	// budget (primary already exhausted for this window).
+	IsUsingOverage bool `json:"isUsingOverage,omitempty"`
+}
+
+// RateLimit is `type=rate_limit_event`. Fired periodically by cc to report
+// the user's current rate-limit status. The daemon caches the latest one
+// on the Session and uses it for pre-flight degrade-gracefully decisions
+// (ops-concerns subitem #4).
+type RateLimit struct {
+	Envelope
+	RateLimitInfo RateLimitInfo `json:"rate_limit_info"`
+}
+
+// DecodeRateLimit re-parses the envelope as a RateLimit. Returns an error
+// if Type doesn't match.
+func (e Envelope) DecodeRateLimit() (RateLimit, error) {
+	if e.Type != EventRateLimit {
+		return RateLimit{}, fmt.Errorf("not a rate_limit_event: type=%s", e.Type)
+	}
+	var r RateLimit
+	if err := json.Unmarshal(e.Raw, &r); err != nil {
+		return r, fmt.Errorf("rate_limit_event decode: %w", err)
+	}
+	return r, nil
+}
+
 // Result is `type=result, subtype=success` (sometimes with is_error=true).
 // Fired at end of every turn.
 type Result struct {

--- a/internal/backend/claude/oom_circuit.go
+++ b/internal/backend/claude/oom_circuit.go
@@ -1,0 +1,137 @@
+package claude
+
+import (
+	"errors"
+	"os/exec"
+	"syscall"
+	"time"
+)
+
+// OOM circuit-breaker (ops-concerns subitem #2 / gh-13 round-1 Tier-4 finding,
+// piaobeizu/tether#22).
+//
+// Problem: when the cc subprocess is killed by the kernel OOM-killer (Linux
+// SIGKILL → exit code -1 with WaitStatus.Signal()=SIGKILL), Recover() will
+// dutifully re-spawn it — and immediately get OOM-killed again, looping
+// forever. The daemon spins, the user sees "session keeps crashing" with
+// no clean failure mode.
+//
+// Mechanism:
+//   1. Recover detects whether the subprocess died ON ITS OWN (vs being
+//      killed by us during the Recover teardown). The pre-kill liveness
+//      probe in session.go's Recover() determines this.
+//   2. If the subprocess died on its own AND its exit was a SIGKILL, we
+//      attribute it to the OOM-killer (or an external `kill -9`) and
+//      append a timestamp to oomEvents.
+//   3. Recover's first action consults oomCircuitTripped(): if N OOM
+//      events have occurred within the policy window, return
+//      ErrOOMCircuitOpen instead of attempting another doomed spawn.
+//
+// Defaults: 3 OOM exits within 60 seconds → trip. Tunable via SpawnOpts.
+
+// Default circuit policy.
+const (
+	DefaultOOMCircuitMaxExits = 3
+	DefaultOOMCircuitWindow   = 60 * time.Second
+)
+
+// ErrOOMCircuitOpen is returned by Recover when the OOM circuit-breaker has
+// tripped. The daemon supervisor should surface a clean degrade-gracefully
+// message to the user instead of looping further Recover attempts.
+var ErrOOMCircuitOpen = errors.New("claude: OOM circuit-breaker open (subprocess killed too often)")
+
+// isOOMExit returns true when err looks like a SIGKILL-induced exit. We use
+// this AFTER we've established that we did NOT kill the subprocess
+// ourselves (the liveness probe in Recover sets that flag) — so a true here
+// means kernel OOM-killer or external `kill -9`.
+//
+// On Linux, SIGKILL produces ExitCode == -1 and WaitStatus.Signal() == SIGKILL.
+// On non-Unix or if the wait status type assertion fails, return false (no
+// false positives).
+func isOOMExit(err error) bool {
+	if err == nil {
+		return false
+	}
+	var ee *exec.ExitError
+	if !errors.As(err, &ee) || ee.ProcessState == nil {
+		return false
+	}
+	ws, ok := ee.ProcessState.Sys().(syscall.WaitStatus)
+	if !ok {
+		return false
+	}
+	return ws.Signaled() && ws.Signal() == syscall.SIGKILL
+}
+
+// recordOOMEvent appends time.Now() to the OOM event log. Caller MUST hold
+// s.mu in exclusive (Lock) mode.
+func (s *Session) recordOOMEventLocked(now time.Time) {
+	s.oomEvents = append(s.oomEvents, now)
+	// Garbage-collect events outside the policy window so the slice
+	// doesn't grow without bound.
+	cutoff := now.Add(-s.oomWindow())
+	keep := s.oomEvents[:0]
+	for _, t := range s.oomEvents {
+		if !t.Before(cutoff) {
+			keep = append(keep, t)
+		}
+	}
+	s.oomEvents = keep
+}
+
+// oomCircuitTrippedLocked reports whether enough OOM events have accumulated
+// within the policy window to trip the circuit-breaker. Caller MUST hold
+// s.mu in shared (RLock) or exclusive mode.
+func (s *Session) oomCircuitTrippedLocked(now time.Time) bool {
+	max := s.oomMaxExits()
+	if max <= 0 {
+		return false // disabled
+	}
+	cutoff := now.Add(-s.oomWindow())
+	n := 0
+	for _, t := range s.oomEvents {
+		if !t.Before(cutoff) {
+			n++
+		}
+	}
+	return n >= max
+}
+
+// OOMExits returns a copy of OOM event timestamps recorded for this Session
+// (within the current window — older events are pruned on each record).
+// Used by daemon-side observability + tests.
+func (s *Session) OOMExits() []time.Time {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	if len(s.oomEvents) == 0 {
+		return nil
+	}
+	out := make([]time.Time, len(s.oomEvents))
+	copy(out, s.oomEvents)
+	return out
+}
+
+// oomMaxExits / oomWindow return the configured policy with default fallback.
+// Caller does NOT need to hold s.mu (these read SpawnOpts which is immutable
+// after New).
+//
+// Tri-state semantics:
+//
+//	> 0  use the configured threshold
+//	== 0 use DefaultOOMCircuitMaxExits
+//	< 0  disabled — return as-is so oomCircuitTrippedLocked's
+//	     `if max <= 0 { return false }` short-circuits and the circuit
+//	     never trips regardless of how many events accumulate
+func (s *Session) oomMaxExits() int {
+	if s.spawnOpts.OOMCircuitMaxExits == 0 {
+		return DefaultOOMCircuitMaxExits
+	}
+	return s.spawnOpts.OOMCircuitMaxExits
+}
+
+func (s *Session) oomWindow() time.Duration {
+	if s.spawnOpts.OOMCircuitWindow > 0 {
+		return s.spawnOpts.OOMCircuitWindow
+	}
+	return DefaultOOMCircuitWindow
+}

--- a/internal/backend/claude/oom_circuit_test.go
+++ b/internal/backend/claude/oom_circuit_test.go
@@ -1,0 +1,215 @@
+package claude
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"os/exec"
+	"runtime"
+	"testing"
+	"time"
+)
+
+// ───────── isOOMExit detector tests ─────────
+
+// nil error is not an OOM exit.
+func TestIsOOMExit_NilNotOOM(t *testing.T) {
+	if isOOMExit(nil) {
+		t.Errorf("isOOMExit(nil) should be false")
+	}
+}
+
+// Plain error (not exec.ExitError) is not an OOM exit.
+func TestIsOOMExit_NonExitErrorNotOOM(t *testing.T) {
+	if isOOMExit(errors.New("random error")) {
+		t.Errorf("isOOMExit on non-ExitError should be false")
+	}
+}
+
+// Real subprocess that self-SIGKILLs → isOOMExit must be true.
+//
+// The whole point of OOM detection is recognizing a SIGKILL exit, regardless
+// of who sent the signal — kernel OOM-killer or `kill -9`. We use shell
+// self-kill as the most portable simulation.
+func TestIsOOMExit_RealSubprocessSelfSIGKILL(t *testing.T) {
+	if runtime.GOOS != "linux" && runtime.GOOS != "darwin" {
+		t.Skipf("isOOMExit relies on syscall.WaitStatus; %s untested here", runtime.GOOS)
+	}
+	cmd := exec.Command("sh", "-c", "kill -9 $$")
+	cmd.Stdout = &bytes.Buffer{}
+	cmd.Stderr = &bytes.Buffer{}
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start: %v", err)
+	}
+	err := cmd.Wait()
+	if !isOOMExit(err) {
+		t.Errorf("expected isOOMExit=true for self-SIGKILL'd subprocess; got err=%v", err)
+	}
+}
+
+// Subprocess that exits cleanly (status 0) → not OOM.
+func TestIsOOMExit_CleanExitNotOOM(t *testing.T) {
+	cmd := exec.Command("/bin/true")
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("/bin/true should exit 0; got %v", err)
+	}
+	if isOOMExit(nil) {
+		t.Errorf("clean exit should not be OOM")
+	}
+}
+
+// Subprocess that exits non-zero (status 1) → not OOM (it's an exit code,
+// not a signal).
+func TestIsOOMExit_NonZeroExitNotOOM(t *testing.T) {
+	cmd := exec.Command("/bin/false")
+	cmd.Stdout = &bytes.Buffer{}
+	cmd.Stderr = &bytes.Buffer{}
+	err := cmd.Run()
+	if err == nil {
+		t.Fatal("/bin/false should error")
+	}
+	if isOOMExit(err) {
+		t.Errorf("status-1 exit should NOT be classified as OOM; got: %v", err)
+	}
+}
+
+// ───────── circuit policy tests ─────────
+
+func oomTestSession(t *testing.T, maxExits int, window time.Duration) *Session {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	t.Cleanup(cancel)
+	sess, err := New(ctx, SpawnOpts{
+		BinaryPath:         "/bin/cat",
+		OOMCircuitMaxExits: maxExits,
+		OOMCircuitWindow:   window,
+	}, nil)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	t.Cleanup(func() { _ = sess.Close() })
+	go drainEvents(sess)
+	return sess
+}
+
+// Defaults: 0 events → not tripped.
+func TestOOMCircuit_FreshSessionNotTripped(t *testing.T) {
+	sess := oomTestSession(t, 0, 0) // 0 = use defaults (3 / 60s)
+	sess.mu.RLock()
+	tripped := sess.oomCircuitTrippedLocked(time.Now())
+	sess.mu.RUnlock()
+	if tripped {
+		t.Errorf("fresh session should not be tripped")
+	}
+	if exits := sess.OOMExits(); len(exits) != 0 {
+		t.Errorf("expected 0 OOM events, got %d", len(exits))
+	}
+}
+
+// Exactly N-1 events within window → still not tripped; N → tripped.
+func TestOOMCircuit_TripsExactlyAtThreshold(t *testing.T) {
+	sess := oomTestSession(t, 3, time.Minute)
+	now := time.Now()
+	sess.mu.Lock()
+	sess.recordOOMEventLocked(now)
+	sess.recordOOMEventLocked(now)
+	tripped2 := sess.oomCircuitTrippedLocked(now)
+	sess.recordOOMEventLocked(now)
+	tripped3 := sess.oomCircuitTrippedLocked(now)
+	sess.mu.Unlock()
+	if tripped2 {
+		t.Errorf("2 events should not trip a max=3 circuit")
+	}
+	if !tripped3 {
+		t.Errorf("3 events at max=3 should trip the circuit")
+	}
+	if got := len(sess.OOMExits()); got != 3 {
+		t.Errorf("expected 3 events recorded, got %d", got)
+	}
+}
+
+// Events outside the window are pruned and don't trip.
+func TestOOMCircuit_OldEventsPruned(t *testing.T) {
+	sess := oomTestSession(t, 3, 10*time.Second)
+	now := time.Now()
+	sess.mu.Lock()
+	// Record 3 events that are 1 minute old — all outside the 10s window.
+	old := now.Add(-1 * time.Minute)
+	sess.recordOOMEventLocked(old)
+	sess.recordOOMEventLocked(old)
+	sess.recordOOMEventLocked(old)
+	sess.mu.Unlock()
+
+	// recordOOMEventLocked prunes during its own write — but we recorded
+	// stale timestamps. Fast-forward by recording one fresh event: pruning
+	// happens against `now`, which is the recorded time. Since old events
+	// were stamped 1min ago vs window=10s, they should be pruned out on
+	// the FRESH event's recording (now > cutoff = now-10s).
+	sess.mu.Lock()
+	sess.recordOOMEventLocked(now)
+	tripped := sess.oomCircuitTrippedLocked(now)
+	sess.mu.Unlock()
+
+	if tripped {
+		t.Errorf("3 old events outside window + 1 fresh should NOT trip max=3 circuit")
+	}
+	exits := sess.OOMExits()
+	if len(exits) != 1 {
+		t.Errorf("expected 1 surviving event after pruning, got %d", len(exits))
+	}
+}
+
+// MaxExits<0 disables the circuit entirely (Recover keeps re-spawning).
+func TestOOMCircuit_NegativeMaxExitsDisables(t *testing.T) {
+	sess := oomTestSession(t, -1, time.Second)
+	now := time.Now()
+	sess.mu.Lock()
+	for i := 0; i < 100; i++ {
+		sess.recordOOMEventLocked(now)
+	}
+	tripped := sess.oomCircuitTrippedLocked(now)
+	sess.mu.Unlock()
+	if tripped {
+		t.Errorf("negative maxExits should disable the circuit; got tripped after 100 events")
+	}
+}
+
+// OOMExits returns a copy — caller mutation must not leak.
+func TestOOMCircuit_OOMExitsReturnsCopy(t *testing.T) {
+	sess := oomTestSession(t, 3, time.Minute)
+	t0 := time.Now()
+	sess.mu.Lock()
+	sess.recordOOMEventLocked(t0)
+	sess.mu.Unlock()
+	exits := sess.OOMExits()
+	if len(exits) != 1 {
+		t.Fatalf("expected 1 event, got %d", len(exits))
+	}
+	exits[0] = time.Time{} // tamper
+
+	exits2 := sess.OOMExits()
+	if exits2[0].Equal(time.Time{}) {
+		t.Errorf("OOMExits must return a copy; caller mutation leaked")
+	}
+}
+
+// ───────── Recover integration test ─────────
+
+// When the circuit is already tripped, Recover() returns ErrOOMCircuitOpen
+// immediately — does NOT proceed to teardown / re-spawn.
+func TestSession_Recover_OOMCircuitOpen(t *testing.T) {
+	sess := oomTestSession(t, 1, time.Minute) // very strict: 1 event = trip
+
+	// Pretend Start happened (Recover gates on sid != "").
+	sess.mu.Lock()
+	sess.sessionID = "fake-sid"
+	sess.recordOOMEventLocked(time.Now())
+	sess.mu.Unlock()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	err := sess.Recover(ctx)
+	if !errors.Is(err, ErrOOMCircuitOpen) {
+		t.Errorf("expected ErrOOMCircuitOpen, got: %v", err)
+	}
+}

--- a/internal/backend/claude/ratelimit.go
+++ b/internal/backend/claude/ratelimit.go
@@ -1,0 +1,65 @@
+package claude
+
+// RateLimitDecision is the outcome of evaluating a RateLimitInfo against the
+// pre-flight policy. Callers (typically daemon-side, ahead of forwarding a
+// user message) consume this to decide whether to forward, warn, or refuse.
+//
+// The decision is advisory — Session.Send does NOT consult it. Higher
+// layers wire it into their request path explicitly so policy stays out of
+// the low-level subprocess driver.
+type RateLimitDecision int
+
+const (
+	// RLDecisionAllow — primary status is "allowed" and we are not yet
+	// dipping into overage. Safe to send.
+	RLDecisionAllow RateLimitDecision = iota
+
+	// RLDecisionWarn — currently using overage budget OR overage status is
+	// not "allowed". Still possible to send, but the user should be told.
+	RLDecisionWarn
+
+	// RLDecisionRefuse — primary status is non-"allowed" (e.g. "exceeded")
+	// or both primary and overage are blocked. Sending will likely produce
+	// an error response from cc; degrade by refusing locally instead and
+	// surfacing a clean reason to the user.
+	RLDecisionRefuse
+)
+
+func (d RateLimitDecision) String() string {
+	switch d {
+	case RLDecisionAllow:
+		return "allow"
+	case RLDecisionWarn:
+		return "warn"
+	case RLDecisionRefuse:
+		return "refuse"
+	default:
+		return "unknown"
+	}
+}
+
+// EvaluateRateLimit applies the default pre-flight policy to a RateLimitInfo:
+//
+//   - RLDecisionRefuse if the primary `status` is set and != "allowed"
+//   - RLDecisionRefuse if `overageStatus` is set and != "allowed"
+//     (we have nothing left in either tier)
+//   - RLDecisionWarn   if `isUsingOverage` is true (primary already done;
+//     we're consuming the buffer)
+//   - RLDecisionAllow  otherwise (status fields empty = unknown = optimistic
+//     allow; cc not having sent any rate_limit_event yet should not block
+//     all sends)
+//
+// Pure function over a snapshot — no Session state. Stable for table-driven
+// tests and easy for callers to invoke without holding any lock.
+func EvaluateRateLimit(info RateLimitInfo) RateLimitDecision {
+	if info.Status != "" && info.Status != "allowed" {
+		return RLDecisionRefuse
+	}
+	if info.OverageStatus != "" && info.OverageStatus != "allowed" {
+		return RLDecisionRefuse
+	}
+	if info.IsUsingOverage {
+		return RLDecisionWarn
+	}
+	return RLDecisionAllow
+}

--- a/internal/backend/claude/ratelimit_test.go
+++ b/internal/backend/claude/ratelimit_test.go
@@ -1,0 +1,200 @@
+package claude
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+// makeRateLimit synthesizes a rate_limit_event Envelope. raw uses the real
+// cc wire schema (camelCase fields under rate_limit_info).
+func makeRateLimit(t *testing.T, status, rlType, overageStatus string, isUsingOverage bool) Envelope {
+	t.Helper()
+	raw := []byte(`{"type":"rate_limit_event","rate_limit_info":{"status":"` + status +
+		`","resetsAt":1777593600,"rateLimitType":"` + rlType +
+		`","overageStatus":"` + overageStatus +
+		`","overageResetsAt":1777593600,"isUsingOverage":` +
+		map[bool]string{true: "true", false: "false"}[isUsingOverage] +
+		`},"uuid":"u-rl","session_id":"sid-rl"}`)
+	env, err := ParseLine(raw)
+	if err != nil {
+		t.Fatalf("ParseLine: %v", err)
+	}
+	return env
+}
+
+// ───────── Decoder tests ─────────
+
+// Decode the real cc fixture line — verifies every field round-trips.
+func TestDecodeRateLimit_RealFixtureLine(t *testing.T) {
+	raw := []byte(`{"type":"rate_limit_event","rate_limit_info":{"status":"allowed","resetsAt":1777593600,"rateLimitType":"overage","overageStatus":"allowed","overageResetsAt":1777593600,"isUsingOverage":false},"uuid":"7ea195ff-1bc1-4a67-be07-04cb13fddc0f","session_id":"c840b5fb-96dd-4593-bc36-602689783a59"}`)
+	env, err := ParseLine(raw)
+	if err != nil {
+		t.Fatalf("ParseLine: %v", err)
+	}
+	rl, err := env.DecodeRateLimit()
+	if err != nil {
+		t.Fatalf("DecodeRateLimit: %v", err)
+	}
+	info := rl.RateLimitInfo
+	if info.Status != "allowed" {
+		t.Errorf("Status: %q", info.Status)
+	}
+	if info.ResetsAt != 1777593600 {
+		t.Errorf("ResetsAt: %d", info.ResetsAt)
+	}
+	if info.RateLimitType != "overage" {
+		t.Errorf("RateLimitType: %q", info.RateLimitType)
+	}
+	if info.OverageStatus != "allowed" {
+		t.Errorf("OverageStatus: %q", info.OverageStatus)
+	}
+	if info.OverageResetsAt != 1777593600 {
+		t.Errorf("OverageResetsAt: %d", info.OverageResetsAt)
+	}
+	if info.IsUsingOverage {
+		t.Errorf("IsUsingOverage should be false")
+	}
+}
+
+// Decode rejects non-rate_limit_event types.
+func TestDecodeRateLimit_WrongTypeRejected(t *testing.T) {
+	raw := []byte(`{"type":"system","subtype":"init","session_id":"x","uuid":"u"}`)
+	env, _ := ParseLine(raw)
+	if _, err := env.DecodeRateLimit(); err == nil {
+		t.Errorf("expected error decoding non-rate_limit envelope, got nil")
+	}
+}
+
+// ───────── EvaluateRateLimit pure-fn tests ─────────
+
+func TestEvaluateRateLimit_TableDriven(t *testing.T) {
+	cases := []struct {
+		name string
+		info RateLimitInfo
+		want RateLimitDecision
+	}{
+		{"empty info → allow (optimistic)", RateLimitInfo{}, RLDecisionAllow},
+		{"primary allowed, no overage", RateLimitInfo{Status: "allowed", OverageStatus: "allowed"}, RLDecisionAllow},
+		{"primary allowed, using overage → warn", RateLimitInfo{Status: "allowed", OverageStatus: "allowed", IsUsingOverage: true}, RLDecisionWarn},
+		{"primary exceeded → refuse", RateLimitInfo{Status: "exceeded", OverageStatus: "allowed"}, RLDecisionRefuse},
+		{"primary throttled → refuse", RateLimitInfo{Status: "throttled"}, RLDecisionRefuse},
+		{"overage exhausted → refuse", RateLimitInfo{Status: "allowed", OverageStatus: "exceeded"}, RLDecisionRefuse},
+		{"primary refuse trumps overage allowed", RateLimitInfo{Status: "exceeded", OverageStatus: "allowed", IsUsingOverage: true}, RLDecisionRefuse},
+		{"only OverageStatus set, blocked → refuse", RateLimitInfo{OverageStatus: "blocked"}, RLDecisionRefuse},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := EvaluateRateLimit(c.info)
+			if got != c.want {
+				t.Errorf("info=%+v: want %s, got %s", c.info, c.want, got)
+			}
+		})
+	}
+}
+
+func TestRateLimitDecision_StringFormat(t *testing.T) {
+	for _, c := range []struct {
+		d    RateLimitDecision
+		want string
+	}{
+		{RLDecisionAllow, "allow"},
+		{RLDecisionWarn, "warn"},
+		{RLDecisionRefuse, "refuse"},
+		{RateLimitDecision(99), "unknown"},
+	} {
+		if got := c.d.String(); got != c.want {
+			t.Errorf("decision %d: want %q, got %q", c.d, c.want, got)
+		}
+	}
+}
+
+// ───────── Session capture tests ─────────
+
+func rateLimitTestSession(t *testing.T) *Session {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	t.Cleanup(cancel)
+	sess, err := New(ctx, SpawnOpts{BinaryPath: "/bin/cat"}, nil)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	t.Cleanup(func() { _ = sess.Close() })
+	go drainEvents(sess)
+	return sess
+}
+
+// Before any rate_limit_event is observed: LastRateLimit() returns ok=false.
+func TestSession_LastRateLimit_NoneSeen(t *testing.T) {
+	sess := rateLimitTestSession(t)
+	info, at, ok := sess.LastRateLimit()
+	if ok {
+		t.Errorf("expected ok=false before any RL event, got ok=true")
+	}
+	if (info != RateLimitInfo{}) {
+		t.Errorf("expected zero RateLimitInfo, got %+v", info)
+	}
+	if !at.IsZero() {
+		t.Errorf("expected zero time, got %v", at)
+	}
+}
+
+// Session captures the latest RL event; subsequent ones overwrite.
+func TestSession_RecordRateLimit_LatestWins(t *testing.T) {
+	sess := rateLimitTestSession(t)
+
+	sess.recordRateLimit(makeRateLimit(t, "allowed", "overage", "allowed", false))
+	info1, at1, ok1 := sess.LastRateLimit()
+	if !ok1 {
+		t.Fatalf("expected ok=true after first record")
+	}
+	if info1.Status != "allowed" || info1.IsUsingOverage {
+		t.Errorf("first record: %+v", info1)
+	}
+	if at1.IsZero() {
+		t.Errorf("recordedAt should be non-zero")
+	}
+
+	// Second event with different status → overwrites.
+	sess.recordRateLimit(makeRateLimit(t, "exceeded", "primary", "allowed", true))
+	info2, at2, ok2 := sess.LastRateLimit()
+	if !ok2 {
+		t.Fatalf("ok=false after second record")
+	}
+	if info2.Status != "exceeded" || !info2.IsUsingOverage {
+		t.Errorf("second record: %+v", info2)
+	}
+	if !at2.After(at1) && !at2.Equal(at1) {
+		t.Errorf("recordedAt should advance or equal: at1=%v at2=%v", at1, at2)
+	}
+}
+
+// recordRateLimit silently ignores envelopes that fail to decode (e.g.
+// wrong type). Best-effort observation.
+func TestSession_RecordRateLimit_BadEnvelopeIgnored(t *testing.T) {
+	sess := rateLimitTestSession(t)
+	// Pass an envelope with wrong type.
+	raw := []byte(`{"type":"assistant","uuid":"u-x"}`)
+	env, _ := ParseLine(raw)
+
+	sess.recordRateLimit(env) // should not panic, should not record
+	if _, _, ok := sess.LastRateLimit(); ok {
+		t.Errorf("non-rate_limit envelope must not flip hasRateLimit to true")
+	}
+}
+
+// End-to-end: combine recording + evaluation. Exercises the typical daemon
+// pre-flight pattern: pull last RL → evaluate → decide.
+func TestSession_PreflightPattern_Refuse(t *testing.T) {
+	sess := rateLimitTestSession(t)
+	sess.recordRateLimit(makeRateLimit(t, "exceeded", "primary", "allowed", false))
+
+	info, _, ok := sess.LastRateLimit()
+	if !ok {
+		t.Fatalf("expected ok=true")
+	}
+	got := EvaluateRateLimit(info)
+	if got != RLDecisionRefuse {
+		t.Errorf("expected refuse for exceeded primary status, got %s", got)
+	}
+}

--- a/internal/backend/claude/session.go
+++ b/internal/backend/claude/session.go
@@ -126,6 +126,13 @@ type Session struct {
 	hasRateLimit     bool
 	lastRateLimitAt  time.Time // wall-clock when last RL was recorded
 
+	// OOM circuit-breaker (ops-concerns subitem #2). Timestamps of recent
+	// SIGKILL-attributed exits (i.e., subprocess died on its own with
+	// SIGKILL — likely OOM-killer or external `kill -9`). Old timestamps
+	// outside the policy window are pruned by recordOOMEventLocked. See
+	// oom_circuit.go for policy + ErrOOMCircuitOpen contract.
+	oomEvents []time.Time
+
 	events chan Envelope // long-lived; only Close() closes it
 	initCh chan string   // first system/init in *current* dispatcher lands here
 
@@ -491,12 +498,33 @@ func (s *Session) Recover(ctx context.Context) error {
 		return ErrUnsafeToReload
 	}
 
+	// OOM circuit-breaker (ops-concerns subitem #2). If too many SIGKILL
+	// exits have been attributed to this Session within the policy window,
+	// refuse to re-spawn — surface ErrOOMCircuitOpen so the daemon can
+	// degrade gracefully instead of looping forever.
+	s.mu.RLock()
+	tripped := s.oomCircuitTrippedLocked(time.Now())
+	s.mu.RUnlock()
+	if tripped {
+		return ErrOOMCircuitOpen
+	}
+
 	// C5: kill subprocess BEFORE AbortPending. Order matters — if we
 	// abort first, a racing outbound() can register in the freshly-empty
 	// pending map, write to the still-live stdin, then block forever
 	// waiting for a response from a soon-to-be-dead process.
+	//
+	// ops-concerns subitem #2: liveness probe via signal(0) BEFORE the
+	// kill so we can later distinguish "OOM-killer killed it" from "we
+	// killed it during teardown" — only the former counts toward the
+	// circuit-breaker. signal(0) returns nil if proc is alive, error if
+	// already gone.
+	preKilledByUs := false
 	if proc := oldSub.Cmd.Process; proc != nil {
-		_ = proc.Kill()
+		if err := proc.Signal(syscall.Signal(0)); err == nil {
+			_ = proc.Kill()
+			preKilledByUs = true
+		}
 	}
 	oldControl.AbortPending(ErrRecoverInterrupted)
 	oldCancel()
@@ -510,7 +538,18 @@ func (s *Session) Recover(ctx context.Context) error {
 	case <-oldStderrDone:
 	case <-time.After(5 * time.Second):
 	}
-	_ = oldSub.WaitOnce()
+	waitErr := oldSub.WaitOnce()
+
+	// ops-concerns subitem #2: if we did NOT kill the subprocess (i.e.
+	// it died on its own before our liveness probe) and its exit was a
+	// SIGKILL, attribute to OOM-killer (or external kill -9) and record
+	// the event. The next Recover invocation will check the circuit at
+	// the top and refuse if we've crossed the threshold.
+	if !preKilledByUs && isOOMExit(waitErr) {
+		s.mu.Lock()
+		s.recordOOMEventLocked(time.Now())
+		s.mu.Unlock()
+	}
 
 	// C4: re-check closed after teardown — Close() may have run
 	// concurrently. Without this we'd Spawn a new subprocess that

--- a/internal/backend/claude/session.go
+++ b/internal/backend/claude/session.go
@@ -729,19 +729,35 @@ func (s *Session) drainStderr() {
 	}
 }
 
+// appendStderr appends p to the bounded stderr ring buffer per spec §A.5.
+//
+// Invariant: after this call, s.stderrBuf.Len() <= stderrCap. We always keep
+// the last stderrCap bytes; older content is dropped (front trim).
+//
+// ops-concerns subitem #1 fix: previously, when len(p) alone exceeded
+// stderrCap the existing buffer was Reset() but the entire oversized p was
+// then appended, leaving the buffer >stderrCap (contract violation). With
+// 4KB read chunks in drainStderr this never bit in practice, but it would
+// trigger the moment a single Read returned more bytes than the cap.
 func (s *Session) appendStderr(p []byte) {
 	s.stderrMu.Lock()
 	defer s.stderrMu.Unlock()
+
+	// Case A: single write itself meets/exceeds cap → drop everything we had,
+	// keep only the last stderrCap bytes of p.
+	if len(p) >= stderrCap {
+		s.stderrBuf.Reset()
+		s.stderrBuf.Write(p[len(p)-stderrCap:])
+		return
+	}
+
+	// Case B: combined would exceed cap → trim front of existing buffer
+	// to make room while keeping len ≤ cap after the upcoming Write(p).
 	if s.stderrBuf.Len()+len(p) > stderrCap {
-		// Trim from the front to keep last stderrCap bytes.
 		excess := s.stderrBuf.Len() + len(p) - stderrCap
-		if excess >= s.stderrBuf.Len() {
-			s.stderrBuf.Reset()
-		} else {
-			rest := s.stderrBuf.Bytes()[excess:]
-			s.stderrBuf.Reset()
-			s.stderrBuf.Write(rest)
-		}
+		rest := s.stderrBuf.Bytes()[excess:]
+		s.stderrBuf.Reset()
+		s.stderrBuf.Write(rest)
 	}
 	s.stderrBuf.Write(p)
 }

--- a/internal/backend/claude/session.go
+++ b/internal/backend/claude/session.go
@@ -117,6 +117,15 @@ type Session struct {
 	recordedClaudeVersion string
 	versionDrifts         []VersionDrift
 
+	// Latest rate_limit_event observed (ops-concerns subitem #4). cc emits
+	// this periodically; we cache it so the daemon can pre-flight check
+	// "is the user about to hit a limit" before forwarding new user
+	// messages. Session itself does NOT enforce — that's a daemon-level
+	// policy via EvaluateRateLimit + LastRateLimit().
+	lastRateLimit    RateLimitInfo
+	hasRateLimit     bool
+	lastRateLimitAt  time.Time // wall-clock when last RL was recorded
+
 	events chan Envelope // long-lived; only Close() closes it
 	initCh chan string   // first system/init in *current* dispatcher lands here
 
@@ -266,6 +275,35 @@ func (s *Session) VersionDrifts() []VersionDrift {
 	out := make([]VersionDrift, len(s.versionDrifts))
 	copy(out, s.versionDrifts)
 	return out
+}
+
+// LastRateLimit returns the latest rate_limit_info recorded from a
+// rate_limit_event, plus a bool indicating whether any has been seen. When
+// ok is false, the returned RateLimitInfo is zero-valued.
+//
+// Used by daemon-level pre-flight checks (see EvaluateRateLimit). Session
+// itself does NOT enforce on Send — keeping the layering: Session records,
+// daemon supervisor decides policy.
+func (s *Session) LastRateLimit() (info RateLimitInfo, recordedAt time.Time, ok bool) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.lastRateLimit, s.lastRateLimitAt, s.hasRateLimit
+}
+
+// recordRateLimit captures a rate_limit_event into Session state. Centralized
+// so dispatch can call it and unit tests can drive it without a subprocess.
+// Bad envelopes (decode errors) are silently ignored — rate-limit observation
+// is best-effort.
+func (s *Session) recordRateLimit(env Envelope) {
+	r, err := env.DecodeRateLimit()
+	if err != nil {
+		return
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.lastRateLimit = r.RateLimitInfo
+	s.hasRateLimit = true
+	s.lastRateLimitAt = time.Now()
 }
 
 // recordSystemInit captures session_id + claude_code_version from a
@@ -602,6 +640,10 @@ func (s *Session) dispatch() {
 				default:
 				}
 			}
+		}
+
+		if env.Type == EventRateLimit {
+			s.recordRateLimit(env)
 		}
 
 		select {

--- a/internal/backend/claude/session.go
+++ b/internal/backend/claude/session.go
@@ -104,6 +104,19 @@ type Session struct {
 	closed         bool
 	sentInit       bool // whether initCh has already been signaled
 
+	// Version drift detection (gh-13 round-1 review Tier-4 / ops-concerns
+	// subitem #3). claude_code_version SHOULD be stable across all
+	// system/init events of the same session — if it changes mid-session
+	// (e.g., user upgraded `claude` binary while a Recover happened), the
+	// daemon needs to know so it can refuse-or-warn.
+	//
+	// recordedClaudeVersion captures the FIRST non-empty version seen and
+	// is never overwritten by drift; versionDrifts accumulates each
+	// subsequent mismatch. Higher layers (daemon supervisor) decide policy
+	// (warn vs refuse) by polling VersionDrifts() after Recover.
+	recordedClaudeVersion string
+	versionDrifts         []VersionDrift
+
 	events chan Envelope // long-lived; only Close() closes it
 	initCh chan string   // first system/init in *current* dispatcher lands here
 
@@ -221,6 +234,70 @@ func (s *Session) SessionID() string {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 	return s.sessionID
+}
+
+// VersionDrift records one mismatch between claude_code_version values seen
+// in successive system/init events. See Session.versionDrifts.
+type VersionDrift struct {
+	From string    // recorded version before the drift event
+	To   string    // version observed in the new system/init
+	At   time.Time // wall-clock when the drift was recorded
+}
+
+// ClaudeCodeVersion returns the claude_code_version recorded from the FIRST
+// non-empty system/init seen on this Session. Subsequent drifts do NOT
+// overwrite this — see VersionDrifts() for those.
+func (s *Session) ClaudeCodeVersion() string {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.recordedClaudeVersion
+}
+
+// VersionDrifts returns a copy of all observed claude_code_version mismatches
+// for this Session. Empty slice = no drift; >0 = the binary has changed
+// underneath us at least once. Higher layers (daemon supervisor) decide what
+// to do (warn-only / refuse Recover / surface to user).
+func (s *Session) VersionDrifts() []VersionDrift {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	if len(s.versionDrifts) == 0 {
+		return nil
+	}
+	out := make([]VersionDrift, len(s.versionDrifts))
+	copy(out, s.versionDrifts)
+	return out
+}
+
+// recordSystemInit captures session_id + claude_code_version from a
+// system/init envelope. Returns true iff initCh has not yet been signaled
+// for this Session (caller should forward the session_id to initCh).
+//
+// Centralized so version drift logic stays in one place and is unit-testable
+// without spinning a real subprocess.
+func (s *Session) recordSystemInit(env Envelope) bool {
+	var newVer string
+	if si, err := env.DecodeSystemInit(); err == nil {
+		newVer = si.ClaudeCodeVersion
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.sessionID = env.SessionID
+	if s.recordedClaudeVersion == "" {
+		// First non-empty observation wins; empty observations don't count.
+		s.recordedClaudeVersion = newVer
+	} else if newVer != "" && newVer != s.recordedClaudeVersion {
+		// Subsequent mismatch — record but DO NOT overwrite recorded.
+		s.versionDrifts = append(s.versionDrifts, VersionDrift{
+			From: s.recordedClaudeVersion,
+			To:   newVer,
+			At:   time.Now(),
+		})
+	}
+	if s.sentInit {
+		return false
+	}
+	s.sentInit = true
+	return true
 }
 
 // State returns the current SessionState. Used by RecoverGate (Step 6).
@@ -519,14 +596,7 @@ func (s *Session) dispatch() {
 		s.applyStateTransition(env)
 
 		if env.Type == EventSystem && env.Subtype == "init" && env.SessionID != "" {
-			s.mu.Lock()
-			s.sessionID = env.SessionID
-			alreadySignaled := s.sentInit
-			if !alreadySignaled {
-				s.sentInit = true
-			}
-			s.mu.Unlock()
-			if !alreadySignaled {
+			if shouldSignal := s.recordSystemInit(env); shouldSignal {
 				select {
 				case s.initCh <- env.SessionID:
 				default:

--- a/internal/backend/claude/spawn.go
+++ b/internal/backend/claude/spawn.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"os/exec"
 	"sync"
+	"time"
 )
 
 // ErrBinaryNotFound is returned by Spawn when the claude binary cannot be
@@ -43,6 +44,19 @@ type SpawnOpts struct {
 	// BinaryPath overrides the default "claude" lookup. For tests / pinned
 	// installs.
 	BinaryPath string
+
+	// OOMCircuitMaxExits is the maximum number of SIGKILL-induced exits
+	// (attributed to the OOM-killer or external `kill -9`) tolerated within
+	// OOMCircuitWindow before Recover returns ErrOOMCircuitOpen. Zero (the
+	// default) means use DefaultOOMCircuitMaxExits (=3). Negative disables
+	// the circuit-breaker entirely (Recover will keep re-spawning).
+	//
+	// ops-concerns subitem #2 (gh-13 round-1 Tier-4).
+	OOMCircuitMaxExits int
+
+	// OOMCircuitWindow is the rolling window in which OOMCircuitMaxExits is
+	// counted. Zero means use DefaultOOMCircuitWindow (=60s).
+	OOMCircuitWindow time.Duration
 }
 
 // Subprocess is a running claude subprocess with stdio pipes.

--- a/internal/backend/claude/stderr_cap_test.go
+++ b/internal/backend/claude/stderr_cap_test.go
@@ -1,0 +1,138 @@
+package claude
+
+import (
+	"bytes"
+	"context"
+	"testing"
+	"time"
+)
+
+// stderrTestSession spins a Session backed by /bin/cat just to get a valid
+// Session struct, then we drive appendStderr() directly. drainStderr is
+// running on cat's stderr (which is empty), so it doesn't interfere.
+func stderrTestSession(t *testing.T) *Session {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	t.Cleanup(cancel)
+	sess, err := New(ctx, SpawnOpts{BinaryPath: "/bin/cat"}, nil)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	t.Cleanup(func() { _ = sess.Close() })
+	go drainEvents(sess)
+	return sess
+}
+
+// Small writes accumulate as-is; no trimming happens below cap.
+func TestStderrCap_SmallWritesAccumulate(t *testing.T) {
+	sess := stderrTestSession(t)
+
+	sess.appendStderr([]byte("first "))
+	sess.appendStderr([]byte("second "))
+	sess.appendStderr([]byte("third"))
+
+	got := sess.StderrSnapshot()
+	want := []byte("first second third")
+	if !bytes.Equal(got, want) {
+		t.Errorf("snapshot: want %q, got %q", want, got)
+	}
+}
+
+// Combined write would exceed cap → front is trimmed; last stderrCap bytes
+// preserved. Test against stderrCap directly so this stays correct if the
+// constant is tuned.
+func TestStderrCap_FrontTrimmedWhenExceeded(t *testing.T) {
+	sess := stderrTestSession(t)
+
+	// Fill to (cap - 5) with 'A's
+	prefix := bytes.Repeat([]byte("A"), stderrCap-5)
+	sess.appendStderr(prefix)
+	if got := len(sess.StderrSnapshot()); got != stderrCap-5 {
+		t.Fatalf("after prefix: want len=%d, got %d", stderrCap-5, got)
+	}
+
+	// Append 10 'B's — combined = cap+5 → expect trim of first 5 'A's,
+	// resulting buffer = (cap-10) 'A's followed by 10 'B's.
+	sess.appendStderr(bytes.Repeat([]byte("B"), 10))
+
+	snap := sess.StderrSnapshot()
+	if len(snap) != stderrCap {
+		t.Errorf("buffer length must equal cap: want %d, got %d", stderrCap, len(snap))
+	}
+	wantAs := bytes.Repeat([]byte("A"), stderrCap-10)
+	if !bytes.Equal(snap[:stderrCap-10], wantAs) {
+		t.Errorf("expected (cap-10) leading A's; first byte=%c last leading byte=%c", snap[0], snap[stderrCap-11])
+	}
+	wantBs := bytes.Repeat([]byte("B"), 10)
+	if !bytes.Equal(snap[stderrCap-10:], wantBs) {
+		t.Errorf("expected 10 trailing B's; got %q", snap[stderrCap-10:])
+	}
+}
+
+// Single write exactly equal to stderrCap → buffer becomes that write,
+// nothing prior survives.
+func TestStderrCap_SingleWriteEqualsCap(t *testing.T) {
+	sess := stderrTestSession(t)
+
+	sess.appendStderr([]byte("OLD-CONTENT"))
+	bigP := bytes.Repeat([]byte("X"), stderrCap)
+	sess.appendStderr(bigP)
+
+	snap := sess.StderrSnapshot()
+	if len(snap) != stderrCap {
+		t.Errorf("len: want %d, got %d", stderrCap, len(snap))
+	}
+	if !bytes.Equal(snap, bigP) {
+		t.Errorf("buffer should be exactly bigP after equal-cap write; first 5 bytes %q", snap[:5])
+	}
+}
+
+// Single write > cap (the bug fixed in s3): only the LAST stderrCap bytes
+// of the write are retained; buffer never exceeds cap. This case did not
+// exercise via real drainStderr (4KB chunks) but must be correct per contract.
+func TestStderrCap_SingleWriteExceedsCap_TailKept(t *testing.T) {
+	sess := stderrTestSession(t)
+
+	// Write cap+100 bytes: 100 'H' (head) followed by stderrCap 'T' (tail).
+	huge := append(bytes.Repeat([]byte("H"), 100), bytes.Repeat([]byte("T"), stderrCap)...)
+	sess.appendStderr(huge)
+
+	snap := sess.StderrSnapshot()
+	if len(snap) != stderrCap {
+		t.Fatalf("buffer must equal cap, got %d (cap=%d)", len(snap), stderrCap)
+	}
+	wantTail := bytes.Repeat([]byte("T"), stderrCap)
+	if !bytes.Equal(snap, wantTail) {
+		t.Errorf("expected only the tail (all T's); first byte=%c last byte=%c", snap[0], snap[len(snap)-1])
+	}
+}
+
+// Pathological: many tiny writes after the cap is reached — buffer must
+// stay at exactly cap regardless of how many appends happen.
+//
+// This test only verifies the BOUND (the core invariant of §A.5), not the
+// exact content of the tail. /bin/cat (used as a stub subprocess in this
+// test setup) can emit a small amount of stderr if it gets unexpected
+// argv from Spawn, and drainStderr would race with our appendStderr calls
+// to interleave bytes. The other tests in this file (which run a fixed
+// short sequence) prove tail-preservation correctness; this one is a
+// bound stress-test only.
+func TestStderrCap_RepeatedTinyWritesStayBounded(t *testing.T) {
+	sess := stderrTestSession(t)
+
+	// Saturate first.
+	sess.appendStderr(bytes.Repeat([]byte("X"), stderrCap))
+	for range 1000 {
+		sess.appendStderr([]byte("y"))
+	}
+	snap := sess.StderrSnapshot()
+	if len(snap) != stderrCap {
+		t.Errorf("len after many tiny appends: want %d, got %d", stderrCap, len(snap))
+	}
+	// Verify our 'y's reached the back: the very last byte should be 'y'
+	// (drainStderr from cat does not append at the end of an explicit
+	// appendStderr call within the same goroutine flow).
+	if last := snap[len(snap)-1]; last != 'y' {
+		t.Errorf("last byte should be 'y' (most recent write), got %q", last)
+	}
+}

--- a/internal/backend/claude/version_test.go
+++ b/internal/backend/claude/version_test.go
@@ -1,0 +1,174 @@
+package claude
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+)
+
+// makeSystemInit synthesizes a system/init Envelope with the given session_id
+// and claude_code_version, going through the real ParseLine pipeline so the
+// test exercises the same decode path as production.
+func makeSystemInit(t *testing.T, sid, ver string) Envelope {
+	t.Helper()
+	raw := []byte(fmt.Sprintf(
+		`{"type":"system","subtype":"init","session_id":%q,"uuid":"u-1","model":"claude-haiku","claude_code_version":%q}`,
+		sid, ver,
+	))
+	env, err := ParseLine(raw)
+	if err != nil {
+		t.Fatalf("ParseLine(system/init): %v", err)
+	}
+	return env
+}
+
+// newSessionStub spins a Session backed by /bin/cat (dispatcher will not see
+// system/init from cat — we drive recordSystemInit() directly). Caller MUST
+// defer sess.Close().
+func newSessionStub(t *testing.T) *Session {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	t.Cleanup(cancel)
+	sess, err := New(ctx, SpawnOpts{BinaryPath: "/bin/cat"}, nil)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	go drainEvents(sess)
+	return sess
+}
+
+// First system/init records claude_code_version + signals initCh.
+func TestSession_VersionDrift_FirstInitRecords(t *testing.T) {
+	sess := newSessionStub(t)
+	defer sess.Close()
+
+	signaled := sess.recordSystemInit(makeSystemInit(t, "sid-1", "2.1.123"))
+	if !signaled {
+		t.Errorf("first recordSystemInit should signal initCh (returned false)")
+	}
+	if got := sess.ClaudeCodeVersion(); got != "2.1.123" {
+		t.Errorf("ClaudeCodeVersion: want %q, got %q", "2.1.123", got)
+	}
+	if drifts := sess.VersionDrifts(); len(drifts) != 0 {
+		t.Errorf("expected no drifts after first init, got %d: %+v", len(drifts), drifts)
+	}
+	if got := sess.SessionID(); got != "sid-1" {
+		t.Errorf("SessionID: want %q, got %q", "sid-1", got)
+	}
+}
+
+// Second system/init with the SAME version (e.g., post-Recover happy path)
+// must not record drift. SessionID is allowed to update (resume can mint a
+// new server-side session_id per spec §7.7).
+func TestSession_VersionDrift_SameVersionNoDrift(t *testing.T) {
+	sess := newSessionStub(t)
+	defer sess.Close()
+
+	sess.recordSystemInit(makeSystemInit(t, "sid-1", "2.1.123"))
+	signaled := sess.recordSystemInit(makeSystemInit(t, "sid-1-resumed", "2.1.123"))
+	if signaled {
+		t.Errorf("second recordSystemInit should NOT signal initCh again")
+	}
+	if got := sess.ClaudeCodeVersion(); got != "2.1.123" {
+		t.Errorf("recorded version should remain unchanged, got %q", got)
+	}
+	if drifts := sess.VersionDrifts(); len(drifts) != 0 {
+		t.Errorf("expected 0 drifts after same-version reinit, got %d: %+v", len(drifts), drifts)
+	}
+	// SessionID allowed to update on resume.
+	if got := sess.SessionID(); got != "sid-1-resumed" {
+		t.Errorf("SessionID should update to new value, got %q", got)
+	}
+}
+
+// Drift case: claude binary upgraded mid-session, second init reports a
+// different claude_code_version. Drift recorded; recordedClaudeVersion stays
+// at the FIRST version (so the daemon can decide policy based on the original).
+func TestSession_VersionDrift_DifferentVersionRecorded(t *testing.T) {
+	sess := newSessionStub(t)
+	defer sess.Close()
+
+	sess.recordSystemInit(makeSystemInit(t, "sid-1", "2.1.123"))
+	sess.recordSystemInit(makeSystemInit(t, "sid-1-resumed", "2.1.124"))
+
+	if got := sess.ClaudeCodeVersion(); got != "2.1.123" {
+		t.Errorf("recordedClaudeVersion must NOT update on drift, got %q (expected first-wins %q)", got, "2.1.123")
+	}
+	drifts := sess.VersionDrifts()
+	if len(drifts) != 1 {
+		t.Fatalf("expected exactly 1 drift, got %d: %+v", len(drifts), drifts)
+	}
+	if drifts[0].From != "2.1.123" || drifts[0].To != "2.1.124" {
+		t.Errorf("drift From/To: want (%q→%q), got (%q→%q)", "2.1.123", "2.1.124", drifts[0].From, drifts[0].To)
+	}
+	if drifts[0].At.IsZero() {
+		t.Errorf("drift.At should be non-zero wall clock")
+	}
+}
+
+// Multiple successive drifts each get recorded; recordedClaudeVersion stays
+// at the original.
+func TestSession_VersionDrift_MultipleDriftsAccumulate(t *testing.T) {
+	sess := newSessionStub(t)
+	defer sess.Close()
+
+	sess.recordSystemInit(makeSystemInit(t, "sid-1", "2.1.123"))
+	sess.recordSystemInit(makeSystemInit(t, "sid-2", "2.1.124"))
+	sess.recordSystemInit(makeSystemInit(t, "sid-3", "2.1.125"))
+
+	if got := sess.ClaudeCodeVersion(); got != "2.1.123" {
+		t.Errorf("recordedClaudeVersion: want %q, got %q", "2.1.123", got)
+	}
+	drifts := sess.VersionDrifts()
+	if len(drifts) != 2 {
+		t.Fatalf("expected 2 drifts (2 mismatches), got %d", len(drifts))
+	}
+	want := []struct{ from, to string }{{"2.1.123", "2.1.124"}, {"2.1.123", "2.1.125"}}
+	for i, d := range drifts {
+		if d.From != want[i].from || d.To != want[i].to {
+			t.Errorf("drifts[%d]: want %q→%q, got %q→%q", i, want[i].from, want[i].to, d.From, d.To)
+		}
+	}
+}
+
+// First init has empty claude_code_version (defensive); second init has a
+// real one. recordedClaudeVersion adopts the first NON-EMPTY observation and
+// no drift is recorded.
+func TestSession_VersionDrift_EmptyFirstInitDoesNotCount(t *testing.T) {
+	sess := newSessionStub(t)
+	defer sess.Close()
+
+	sess.recordSystemInit(makeSystemInit(t, "sid-1", "")) // claude omitted version
+	if got := sess.ClaudeCodeVersion(); got != "" {
+		t.Errorf("recorded should be empty after empty-version init, got %q", got)
+	}
+	sess.recordSystemInit(makeSystemInit(t, "sid-2", "2.1.123"))
+
+	if got := sess.ClaudeCodeVersion(); got != "2.1.123" {
+		t.Errorf("recorded should adopt first non-empty version, got %q", got)
+	}
+	if drifts := sess.VersionDrifts(); len(drifts) != 0 {
+		t.Errorf("empty→non-empty is NOT drift, got %d: %+v", len(drifts), drifts)
+	}
+}
+
+// Drifts() returns a copy — caller mutation must not affect Session state.
+func TestSession_VersionDrift_DriftsReturnsCopy(t *testing.T) {
+	sess := newSessionStub(t)
+	defer sess.Close()
+
+	sess.recordSystemInit(makeSystemInit(t, "sid-1", "2.1.123"))
+	sess.recordSystemInit(makeSystemInit(t, "sid-2", "2.1.124"))
+
+	d1 := sess.VersionDrifts()
+	if len(d1) != 1 {
+		t.Fatalf("expected 1 drift, got %d", len(d1))
+	}
+	d1[0].From = "tampered"
+
+	d2 := sess.VersionDrifts()
+	if d2[0].From != "2.1.123" {
+		t.Errorf("Session.VersionDrifts() must return a copy; caller mutation leaked: %q", d2[0].From)
+	}
+}


### PR DESCRIPTION
Closes #22 (ops-concerns / gh-13 round-1 review Tier-4 catch-all).

## Subitems

Five small independent fixes under the gh-13 spike Tier-4 follow-up bucket. Each is its own commit on this branch.

| # | Subitem | Commit | Tests |
|---|---|---|---|
| s1 | Cleanup leftover dogfood markers (BRIDGE-TEST + DOGFOOD .md) | `ee138b6` | — |
| s2 | `claude_code_version` drift detection across system/init events | `3b6fcb0` | 6 unit tests |
| s3 | Bound stderr ring buffer when single write exceeds cap (spec §A.5) | `bf39ed6` | 5 unit tests |
| s4 | `rate_limit_event` observation + pre-flight evaluator | `b191082` | 13 unit tests |
| s5 | OOM circuit-breaker — refuse Recover after repeated SIGKILL exits | `9d9642a` | 11 unit tests |

**35 new unit tests total. All s1–s5 + existing recover_test/message_test/parser_test/control_test scenarios pass. RealClaude integration tests skipped in CI (no claude binary in test env) — they should be exercised manually before merge.**

## Architectural notes

- **s2 and s4 follow the same _observe, dont decide_ layering**: Session records facts (drift list, rate-limit info), accessors expose them, daemon supervisor decides policy. Send() default semantics unchanged.
- **s5 differs**: circuit-breaker is enforced inside Recover() itself because the policy IS protecting Recover() from self-loop. Returns a typed `ErrOOMCircuitOpen` for the daemon to surface cleanly.
- **s3 fixes a contract violation** (single write > cap left buffer > cap) — never bit in production because drainStderr reads in 4KB chunks, but covers the contract for any future caller.

## Plan

Planned via `/methodology-plan` and stored in `.workspace/memory/local/plan-ops-concerns.md` on the polyforge-v2 workspace. Order chosen smallest+isolated first → Recover-loop change last to minimize risk.

## Test plan

- [x] `go test ./internal/backend/claude/ -run [unit-style filter]` — 35 new + ~15 existing unit tests, 0 failures
- [ ] Manual: confirm `pf2-* slash command chain` resolves cleanly on a real claude binary (RealClaude tests in repo)
- [ ] Reviewer: spot-check s5 liveness-probe path (signal(0) before Kill) — only Linux+darwin tested via `sh -c kill -9 $$`
