### PR TITLE
creds-injection: SpawnOpts.Env + spec §10.3 v0.1 decision

### DIFF
--- a/internal/backend/claude/env_test.go
+++ b/internal/backend/claude/env_test.go
@@ -1,0 +1,118 @@
+package claude
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+// effectiveEnv unit tests — pure function, no subprocess required.
+
+func TestEffectiveEnv_NilReturnsNil(t *testing.T) {
+	if got := effectiveEnv(nil); got != nil {
+		t.Errorf("nil overrides should return nil (= inherit parent env); got %v", got)
+	}
+}
+
+func TestEffectiveEnv_EmptyMapReturnsNil(t *testing.T) {
+	if got := effectiveEnv(map[string]string{}); got != nil {
+		t.Errorf("empty map should return nil (= inherit parent env); got %v", got)
+	}
+}
+
+// New key not present in parent env → appended.
+func TestEffectiveEnv_NewKeyAppended(t *testing.T) {
+	got := effectiveEnv(map[string]string{
+		"POLYFORGE_TEST_NEW_KEY_XYZ": "1",
+	})
+	if !envContains(got, "POLYFORGE_TEST_NEW_KEY_XYZ=1") {
+		t.Errorf("new key should be appended; got %d entries, no match", len(got))
+	}
+}
+
+// Existing parent env key (PATH) → replaced exactly once.
+func TestEffectiveEnv_ExistingKeyReplacedNotDuplicated(t *testing.T) {
+	got := effectiveEnv(map[string]string{
+		"PATH": "/sentinel/bin",
+	})
+	pathCount := 0
+	for _, kv := range got {
+		if strings.HasPrefix(kv, "PATH=") {
+			pathCount++
+			if kv != "PATH=/sentinel/bin" {
+				t.Errorf("PATH should equal sentinel; got %q", kv)
+			}
+		}
+	}
+	if pathCount != 1 {
+		t.Errorf("PATH should appear exactly once after replace; got %d occurrences", pathCount)
+	}
+}
+
+// Empty-value override is allowed (subprocess sees empty string vs unset).
+func TestEffectiveEnv_EmptyValueIsAllowed(t *testing.T) {
+	got := effectiveEnv(map[string]string{
+		"POLYFORGE_TEST_EMPTY_VAR": "",
+	})
+	if !envContains(got, "POLYFORGE_TEST_EMPTY_VAR=") {
+		t.Errorf("empty-value override should produce 'KEY=' entry; got: %v", filterPolyforgeKeys(got))
+	}
+}
+
+// Multiple overrides — mix of new + replace, all applied.
+func TestEffectiveEnv_MultipleOverridesAllApplied(t *testing.T) {
+	got := effectiveEnv(map[string]string{
+		"POLYFORGE_TEST_A": "alpha",
+		"POLYFORGE_TEST_B": "beta",
+		"PATH":             "/sentinel",
+	})
+	if !envContains(got, "POLYFORGE_TEST_A=alpha") {
+		t.Errorf("expected POLYFORGE_TEST_A=alpha")
+	}
+	if !envContains(got, "POLYFORGE_TEST_B=beta") {
+		t.Errorf("expected POLYFORGE_TEST_B=beta")
+	}
+	if !envContains(got, "PATH=/sentinel") {
+		t.Errorf("expected PATH=/sentinel")
+	}
+	// Sanity: the parent env is preserved (e.g. HOME or PWD likely present).
+	if len(got) <= 3 {
+		t.Errorf("expected parent env preserved; got only %d entries: %v", len(got), got)
+	}
+}
+
+// Parent env entries not mentioned in overrides survive.
+func TestEffectiveEnv_UnoverriddenKeysSurvive(t *testing.T) {
+	// Pick a key we know is in the parent env (HOME).
+	homeBefore := os.Getenv("HOME")
+	if homeBefore == "" {
+		t.Skip("HOME not set; cannot exercise this path portably")
+	}
+	got := effectiveEnv(map[string]string{
+		"POLYFORGE_TEST_OVERRIDE": "x",
+	})
+	if !envContains(got, "HOME="+homeBefore) {
+		t.Errorf("HOME should be inherited unchanged; expected HOME=%q in result", homeBefore)
+	}
+}
+
+// ───────── helpers ─────────
+
+func envContains(env []string, want string) bool {
+	for _, kv := range env {
+		if kv == want {
+			return true
+		}
+	}
+	return false
+}
+
+func filterPolyforgeKeys(env []string) []string {
+	out := []string{}
+	for _, kv := range env {
+		if strings.HasPrefix(kv, "POLYFORGE_TEST_") || strings.HasPrefix(kv, "PATH=") {
+			out = append(out, kv)
+		}
+	}
+	return out
+}

--- a/internal/backend/claude/spawn.go
+++ b/internal/backend/claude/spawn.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"os"
 	"os/exec"
+	"strings"
 	"sync"
 	"time"
 )
@@ -57,6 +58,28 @@ type SpawnOpts struct {
 	// OOMCircuitWindow is the rolling window in which OOMCircuitMaxExits is
 	// counted. Zero means use DefaultOOMCircuitWindow (=60s).
 	OOMCircuitWindow time.Duration
+
+	// Env adds / overrides environment variables for the spawned subprocess
+	// on top of the parent process's environment. Nil (or empty map)
+	// inherits the parent's env unchanged — the v0 default.
+	//
+	// Per spec §10.3 (creds-injection / piaobeizu/tether#21): v0.1 cc
+	// authentication flows via env-var injection (ANTHROPIC_API_KEY or
+	// equivalent) at spawn time. The caller (daemon, when it exists; CLI
+	// for now) decides where the credential comes from — direct env, k8s
+	// Secret, vault, OAuth-derived token. Session.Spawn does NOT enforce
+	// any credential storage policy; it only forwards what the caller
+	// passes here.
+	//
+	// v0.2+ may add OAuth flow + secret store + token rotation; that work
+	// lives daemon-side and ultimately funnels into this same Env field —
+	// the shape is forward-compatible.
+	//
+	// Semantics: a key in Env replaces any same-named entry from the
+	// parent env. Keys not in Env are inherited as-is. To explicitly set
+	// an inherited variable to empty (vs unset), include it with value
+	// "" — subprocess sees the empty string.
+	Env map[string]string
 }
 
 // Subprocess is a running claude subprocess with stdio pipes.
@@ -132,6 +155,12 @@ func Spawn(ctx context.Context, opts SpawnOpts) (*Subprocess, error) {
 	cmd := exec.CommandContext(ctx, resolved, BuildArgs(opts)...)
 	cmd.Dir = effectiveCwd(opts.ProjectCwd)
 	cmd.ExtraFiles = nil // A.1: no fd 3 / extra channels
+	if env := effectiveEnv(opts.Env); env != nil {
+		cmd.Env = env
+	}
+	// nil cmd.Env preserves the historical default: cmd inherits the
+	// parent's env wholesale. Only callers who pass non-empty Env opt
+	// into the merge path.
 
 	stdin, err := cmd.StdinPipe()
 	if err != nil {
@@ -180,4 +209,38 @@ func effectiveCwd(opt string) string {
 		return h
 	}
 	return "/tmp"
+}
+
+// effectiveEnv builds the cmd.Env slice from parent env + caller overrides
+// per SpawnOpts.Env semantics (creds-injection / piaobeizu/tether#21):
+//
+//   - nil / empty map → return nil (caller of Spawn leaves cmd.Env as nil
+//     so cmd.Run inherits the parent env wholesale; preserves v0 default).
+//   - non-empty map → start from os.Environ(); for each (k,v) in
+//     overrides, replace the existing "k=*" entry if present, else append.
+//
+// Pure function; testable without a subprocess.
+func effectiveEnv(overrides map[string]string) []string {
+	if len(overrides) == 0 {
+		return nil
+	}
+	base := os.Environ()
+	// Index existing keys for O(1) replace.
+	idx := make(map[string]int, len(base))
+	for i, kv := range base {
+		eq := strings.IndexByte(kv, '=')
+		if eq <= 0 {
+			continue // malformed entry; leave alone
+		}
+		idx[kv[:eq]] = i
+	}
+	for k, v := range overrides {
+		entry := k + "=" + v
+		if i, ok := idx[k]; ok {
+			base[i] = entry
+		} else {
+			base = append(base, entry)
+		}
+	}
+	return base
 }


### PR DESCRIPTION
Closes #21 (creds-injection / gh-13 round-1 followup).

## Why

Path from user authentication → tether daemon → cc subprocess env, per spec §10.3. The original v1 ticket scope assumed full OAuth + secret store + rotation, but those depend on a daemon that doesn't exist yet (still spike+library mode per gh-13 retro). What CAN be locked at the library boundary is the **injection point itself**.

## What

**Code (tether)**: `SpawnOpts.Env map[string]string` — caller-controlled env override merged onto `os.Environ()`. Nil = inherit unchanged (backwards compat). 7 unit tests in env_test.go.

**Docs (tether-doc)**: spec §10.3 stops being a placeholder. v0.1 decision recorded: env-var injection via SpawnOpts.Env. Three deployment shapes documented (local dev / daemon / test). v0.2+ work (OAuth + secret store + rotation) explicitly listed as deferred + daemon-side; emphasized that SpawnOpts.Env shape is forward-compatible.

## Why library doesn't manage storage

Same philosophy as §A.5 stderr drain: provide **mechanism**, leave **policy** to caller. Avoids pre-committing to vault vs k8s Secret vs OAuth before daemon design is settled. Library stays scenario-agnostic.

## Test plan

- [x] 7 new env_test.go tests pass (nil/empty/append/replace/empty-value/multi/inherit)
- [x] Full s1-s5 ops-concerns regression still green
- [x] Backwards compat: existing callers (tests + spike/main.go) all `Env: nil` path → no behavior change
- [ ] Reviewer: confirm spec §10.3 wording captures the intended deferral correctly
