### PR TITLE
Epic #5 E2E C1 crypto + Go↔Rust wire-format spec

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,7 @@
 module github.com/piaobeizu/tether
 
 go 1.25.0
+
+require golang.org/x/crypto v0.50.0
+
+require golang.org/x/sys v0.43.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,4 @@
+golang.org/x/crypto v0.50.0 h1:zO47/JPrL6vsNkINmLoo/PH1gcxpls50DNogFvB5ZGI=
+golang.org/x/crypto v0.50.0/go.mod h1:3muZ7vA7PBCE6xgPX7nkzzjiUq87kRItoJQM1Yo8S+Q=
+golang.org/x/sys v0.43.0 h1:Rlag2XtaFTxp19wS8MXlJwTvoh8ArU6ezoyFsMyCTNI=
+golang.org/x/sys v0.43.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=

--- a/internal/crypto/doc.go
+++ b/internal/crypto/doc.go
@@ -1,0 +1,68 @@
+// Package crypto implements the C1 (精简版) end-to-end crypto layer specified in
+// spec §11.C / D-12 — the "server-compromise confidentiality" guarantee for
+// envelopes flowing daemon ↔ Mobile App through an honest-but-curious server.
+//
+// The server is a dumb relay: it sees only routing metadata
+// (sessionId / fromDeviceId / toDeviceId / nonce / keyVersion / ts / opaque
+// ciphertext) and never observes plaintext. Compromise of the server does not
+// reveal envelope contents. See spec §11.C ("Server-compromise confidentiality
+// guarantee", post P0-5 review rename).
+//
+// # Layering
+//
+//	┌────────────────────────────────────────────────────────────────────┐
+//	│ pairing.go     One-time QR pairing: X25519 ECDH → device_pair      │
+//	│                secret → HKDF-SHA256("tether-pair-v1") → wrap_key.  │
+//	│                SAS fallback (6-digit) for server-mediated pairing  │
+//	│                paths (only enabled in dev builds per spec §11.C).  │
+//	├────────────────────────────────────────────────────────────────────┤
+//	│ session.go     Per-cc-session ephemeral session_key (32B random),  │
+//	│                wrapped under wrap_key for transport. Persisted to  │
+//	│                disk encrypted under wrap_key for cc-session-length │
+//	│                lifetime (spec §11.B B4: must survive daemon        │
+//	│                restart so server-spooled ciphertext stays          │
+//	│                decryptable). Rotated on cc-session start.          │
+//	├────────────────────────────────────────────────────────────────────┤
+//	│ xchacha20poly1305.go  Per-envelope AEAD seal/open. 24-byte random  │
+//	│                nonce, AD = sessionId||fromDeviceId||toDeviceId     │
+//	│                ||keyVersion. XChaCha20-Poly1305 — see spec §11.M.  │
+//	├────────────────────────────────────────────────────────────────────┤
+//	│ replay.go      Receive-side defenses: 5-minute timestamp skew      │
+//	│                rejection + LRU envelope-id dedup window.           │
+//	└────────────────────────────────────────────────────────────────────┘
+//
+// hkdf.go and x25519.go provide the lower-level primitives (HKDF-SHA256
+// derivation, X25519 keypair gen + ECDH) reused by the rest of the layer.
+//
+// # Threat model (per spec §11.C)
+//
+//   - Server alone compromised: plaintext is safe. Server sees ciphertext +
+//     metadata only.
+//   - Device long-term wrap_key leak: future sessions exposed; already-ended
+//     cc sessions remain safe (their session_key was wiped on cc kill).
+//   - Daemon disk cold attack while cc session is alive: attacker can decrypt
+//     that one session's spool (acknowledged cost — see §11.B / B4).
+//
+// True message-level forward secrecy (Signal-style ratchet) is explicitly
+// out of scope for v0.1.
+//
+// # Cross-language interop (Tauri Mobile, Rust side)
+//
+// The Mobile App is a Tauri 2 application; its Rust core consumes/produces
+// the same wire artifacts this Go package produces. The Rust counterpart
+// uses:
+//
+//   - x25519-dalek for X25519 keypair + ECDH (matches RFC 7748)
+//   - chacha20poly1305 crate for XChaCha20-Poly1305
+//   - hkdf crate for HKDF-SHA256
+//
+// Wire compatibility is byte-for-byte: the Envelope struct in
+// xchacha20poly1305.go documents the exact serialization layout that Rust
+// must encode/decode. All multi-byte integers are big-endian; identifiers
+// are length-prefixed UTF-8 strings; Additional Data (AD) is constructed
+// with the exact deterministic concatenation defined in BuildAD.
+//
+// The HKDF info-strings ("tether-pair-v1", "tether-session-wrap-v1",
+// "tether-session-key-v1", "tether-pair-sas") are stable wire constants —
+// do not rename without a keyVersion bump (spec §11.C).
+package crypto

--- a/internal/crypto/hkdf.go
+++ b/internal/crypto/hkdf.go
@@ -1,0 +1,83 @@
+package crypto
+
+import (
+	"crypto/sha256"
+	"errors"
+	"fmt"
+	"io"
+
+	"golang.org/x/crypto/hkdf"
+)
+
+// HKDFKeySize is the canonical key length we derive throughout this package
+// — both wrap_key and session_key are 32 bytes, matching the
+// XChaCha20-Poly1305 key size (sym.KeySize).
+const HKDFKeySize = 32
+
+// Stable info-strings for HKDF expansion. Treat as wire constants per spec
+// §11.C — renaming requires a keyVersion bump because peers using different
+// info strings derive different keys.
+const (
+	// HKDFInfoPair is the info parameter for deriving wrap_key from the
+	// X25519 device-pair shared secret. Pairs with x25519-dalek output on
+	// the Rust side.
+	HKDFInfoPair = "tether-pair-v1"
+
+	// HKDFInfoSessionWrap is the info string for the AEAD key that wraps
+	// session_key for transport in a control envelope (CLI → Mobile App).
+	// Distinct from HKDFInfoPair so a leaked wrap_key does not give the
+	// holder reuse across domains.
+	HKDFInfoSessionWrap = "tether-session-wrap-v1"
+
+	// HKDFInfoSessionKey is the info string for the per-session AEAD key
+	// used to encrypt envelopes within a cc session.
+	HKDFInfoSessionKey = "tether-session-key-v1"
+
+	// HKDFInfoSAS derives the 6-digit Short Authentication String for the
+	// server-mediated pairing fallback (dev/debug builds only — see
+	// pairing.go and spec §11.C).
+	HKDFInfoSAS = "tether-pair-sas"
+
+	// HKDFInfoSessionPersist derives the AEAD key used to wrap session_key
+	// at rest in keys.bin (spec §11.B B4 — daemon restart must be able to
+	// recover the key to decrypt server-spooled history).
+	HKDFInfoSessionPersist = "tether-session-persist-v1"
+)
+
+// ErrHKDFInput is returned when an input to DeriveKey is empty or malformed
+// in a way that would weaken the derivation.
+var ErrHKDFInput = errors.New("crypto: invalid HKDF input")
+
+// DeriveKey runs HKDF-SHA256(ikm, salt, info) and returns `length` bytes.
+// salt may be nil for the standard "no salt" mode (HKDF then uses a hash-
+// length zero string per RFC 5869 §2.2). info MUST be one of the constants
+// above — passing an arbitrary user-controlled string risks domain crossing.
+func DeriveKey(ikm, salt []byte, info string, length int) ([]byte, error) {
+	if len(ikm) == 0 {
+		return nil, fmt.Errorf("%w: empty IKM", ErrHKDFInput)
+	}
+	if length <= 0 || length > 255*sha256.Size {
+		// HKDF-SHA256 max output per RFC 5869 §2.3 is 255 * HashLen = 8160 B.
+		return nil, fmt.Errorf("%w: bad length %d", ErrHKDFInput, length)
+	}
+	r := hkdf.New(sha256.New, ikm, salt, []byte(info))
+	out := make([]byte, length)
+	if _, err := io.ReadFull(r, out); err != nil {
+		return nil, fmt.Errorf("crypto: HKDF expand: %w", err)
+	}
+	return out, nil
+}
+
+// DeriveWrapKey runs the canonical pairing chain documented in spec §11.C:
+//
+//	wrap_key = HKDF-SHA256(device_pair_secret, salt=nil, info="tether-pair-v1", 32B)
+//
+// device_pair_secret is the raw 32-byte ECDH output of X25519SharedSecret.
+// Equivalent on the Rust side: hkdf::Hkdf::<Sha256>::new(None, &shared)
+// .expand(b"tether-pair-v1", &mut wrap_key).
+func DeriveWrapKey(devicePairSecret []byte) ([]byte, error) {
+	if len(devicePairSecret) != SharedSecretSize {
+		return nil, fmt.Errorf("%w: device pair secret must be %d bytes", ErrHKDFInput, SharedSecretSize)
+	}
+	return DeriveKey(devicePairSecret, nil, HKDFInfoPair, HKDFKeySize)
+}

--- a/internal/crypto/hkdf_test.go
+++ b/internal/crypto/hkdf_test.go
@@ -1,0 +1,94 @@
+package crypto
+
+import (
+	"bytes"
+	"errors"
+	"testing"
+)
+
+func TestDeriveKey_Deterministic(t *testing.T) {
+	ikm := bytes.Repeat([]byte{0xAB}, 32)
+	out1, err := DeriveKey(ikm, nil, HKDFInfoPair, 32)
+	if err != nil {
+		t.Fatalf("first: %v", err)
+	}
+	out2, err := DeriveKey(ikm, nil, HKDFInfoPair, 32)
+	if err != nil {
+		t.Fatalf("second: %v", err)
+	}
+	if !bytes.Equal(out1, out2) {
+		t.Fatal("HKDF must be deterministic for identical inputs")
+	}
+	if len(out1) != 32 {
+		t.Fatalf("len = %d, want 32", len(out1))
+	}
+}
+
+func TestDeriveKey_DomainSeparation(t *testing.T) {
+	ikm := bytes.Repeat([]byte{0x01}, 32)
+	pair, err := DeriveKey(ikm, nil, HKDFInfoPair, 32)
+	if err != nil {
+		t.Fatalf("pair: %v", err)
+	}
+	wrap, err := DeriveKey(ikm, nil, HKDFInfoSessionWrap, 32)
+	if err != nil {
+		t.Fatalf("wrap: %v", err)
+	}
+	sas, err := DeriveKey(ikm, nil, HKDFInfoSAS, 32)
+	if err != nil {
+		t.Fatalf("sas: %v", err)
+	}
+	if bytes.Equal(pair, wrap) || bytes.Equal(pair, sas) || bytes.Equal(wrap, sas) {
+		t.Fatal("different info strings must produce different outputs")
+	}
+}
+
+func TestDeriveKey_SaltAffectsOutput(t *testing.T) {
+	ikm := bytes.Repeat([]byte{0x55}, 32)
+	a, err := DeriveKey(ikm, []byte("salt-A"), HKDFInfoPair, 32)
+	if err != nil {
+		t.Fatalf("a: %v", err)
+	}
+	b, err := DeriveKey(ikm, []byte("salt-B"), HKDFInfoPair, 32)
+	if err != nil {
+		t.Fatalf("b: %v", err)
+	}
+	if bytes.Equal(a, b) {
+		t.Fatal("different salts must produce different outputs")
+	}
+}
+
+func TestDeriveKey_Errors(t *testing.T) {
+	cases := []struct {
+		name   string
+		ikm    []byte
+		length int
+	}{
+		{"empty ikm", []byte{}, 32},
+		{"zero length", []byte{0x01}, 0},
+		{"too long", []byte{0x01}, 255*32 + 1},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := DeriveKey(tc.ikm, nil, HKDFInfoPair, tc.length)
+			if !errors.Is(err, ErrHKDFInput) {
+				t.Fatalf("want ErrHKDFInput, got %v", err)
+			}
+		})
+	}
+}
+
+func TestDeriveWrapKey(t *testing.T) {
+	good := bytes.Repeat([]byte{0xCC}, SharedSecretSize)
+	wk, err := DeriveWrapKey(good)
+	if err != nil {
+		t.Fatalf("derive: %v", err)
+	}
+	if len(wk) != HKDFKeySize {
+		t.Fatalf("wrap key length = %d, want %d", len(wk), HKDFKeySize)
+	}
+	// Wrong size IKM rejected.
+	if _, err := DeriveWrapKey([]byte{0x01, 0x02}); !errors.Is(err, ErrHKDFInput) {
+		t.Fatalf("short ikm: want ErrHKDFInput, got %v", err)
+	}
+}

--- a/internal/crypto/integration_test.go
+++ b/internal/crypto/integration_test.go
@@ -1,0 +1,162 @@
+package crypto
+
+import (
+	"bytes"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// TestE2E_PairToEnvelopeRoundTrip walks the full C1 protocol end-to-end,
+// modeling the two peers (CLI side + Mobile App side) entirely in-process.
+// This is the spec §11.C compliance fingerprint test — if it ever breaks,
+// the wire is no longer compatible with the deployed Mobile App.
+//
+// Steps:
+//  1. Both sides generate X25519 keypairs.
+//  2. Pair: each side runs CompletePairing with peer's public key →
+//     identical wrap_key.
+//  3. CLI generates session_key, persists to disk under wrap_key (sim of
+//     the Mobile-App-receives-wrapped-session-key step would marshal into
+//     a control envelope; we instead reload from disk and prove the disk
+//     persistence is reversible — Mobile-side wire-wrap is structurally
+//     the same operation: AEAD with a wrap_key-derived key).
+//  4. CLI seals an envelope under session_key.
+//  5. The "transport" delivers the marshaled bytes (server side sees
+//     only this opaque blob) — we marshal then unmarshal to prove the
+//     wire format round-trips.
+//  6. Receiver runs replay guard, then opens envelope. Plaintext must
+//     match.
+//  7. Replay attempt with the same envelope-id is rejected.
+func TestE2E_PairToEnvelopeRoundTrip(t *testing.T) {
+	// ---- 1. keygen ----
+	cliKP, err := GenerateX25519KeyPair()
+	if err != nil {
+		t.Fatalf("cli kp: %v", err)
+	}
+	mobKP, err := GenerateX25519KeyPair()
+	if err != nil {
+		t.Fatalf("mob kp: %v", err)
+	}
+
+	// ---- 2. pair ----
+	cliPair, err := CompletePairing(cliKP.Private[:], mobKP.Public[:])
+	if err != nil {
+		t.Fatalf("cli pair: %v", err)
+	}
+	mobPair, err := CompletePairing(mobKP.Private[:], cliKP.Public[:])
+	if err != nil {
+		t.Fatalf("mob pair: %v", err)
+	}
+	if !bytes.Equal(cliPair.WrapKey, mobPair.WrapKey) {
+		t.Fatal("pair: wrap_keys disagree")
+	}
+	wrapKey := cliPair.WrapKey
+
+	// User-visible fingerprint mirroring (spec §11.C "scan QR → display
+	// fingerprint to user"):
+	if cliPair.LocalFingerprint != mobPair.PeerFingerprint ||
+		cliPair.PeerFingerprint != mobPair.LocalFingerprint {
+		t.Fatal("fingerprints don't mirror — UX confirmation step is broken")
+	}
+
+	// ---- 3. session_key + disk persistence ----
+	cliSK, err := NewSessionKey()
+	if err != nil {
+		t.Fatalf("session: %v", err)
+	}
+	dir := t.TempDir()
+	keysPath := filepath.Join(dir, "sessions", "cc-session-1", "keys.bin")
+	if err := cliSK.Persist(keysPath, wrapKey); err != nil {
+		t.Fatalf("persist: %v", err)
+	}
+
+	// Daemon-restart simulation — load it back. (Spec §11.B B4 invariant.)
+	cliSK2, err := LoadSessionKey(keysPath, wrapKey)
+	if err != nil {
+		t.Fatalf("reload: %v", err)
+	}
+	keyA, _ := cliSK.Bytes()
+	keyB, _ := cliSK2.Bytes()
+	if !bytes.Equal(keyA, keyB) {
+		t.Fatal("reloaded session_key differs from persisted")
+	}
+	sessionKey := keyA // both sides use this in-process; in the real
+	// system the Mobile App would have received it via a wrap_key-encrypted
+	// control envelope at session start.
+
+	// ---- 4. seal ----
+	plaintext := []byte("the quick brown fox jumps over the lazy daemon")
+	const sessionID = "cc-session-1"
+	const fromID = "cli-device-A"
+	const toID = "mobile-device-B"
+	env, err := SealEnvelope(sessionKey, sessionID, fromID, toID, 1, plaintext)
+	if err != nil {
+		t.Fatalf("seal: %v", err)
+	}
+
+	// ---- 5. wire round-trip ----
+	wire, err := env.Marshal()
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	// "Server" can see this blob but learns no plaintext — sanity-check
+	// no trivial leak.
+	if bytes.Contains(wire, plaintext) {
+		t.Fatal("plaintext appears verbatim in wire bytes — encryption broken")
+	}
+
+	delivered, err := UnmarshalEnvelope(wire)
+	if err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	// ---- 6. replay guard + open ----
+	const envelopeID = "env-uuid-1"
+	guard := NewReplayGuard()
+	if err := guard.Check(envelopeID, time.Now()); err != nil {
+		t.Fatalf("guard fresh: %v", err)
+	}
+	got, err := OpenEnvelope(sessionKey, delivered)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	if !bytes.Equal(got, plaintext) {
+		t.Fatalf("plaintext mismatch:\n got: %q\nwant: %q", got, plaintext)
+	}
+
+	// ---- 7. replay ----
+	if err := guard.Check(envelopeID, time.Now()); err == nil {
+		t.Fatal("replay guard accepted the same envelope-id twice")
+	}
+}
+
+// TestE2E_ServerCanNotReadAfterCompromise simulates the §11.C threat
+// model: even with full ciphertext access (the "compromised server"), the
+// adversary cannot recover plaintext without a session_key.
+func TestE2E_ServerCanNotReadAfterCompromise(t *testing.T) {
+	cli, _ := GenerateX25519KeyPair()
+	mob, _ := GenerateX25519KeyPair()
+	pr, _ := CompletePairing(cli.Private[:], mob.Public[:])
+	sk, _ := NewSessionKey()
+	keyBytes, _ := sk.Bytes()
+	env, _ := SealEnvelope(keyBytes, "s", "f", "t", 1, []byte("secret payload"))
+	wire, _ := env.Marshal()
+
+	// "Server" sees `wire` only; it has no session_key.
+	parsed, err := UnmarshalEnvelope(wire)
+	if err != nil {
+		t.Fatalf("server unmarshal: %v", err)
+	}
+	// Without session_key, server cannot decrypt — even if it tries with
+	// wrap_key (which it doesn't have either, but as a paranoid sanity
+	// check):
+	if _, err := OpenEnvelope(pr.WrapKey, parsed); err == nil {
+		t.Fatal("server-known wrap_key should NOT decrypt session-key envelope")
+	}
+	// Random key obviously doesn't work either:
+	bogus := make([]byte, AEADKeySize)
+	if _, err := OpenEnvelope(bogus, parsed); err == nil {
+		t.Fatal("zero key should NOT decrypt envelope")
+	}
+}

--- a/internal/crypto/pairing.go
+++ b/internal/crypto/pairing.go
@@ -1,0 +1,169 @@
+package crypto
+
+import (
+	"crypto/sha256"
+	"crypto/subtle"
+	"encoding/binary"
+	"encoding/hex"
+	"errors"
+	"fmt"
+)
+
+// ErrPairing is returned for pairing-flow failures (bad key sizes, SAS
+// mismatch, fingerprint mismatch).
+var ErrPairing = errors.New("crypto: pairing failure")
+
+// FingerprintPrefixLen / FingerprintSuffixLen control the visual fingerprint
+// shown to users on QR scan: prefix-of-pubkey-hash + "..." +
+// suffix-of-pubkey-hash. Per spec §11.C: "前 4 字节 + 后 4 字节 hex".
+const (
+	FingerprintPrefixLen = 4
+	FingerprintSuffixLen = 4
+)
+
+// SASDigits is the number of decimal digits in the Short Authentication
+// String. Per spec §11.C: "6 位 short authentication string".
+const SASDigits = 6
+
+// Fingerprint is the user-facing identifier shown on both ends of a QR
+// pairing flow. Per spec §11.C the user visually confirms it matches what
+// the other side displays.
+//
+// Encoding: hex(sha256(pubkey)[:FingerprintPrefixLen]) + ":" +
+//           hex(sha256(pubkey)[-FingerprintSuffixLen:])
+//
+// Cross-Rust interop: Tauri Mobile must compute the same SHA-256 over the
+// raw 32-byte X25519 public key and slice the same prefix/suffix. The
+// `:` separator is part of the canonical form — do not localize.
+func Fingerprint(publicKey []byte) (string, error) {
+	if len(publicKey) != X25519KeySize {
+		return "", fmt.Errorf("%w: public key must be %d bytes", ErrPairing, X25519KeySize)
+	}
+	h := sha256.Sum256(publicKey)
+	prefix := hex.EncodeToString(h[:FingerprintPrefixLen])
+	suffix := hex.EncodeToString(h[sha256.Size-FingerprintSuffixLen:])
+	return prefix + ":" + suffix, nil
+}
+
+// VerifyFingerprint constant-time compares a user-presented fingerprint
+// against the one computed for publicKey. Returns nil iff the fingerprints
+// match exactly.
+func VerifyFingerprint(publicKey []byte, claimed string) error {
+	expected, err := Fingerprint(publicKey)
+	if err != nil {
+		return err
+	}
+	if subtle.ConstantTimeCompare([]byte(expected), []byte(claimed)) != 1 {
+		return fmt.Errorf("%w: fingerprint mismatch", ErrPairing)
+	}
+	return nil
+}
+
+// ComputeSAS derives the 6-digit Short Authentication String from the raw
+// X25519 shared secret. Per spec §11.C:
+//
+//	SAS = HKDF(shared_secret, "tether-pair-sas") taken as a 6-digit decimal
+//
+// We expand 4 bytes from HKDF and reduce mod 10^SASDigits — biased but
+// negligibly so for 6 digits (worst-case bias < 1/10^7). Both sides MUST
+// derive the same SAS independently and the user reads them aloud to
+// confirm match — defends against MITM in the server-mediated fallback
+// pairing path (which is dev/debug-only per spec §11.C).
+func ComputeSAS(sharedSecret []byte) (string, error) {
+	if len(sharedSecret) != SharedSecretSize {
+		return "", fmt.Errorf("%w: shared secret must be %d bytes", ErrPairing, SharedSecretSize)
+	}
+	derived, err := DeriveKey(sharedSecret, nil, HKDFInfoSAS, 4)
+	if err != nil {
+		return "", fmt.Errorf("%w: derive SAS: %v", ErrPairing, err)
+	}
+	n := binary.BigEndian.Uint32(derived)
+	mod := uint32(1)
+	for i := 0; i < SASDigits; i++ {
+		mod *= 10
+	}
+	return fmt.Sprintf("%0*d", SASDigits, n%mod), nil
+}
+
+// VerifySAS constant-time compares the locally-computed SAS for
+// sharedSecret against what the user entered (typically read aloud from
+// the peer device). Returns nil iff they match.
+func VerifySAS(sharedSecret []byte, userEntered string) error {
+	expected, err := ComputeSAS(sharedSecret)
+	if err != nil {
+		return err
+	}
+	if len(expected) != len(userEntered) {
+		return fmt.Errorf("%w: SAS length mismatch", ErrPairing)
+	}
+	if subtle.ConstantTimeCompare([]byte(expected), []byte(userEntered)) != 1 {
+		return fmt.Errorf("%w: SAS mismatch", ErrPairing)
+	}
+	return nil
+}
+
+// PairResult is the output of CompletePairing — the wrap_key both sides
+// will keep long-term, plus the local fingerprint that should be shown to
+// the user as a final visual sanity check (the Mobile app can also display
+// the CLI-side fingerprint computed from the peer pubkey).
+//
+// PeerFingerprint is what the LOCAL side computes for the PEER's public
+// key — both peers must show the same value for each peer's pubkey, so
+// the two devices end up displaying mirrored pairs.
+type PairResult struct {
+	WrapKey         []byte
+	LocalFingerprint string
+	PeerFingerprint  string
+}
+
+// CompletePairing runs the full pairing derivation given an already-
+// generated local keypair and the peer's public key (typically scanned from
+// QR). On success returns the wrap_key both sides share, plus fingerprints
+// for user confirmation.
+//
+// Cross-Rust interop: the Mobile App runs the same X25519 ECDH and the
+// same DeriveWrapKey HKDF chain. Result wrap_key bytes are byte-identical
+// on both sides — that is the entire point of the protocol.
+func CompletePairing(localPrivate, peerPublic []byte) (*PairResult, error) {
+	if len(localPrivate) != X25519KeySize || len(peerPublic) != X25519KeySize {
+		return nil, fmt.Errorf("%w: keys must be %d bytes each", ErrPairing, X25519KeySize)
+	}
+	shared, err := X25519SharedSecret(localPrivate, peerPublic)
+	if err != nil {
+		return nil, fmt.Errorf("%w: ECDH: %v", ErrPairing, err)
+	}
+	wrap, err := DeriveWrapKey(shared)
+	if err != nil {
+		return nil, fmt.Errorf("%w: derive wrap key: %v", ErrPairing, err)
+	}
+	// Local fingerprint = fingerprint of OUR pubkey (Mobile would show this
+	// as "the CLI's fingerprint"); we recover our public from the private.
+	localPub, err := derivePublic(localPrivate)
+	if err != nil {
+		return nil, fmt.Errorf("%w: derive local public: %v", ErrPairing, err)
+	}
+	localFp, err := Fingerprint(localPub)
+	if err != nil {
+		return nil, err
+	}
+	peerFp, err := Fingerprint(peerPublic)
+	if err != nil {
+		return nil, err
+	}
+	return &PairResult{
+		WrapKey:          wrap,
+		LocalFingerprint: localFp,
+		PeerFingerprint:  peerFp,
+	}, nil
+}
+
+func derivePublic(private []byte) ([]byte, error) {
+	if len(private) != X25519KeySize {
+		return nil, ErrInvalidX25519Key
+	}
+	// Reuse curve25519 via the package helper — call into the same path
+	// X25519SharedSecret uses but with the basepoint (which is what
+	// generateX25519KeyPairFrom does internally). We re-export through
+	// X25519SharedSecret using the curve25519.Basepoint constant.
+	return basepointMul(private)
+}

--- a/internal/crypto/pairing_test.go
+++ b/internal/crypto/pairing_test.go
@@ -1,0 +1,144 @@
+package crypto
+
+import (
+	"bytes"
+	"errors"
+	"strings"
+	"testing"
+)
+
+func TestFingerprint_DeterministicAndShape(t *testing.T) {
+	kp, err := GenerateX25519KeyPair()
+	if err != nil {
+		t.Fatalf("kp: %v", err)
+	}
+	fpA, err := Fingerprint(kp.Public[:])
+	if err != nil {
+		t.Fatalf("fp1: %v", err)
+	}
+	fpB, err := Fingerprint(kp.Public[:])
+	if err != nil {
+		t.Fatalf("fp2: %v", err)
+	}
+	if fpA != fpB {
+		t.Fatal("fingerprint must be deterministic for the same pubkey")
+	}
+	parts := strings.Split(fpA, ":")
+	if len(parts) != 2 {
+		t.Fatalf("expected `prefix:suffix`, got %q", fpA)
+	}
+	if len(parts[0]) != 2*FingerprintPrefixLen || len(parts[1]) != 2*FingerprintSuffixLen {
+		t.Fatalf("unexpected fingerprint shape: %q", fpA)
+	}
+}
+
+func TestFingerprint_DifferentKeysDiffer(t *testing.T) {
+	a, _ := GenerateX25519KeyPair()
+	b, _ := GenerateX25519KeyPair()
+	fa, _ := Fingerprint(a.Public[:])
+	fb, _ := Fingerprint(b.Public[:])
+	if fa == fb {
+		t.Fatal("two random pubkeys produced same fingerprint")
+	}
+}
+
+func TestVerifyFingerprint(t *testing.T) {
+	kp, _ := GenerateX25519KeyPair()
+	fp, _ := Fingerprint(kp.Public[:])
+	if err := VerifyFingerprint(kp.Public[:], fp); err != nil {
+		t.Fatalf("verify good: %v", err)
+	}
+	if err := VerifyFingerprint(kp.Public[:], "ffffffff:ffffffff"); !errors.Is(err, ErrPairing) {
+		t.Fatalf("verify wrong: want ErrPairing, got %v", err)
+	}
+}
+
+func TestComputeSAS_ShapeAndDeterminism(t *testing.T) {
+	shared := bytes.Repeat([]byte{0xAA}, SharedSecretSize)
+	a, err := ComputeSAS(shared)
+	if err != nil {
+		t.Fatalf("a: %v", err)
+	}
+	b, err := ComputeSAS(shared)
+	if err != nil {
+		t.Fatalf("b: %v", err)
+	}
+	if a != b {
+		t.Fatal("SAS must be deterministic for same shared secret")
+	}
+	if len(a) != SASDigits {
+		t.Fatalf("SAS length = %d, want %d", len(a), SASDigits)
+	}
+	for _, c := range a {
+		if c < '0' || c > '9' {
+			t.Fatalf("SAS contains non-digit: %q", a)
+		}
+	}
+}
+
+func TestComputeSAS_DifferentSecretsDiffer(t *testing.T) {
+	s1 := bytes.Repeat([]byte{0xAA}, SharedSecretSize)
+	s2 := bytes.Repeat([]byte{0xBB}, SharedSecretSize)
+	a, _ := ComputeSAS(s1)
+	b, _ := ComputeSAS(s2)
+	if a == b {
+		// 1 in 1e6 collision possible by chance — fixed inputs above are safe.
+		t.Fatal("SAS collided on different shared secrets")
+	}
+}
+
+func TestVerifySAS(t *testing.T) {
+	shared := bytes.Repeat([]byte{0x11}, SharedSecretSize)
+	good, _ := ComputeSAS(shared)
+	if err := VerifySAS(shared, good); err != nil {
+		t.Fatalf("verify match: %v", err)
+	}
+	if err := VerifySAS(shared, "000000"); !errors.Is(err, ErrPairing) {
+		// extremely unlikely the real SAS is "000000" for this fixed input.
+		if good != "000000" {
+			t.Fatalf("verify wrong: want ErrPairing, got %v", err)
+		}
+	}
+	if err := VerifySAS(shared, "1234"); !errors.Is(err, ErrPairing) {
+		t.Fatalf("verify length mismatch: want ErrPairing, got %v", err)
+	}
+}
+
+func TestCompletePairing_BothSidesAgree(t *testing.T) {
+	cli, err := GenerateX25519KeyPair()
+	if err != nil {
+		t.Fatalf("cli: %v", err)
+	}
+	mob, err := GenerateX25519KeyPair()
+	if err != nil {
+		t.Fatalf("mob: %v", err)
+	}
+	cliResult, err := CompletePairing(cli.Private[:], mob.Public[:])
+	if err != nil {
+		t.Fatalf("cli pair: %v", err)
+	}
+	mobResult, err := CompletePairing(mob.Private[:], cli.Public[:])
+	if err != nil {
+		t.Fatalf("mob pair: %v", err)
+	}
+	if !bytes.Equal(cliResult.WrapKey, mobResult.WrapKey) {
+		t.Fatal("wrap_key must agree across pairing peers (the entire point)")
+	}
+	// Local fingerprint on one side equals peer fingerprint on the other.
+	if cliResult.LocalFingerprint != mobResult.PeerFingerprint {
+		t.Fatal("CLI's local fingerprint should equal Mobile's peer fingerprint")
+	}
+	if cliResult.PeerFingerprint != mobResult.LocalFingerprint {
+		t.Fatal("CLI's peer fingerprint should equal Mobile's local fingerprint")
+	}
+}
+
+func TestCompletePairing_BadInputs(t *testing.T) {
+	good, _ := GenerateX25519KeyPair()
+	if _, err := CompletePairing([]byte{0x01}, good.Public[:]); !errors.Is(err, ErrPairing) {
+		t.Fatalf("short priv: %v", err)
+	}
+	if _, err := CompletePairing(good.Private[:], []byte{0x01}); !errors.Is(err, ErrPairing) {
+		t.Fatalf("short peer: %v", err)
+	}
+}

--- a/internal/crypto/replay.go
+++ b/internal/crypto/replay.go
@@ -1,0 +1,154 @@
+package crypto
+
+import (
+	"container/list"
+	"errors"
+	"fmt"
+	"sync"
+	"time"
+)
+
+// DefaultReplayWindow is the timestamp tolerance window. Per spec §11.C
+// envelopes carry a `ts` metadata field; receivers reject envelopes whose
+// ts is more than DefaultReplayWindow off from the local clock. 5 minutes
+// matches the Kerberos-era convention of allowing real-world clock skew
+// between mobile and daemon hosts.
+const DefaultReplayWindow = 5 * time.Minute
+
+// DefaultReplayCacheSize is the LRU dedup cache capacity. Sized to ~5
+// minutes of envelope traffic at a generous 100 envelopes/sec.
+const DefaultReplayCacheSize = 30000
+
+// ErrReplay is returned when an envelope fails the replay check —
+// already-seen ID, or timestamp outside the skew window. Callers MUST
+// treat this as a hard rejection (do NOT decrypt; the envelope's authority
+// has already been undermined).
+var ErrReplay = errors.New("crypto: replay detected")
+
+// ReplayGuard tracks recently-seen envelope IDs and the local notion of
+// "now" for skew rejection. Concurrent-safe.
+//
+// Cross-Rust interop: the Mobile App runs an analogous guard with the same
+// 5-minute window and same dedup window size. The wire field carrying the
+// envelope ID (caller-supplied) is whatever the upper layer chooses —
+// typically a UUIDv4 generated at SealEnvelope time and prepended to the
+// outer transport frame. The replay guard does NOT itself read fields
+// from the Envelope struct in xchacha20poly1305.go — the wire ID lives at
+// the transport layer above this package.
+type ReplayGuard struct {
+	mu       sync.Mutex
+	window   time.Duration
+	capacity int
+	now      func() time.Time
+	// seen maps envelope ID → list element holding (id, time) for LRU eviction.
+	seen  map[string]*list.Element
+	order *list.List
+}
+
+type replayEntry struct {
+	id        string
+	receivedAt time.Time
+}
+
+// ReplayGuardOption configures NewReplayGuard. Accepting options as a
+// variadic keeps the common-case (defaults) call site uncluttered while
+// letting tests inject a deterministic clock.
+type ReplayGuardOption func(*ReplayGuard)
+
+// WithReplayWindow overrides the default 5-minute skew window.
+func WithReplayWindow(d time.Duration) ReplayGuardOption {
+	return func(g *ReplayGuard) { g.window = d }
+}
+
+// WithReplayCacheSize overrides the default LRU capacity.
+func WithReplayCacheSize(n int) ReplayGuardOption {
+	return func(g *ReplayGuard) { g.capacity = n }
+}
+
+// WithReplayClock injects a clock function — tests pass a fake to advance
+// time deterministically.
+func WithReplayClock(now func() time.Time) ReplayGuardOption {
+	return func(g *ReplayGuard) { g.now = now }
+}
+
+// NewReplayGuard returns a ReplayGuard configured with the supplied options
+// (or the package defaults).
+func NewReplayGuard(opts ...ReplayGuardOption) *ReplayGuard {
+	g := &ReplayGuard{
+		window:   DefaultReplayWindow,
+		capacity: DefaultReplayCacheSize,
+		now:      time.Now,
+		seen:     make(map[string]*list.Element),
+		order:    list.New(),
+	}
+	for _, o := range opts {
+		o(g)
+	}
+	return g
+}
+
+// Check verifies that envelopeID has not been seen and that timestamp is
+// within the skew window. On success it records envelopeID in the LRU
+// cache (evicting the oldest entry if at capacity) and returns nil. On
+// failure it returns ErrReplay wrapped with a reason — the envelope MUST
+// be dropped, not decrypted.
+//
+// Concurrent calls with the same envelopeID race-correctly: exactly one
+// call returns nil, the rest return ErrReplay.
+func (g *ReplayGuard) Check(envelopeID string, timestamp time.Time) error {
+	if envelopeID == "" {
+		return fmt.Errorf("%w: empty envelope id", ErrReplay)
+	}
+	g.mu.Lock()
+	defer g.mu.Unlock()
+
+	// 1. Skew check — uses local "now" not the cache's recorded times so
+	//    timestamps from far past or far future are immediately rejected.
+	now := g.now()
+	if timestamp.Before(now.Add(-g.window)) {
+		return fmt.Errorf("%w: timestamp %s is more than %s in the past", ErrReplay, timestamp.Format(time.RFC3339Nano), g.window)
+	}
+	if timestamp.After(now.Add(g.window)) {
+		return fmt.Errorf("%w: timestamp %s is more than %s in the future", ErrReplay, timestamp.Format(time.RFC3339Nano), g.window)
+	}
+
+	// 2. Garbage-collect entries older than the window — bounds memory
+	//    independent of the LRU capacity if traffic is bursty.
+	cutoff := now.Add(-g.window)
+	for e := g.order.Front(); e != nil; {
+		entry := e.Value.(*replayEntry)
+		if entry.receivedAt.After(cutoff) {
+			break
+		}
+		next := e.Next()
+		g.order.Remove(e)
+		delete(g.seen, entry.id)
+		e = next
+	}
+
+	// 3. Dedup check.
+	if _, ok := g.seen[envelopeID]; ok {
+		return fmt.Errorf("%w: envelope %s already seen", ErrReplay, envelopeID)
+	}
+
+	// 4. Insert + LRU evict if needed.
+	for g.order.Len() >= g.capacity {
+		oldest := g.order.Front()
+		if oldest == nil {
+			break
+		}
+		entry := oldest.Value.(*replayEntry)
+		g.order.Remove(oldest)
+		delete(g.seen, entry.id)
+	}
+	elem := g.order.PushBack(&replayEntry{id: envelopeID, receivedAt: now})
+	g.seen[envelopeID] = elem
+	return nil
+}
+
+// Size returns the current number of cached envelope IDs (testing aid).
+func (g *ReplayGuard) Size() int {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	return g.order.Len()
+}

--- a/internal/crypto/replay_test.go
+++ b/internal/crypto/replay_test.go
@@ -1,0 +1,147 @@
+package crypto
+
+import (
+	"errors"
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestReplay_AcceptsFreshThenRejectsDup(t *testing.T) {
+	g := NewReplayGuard()
+	now := time.Now()
+	if err := g.Check("env-1", now); err != nil {
+		t.Fatalf("first: %v", err)
+	}
+	if err := g.Check("env-1", now); !errors.Is(err, ErrReplay) {
+		t.Fatalf("dup: want ErrReplay, got %v", err)
+	}
+	if err := g.Check("env-2", now); err != nil {
+		t.Fatalf("different id: %v", err)
+	}
+}
+
+func TestReplay_RejectsTooOld(t *testing.T) {
+	now := time.Date(2026, 5, 6, 12, 0, 0, 0, time.UTC)
+	g := NewReplayGuard(WithReplayClock(func() time.Time { return now }))
+	stale := now.Add(-DefaultReplayWindow - time.Second)
+	err := g.Check("env-old", stale)
+	if !errors.Is(err, ErrReplay) {
+		t.Fatalf("want ErrReplay for stale ts, got %v", err)
+	}
+}
+
+func TestReplay_RejectsTooFuture(t *testing.T) {
+	now := time.Date(2026, 5, 6, 12, 0, 0, 0, time.UTC)
+	g := NewReplayGuard(WithReplayClock(func() time.Time { return now }))
+	future := now.Add(DefaultReplayWindow + time.Second)
+	err := g.Check("env-future", future)
+	if !errors.Is(err, ErrReplay) {
+		t.Fatalf("want ErrReplay for far-future ts, got %v", err)
+	}
+}
+
+func TestReplay_AcceptsWithinWindow(t *testing.T) {
+	now := time.Date(2026, 5, 6, 12, 0, 0, 0, time.UTC)
+	g := NewReplayGuard(WithReplayClock(func() time.Time { return now }))
+	cases := []time.Duration{
+		-DefaultReplayWindow + time.Second,
+		0,
+		DefaultReplayWindow - time.Second,
+	}
+	for i, d := range cases {
+		id := "env-" + time.Now().Format("150405") + "-" + string(rune('a'+i))
+		if err := g.Check(id, now.Add(d)); err != nil {
+			t.Fatalf("offset %s: %v", d, err)
+		}
+	}
+}
+
+func TestReplay_LRUEviction(t *testing.T) {
+	now := time.Date(2026, 5, 6, 12, 0, 0, 0, time.UTC)
+	g := NewReplayGuard(
+		WithReplayClock(func() time.Time { return now }),
+		WithReplayCacheSize(3),
+	)
+	// Fill exactly to capacity.
+	for _, id := range []string{"a", "b", "c"} {
+		if err := g.Check(id, now); err != nil {
+			t.Fatalf("fill %s: %v", id, err)
+		}
+	}
+	if g.Size() != 3 {
+		t.Fatalf("size after fill = %d", g.Size())
+	}
+	// One more — evicts "a".
+	if err := g.Check("d", now); err != nil {
+		t.Fatalf("d: %v", err)
+	}
+	if g.Size() != 3 {
+		t.Fatalf("size after evict = %d", g.Size())
+	}
+	// "b" and "c" still in cache → still rejected as dup.
+	if err := g.Check("b", now); !errors.Is(err, ErrReplay) {
+		t.Fatalf("b should still be in cache, got %v", err)
+	}
+	if err := g.Check("c", now); !errors.Is(err, ErrReplay) {
+		t.Fatalf("c should still be in cache, got %v", err)
+	}
+	// "a" was evicted → can now be re-checked. Doing so will evict "b"
+	// (the new oldest) — so we test "a" last to keep the assertion order
+	// independent. In real deployment the timestamp window would still
+	// reject "a" if it were genuinely a replay outside the 5-min window.
+	if err := g.Check("a", now); err != nil {
+		t.Fatalf("re-check evicted entry: %v", err)
+	}
+}
+
+func TestReplay_TimeBasedGC(t *testing.T) {
+	now := time.Date(2026, 5, 6, 12, 0, 0, 0, time.UTC)
+	clk := now
+	g := NewReplayGuard(WithReplayClock(func() time.Time { return clk }))
+
+	if err := g.Check("old", clk); err != nil {
+		t.Fatalf("first: %v", err)
+	}
+	// Advance clock past window — "old" should be GC'd on next call.
+	clk = clk.Add(DefaultReplayWindow + time.Minute)
+	if err := g.Check("new", clk); err != nil {
+		t.Fatalf("new: %v", err)
+	}
+	if g.Size() != 1 {
+		t.Fatalf("size after GC = %d, want 1", g.Size())
+	}
+}
+
+func TestReplay_EmptyIDRejected(t *testing.T) {
+	g := NewReplayGuard()
+	if err := g.Check("", time.Now()); !errors.Is(err, ErrReplay) {
+		t.Fatalf("empty id: want ErrReplay, got %v", err)
+	}
+}
+
+func TestReplay_ConcurrentDedup(t *testing.T) {
+	g := NewReplayGuard()
+	now := time.Now()
+	const N = 100
+	var wg sync.WaitGroup
+	successes := make(chan struct{}, N)
+	for i := 0; i < N; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			if err := g.Check("hot-id", now); err == nil {
+				successes <- struct{}{}
+			}
+		}()
+	}
+	wg.Wait()
+	close(successes)
+	count := 0
+	for range successes {
+		count++
+	}
+	if count != 1 {
+		t.Fatalf("concurrent dedup: %d successes, want exactly 1", count)
+	}
+}

--- a/internal/crypto/session.go
+++ b/internal/crypto/session.go
@@ -1,0 +1,292 @@
+package crypto
+
+import (
+	"crypto/rand"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sync"
+)
+
+// SessionKeySize is the byte length of a per-cc-session AEAD key. Matches
+// AEADKeySize so SealEnvelope/OpenEnvelope can use it directly.
+const SessionKeySize = AEADKeySize
+
+// ErrSessionKey is returned for session-key operations that fail (wrong
+// length, decrypt failure, missing file etc).
+var ErrSessionKey = errors.New("crypto: session key error")
+
+// SessionKey is the ephemeral per-cc-session 32-byte AEAD key. Lifetime
+// per spec §11.B B4: created when the cc session starts, persisted to
+// keys.bin (encrypted under wrap_key) for the duration of the cc session,
+// rotated on cc session start (NOT on daemon restart — daemon restart must
+// recover the SAME key from disk so server-spooled ciphertext stays
+// decryptable). Wiped (RotateSessionKey or DeletePersisted) when the user
+// runs `tether kill <id>`.
+type SessionKey struct {
+	mu      sync.Mutex
+	keyVer  uint32
+	current []byte // 32B, may be nil after wipe
+}
+
+// NewSessionKey allocates a fresh random 32-byte session key. Per spec
+// §11.B "session_key 跟 cc session 等长" — call this once at cc session
+// start, then Persist() to disk, then reuse the same SessionKey for the
+// session's full lifetime.
+func NewSessionKey() (*SessionKey, error) {
+	return newSessionKeyFrom(rand.Reader)
+}
+
+func newSessionKeyFrom(r io.Reader) (*SessionKey, error) {
+	buf := make([]byte, SessionKeySize)
+	if _, err := io.ReadFull(r, buf); err != nil {
+		return nil, fmt.Errorf("%w: read random: %v", ErrSessionKey, err)
+	}
+	return &SessionKey{keyVer: 1, current: buf}, nil
+}
+
+// Bytes returns a copy of the current key bytes. Callers should pass the
+// result directly to SealEnvelope/OpenEnvelope and not retain it.
+func (sk *SessionKey) Bytes() ([]byte, error) {
+	sk.mu.Lock()
+	defer sk.mu.Unlock()
+	if sk.current == nil {
+		return nil, fmt.Errorf("%w: key wiped", ErrSessionKey)
+	}
+	out := make([]byte, len(sk.current))
+	copy(out, sk.current)
+	return out, nil
+}
+
+// KeyVersion returns the per-rotation counter (starts at 1, increments on
+// each Rotate). Distinct from envelope keyVersion (spec §11.C v0.1=1) —
+// this counter is local bookkeeping, never shipped on the wire.
+func (sk *SessionKey) KeyVersion() uint32 {
+	sk.mu.Lock()
+	defer sk.mu.Unlock()
+	return sk.keyVer
+}
+
+// Rotate replaces the current key with a fresh random one. Per spec §11.B
+// rotate is called only on cc-session boundaries (cc session start, or
+// `tether kill`) — NOT on daemon restart. Old key bytes are zeroized.
+func (sk *SessionKey) Rotate() error {
+	return sk.rotateFrom(rand.Reader)
+}
+
+func (sk *SessionKey) rotateFrom(r io.Reader) error {
+	buf := make([]byte, SessionKeySize)
+	if _, err := io.ReadFull(r, buf); err != nil {
+		return fmt.Errorf("%w: read random: %v", ErrSessionKey, err)
+	}
+	sk.mu.Lock()
+	defer sk.mu.Unlock()
+	zeroize(sk.current)
+	sk.current = buf
+	sk.keyVer++
+	return nil
+}
+
+// Wipe zeroizes the in-memory key. After Wipe, Bytes() returns ErrSessionKey
+// until Rotate() is called. Use on `tether kill` to make in-memory disk
+// scraping useless without touching the on-disk persisted copy
+// (DeletePersisted handles that).
+func (sk *SessionKey) Wipe() {
+	sk.mu.Lock()
+	defer sk.mu.Unlock()
+	zeroize(sk.current)
+	sk.current = nil
+}
+
+// --- Persistence (spec §11.B B4) ----------------------------------------
+//
+// Format of keys.bin on disk (single-version v1 only):
+//
+//	+----+----+--------+----+------------+----+--------+----+----+
+//	| K  | salt(16)   | nonce(24) | keyVerBE(4) | ct_len(4) | ciphertext(N) |
+//	+----+------------+-----------+-------------+-----------+---------------+
+//	  1B   16B          24B          4B BE          4B BE      N bytes
+//
+// K = persist version (currently 1).
+// salt = per-file random salt fed to HKDF along with wrap_key to derive
+//        a unique persistence-AEAD key — defends against off-line
+//        cross-file key reuse if wrap_key ever leaks for one device.
+// AEAD = XChaCha20-Poly1305 over the raw 32-byte session key bytes,
+//        AD = "tether-keysbin-v1".
+//
+// Cross-Rust interop note: the Mobile App typically stores its own
+// session_key copy under iOS Keychain / Android Keystore (see
+// tauri-plugin-keyring) and does NOT use this format. This format is
+// CLI/daemon-side only. If a future "shared keys.bin" feature lands, the
+// Rust side must mirror this exact byte layout.
+
+const (
+	persistFormatV1     uint8  = 1
+	persistSaltSize            = 16
+	persistAEADInfoSalt        = "tether-session-persist-v1"
+	persistAEADADString        = "tether-keysbin-v1"
+)
+
+// Persist serializes the current SessionKey, encrypts it under a key
+// derived from wrap_key + a fresh per-file salt, and writes it atomically
+// to path. wrap_key is the 32-byte device pairing key (DeriveWrapKey).
+//
+// Atomic write: write to "<path>.tmp" then rename — survives crash mid-
+// write. Caller is expected to pass a path inside
+// ~/.tether/users/default/sessions/<id>/keys.bin (spec §6.1).
+func (sk *SessionKey) Persist(path string, wrapKey []byte) error {
+	if len(wrapKey) != HKDFKeySize {
+		return fmt.Errorf("%w: wrap key must be %d bytes", ErrSessionKey, HKDFKeySize)
+	}
+	sk.mu.Lock()
+	defer sk.mu.Unlock()
+	if sk.current == nil {
+		return fmt.Errorf("%w: cannot persist wiped key", ErrSessionKey)
+	}
+	salt := make([]byte, persistSaltSize)
+	if _, err := io.ReadFull(rand.Reader, salt); err != nil {
+		return fmt.Errorf("%w: read salt: %v", ErrSessionKey, err)
+	}
+	persistKey, err := DeriveKey(wrapKey, salt, HKDFInfoSessionPersist, AEADKeySize)
+	if err != nil {
+		return fmt.Errorf("%w: derive persist key: %v", ErrSessionKey, err)
+	}
+	defer zeroize(persistKey)
+
+	nonce := make([]byte, AEADNonceSize)
+	if _, err := io.ReadFull(rand.Reader, nonce); err != nil {
+		return fmt.Errorf("%w: read nonce: %v", ErrSessionKey, err)
+	}
+	aead, err := newAEADKey(persistKey)
+	if err != nil {
+		return err
+	}
+	ct := aead.Seal(nil, nonce, sk.current, []byte(persistAEADADString))
+
+	buf := make([]byte, 0, 1+persistSaltSize+AEADNonceSize+4+4+len(ct))
+	buf = append(buf, persistFormatV1)
+	buf = append(buf, salt...)
+	buf = append(buf, nonce...)
+	buf = appendUint32BE(buf, sk.keyVer)
+	buf = appendUint32BE(buf, uint32(len(ct)))
+	buf = append(buf, ct...)
+
+	if err := atomicWriteFile(path, buf, 0o600); err != nil {
+		return fmt.Errorf("%w: write keys.bin: %v", ErrSessionKey, err)
+	}
+	return nil
+}
+
+// LoadSessionKey is the inverse of Persist — used by daemon restart logic
+// (spec §11.B B4: recover session_key from disk so the daemon can decrypt
+// server-spooled ciphertext from the still-running cc session).
+func LoadSessionKey(path string, wrapKey []byte) (*SessionKey, error) {
+	if len(wrapKey) != HKDFKeySize {
+		return nil, fmt.Errorf("%w: wrap key must be %d bytes", ErrSessionKey, HKDFKeySize)
+	}
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("%w: read keys.bin: %v", ErrSessionKey, err)
+	}
+	r := newByteReader(raw)
+	ver, err := r.readByte()
+	if err != nil {
+		return nil, fmt.Errorf("%w: format version: %v", ErrSessionKey, err)
+	}
+	if ver != persistFormatV1 {
+		return nil, fmt.Errorf("%w: unsupported persist format %d", ErrSessionKey, ver)
+	}
+	salt, err := r.readN(persistSaltSize)
+	if err != nil {
+		return nil, fmt.Errorf("%w: salt: %v", ErrSessionKey, err)
+	}
+	nonce, err := r.readN(AEADNonceSize)
+	if err != nil {
+		return nil, fmt.Errorf("%w: nonce: %v", ErrSessionKey, err)
+	}
+	keyVer, err := r.readUint32()
+	if err != nil {
+		return nil, fmt.Errorf("%w: keyVer: %v", ErrSessionKey, err)
+	}
+	ctLen, err := r.readUint32()
+	if err != nil {
+		return nil, fmt.Errorf("%w: ctLen: %v", ErrSessionKey, err)
+	}
+	ct, err := r.readN(int(ctLen))
+	if err != nil {
+		return nil, fmt.Errorf("%w: ciphertext: %v", ErrSessionKey, err)
+	}
+	if r.remaining() != 0 {
+		return nil, fmt.Errorf("%w: trailing bytes", ErrSessionKey)
+	}
+	persistKey, err := DeriveKey(wrapKey, salt, HKDFInfoSessionPersist, AEADKeySize)
+	if err != nil {
+		return nil, fmt.Errorf("%w: derive persist key: %v", ErrSessionKey, err)
+	}
+	defer zeroize(persistKey)
+	aead, err := newAEADKey(persistKey)
+	if err != nil {
+		return nil, err
+	}
+	pt, err := aead.Open(nil, nonce, ct, []byte(persistAEADADString))
+	if err != nil {
+		return nil, fmt.Errorf("%w: decrypt session key: %v", ErrSessionKey, err)
+	}
+	if len(pt) != SessionKeySize {
+		return nil, fmt.Errorf("%w: bad session key length %d", ErrSessionKey, len(pt))
+	}
+	return &SessionKey{keyVer: keyVer, current: pt}, nil
+}
+
+// DeletePersisted removes the keys.bin file (spec §11.C: "cc session 结束 →
+// CLI 持久化清掉 session_key"). Idempotent — missing file is not an error.
+func DeletePersisted(path string) error {
+	if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("%w: remove keys.bin: %v", ErrSessionKey, err)
+	}
+	return nil
+}
+
+// --- helpers ---
+
+func zeroize(b []byte) {
+	for i := range b {
+		b[i] = 0
+	}
+}
+
+func appendUint32BE(buf []byte, v uint32) []byte {
+	tmp := [4]byte{byte(v >> 24), byte(v >> 16), byte(v >> 8), byte(v)}
+	return append(buf, tmp[:]...)
+}
+
+// atomicWriteFile writes data to <path>.tmp then renames to path so a
+// crash mid-write leaves the previous file intact (spec §11.C / §6.1
+// persistence invariant).
+func atomicWriteFile(path string, data []byte, mode os.FileMode) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		return err
+	}
+	tmp := path + ".tmp"
+	f, err := os.OpenFile(tmp, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, mode)
+	if err != nil {
+		return err
+	}
+	if _, err := f.Write(data); err != nil {
+		f.Close()
+		os.Remove(tmp)
+		return err
+	}
+	if err := f.Sync(); err != nil {
+		f.Close()
+		os.Remove(tmp)
+		return err
+	}
+	if err := f.Close(); err != nil {
+		os.Remove(tmp)
+		return err
+	}
+	return os.Rename(tmp, path)
+}

--- a/internal/crypto/session_test.go
+++ b/internal/crypto/session_test.go
@@ -1,0 +1,189 @@
+package crypto
+
+import (
+	"bytes"
+	"crypto/rand"
+	"errors"
+	"path/filepath"
+	"testing"
+)
+
+func TestNewSessionKey_RandomAndCorrectLen(t *testing.T) {
+	a, err := NewSessionKey()
+	if err != nil {
+		t.Fatalf("a: %v", err)
+	}
+	b, err := NewSessionKey()
+	if err != nil {
+		t.Fatalf("b: %v", err)
+	}
+	ka, _ := a.Bytes()
+	kb, _ := b.Bytes()
+	if len(ka) != SessionKeySize {
+		t.Fatalf("len = %d", len(ka))
+	}
+	if bytes.Equal(ka, kb) {
+		t.Fatal("two random session keys collided — RNG bug")
+	}
+	if a.KeyVersion() != 1 {
+		t.Fatalf("initial keyVer = %d, want 1", a.KeyVersion())
+	}
+}
+
+func TestSessionKey_RotateInvalidatesOld(t *testing.T) {
+	sk, err := NewSessionKey()
+	if err != nil {
+		t.Fatalf("setup: %v", err)
+	}
+	old, _ := sk.Bytes()
+
+	// Encrypt under old key.
+	env, err := SealEnvelope(old, "s", "f", "t", 1, []byte("payload"))
+	if err != nil {
+		t.Fatalf("seal: %v", err)
+	}
+
+	if err := sk.Rotate(); err != nil {
+		t.Fatalf("rotate: %v", err)
+	}
+	if sk.KeyVersion() != 2 {
+		t.Fatalf("post-rotate keyVer = %d, want 2", sk.KeyVersion())
+	}
+	newKey, _ := sk.Bytes()
+	if bytes.Equal(old, newKey) {
+		t.Fatal("rotate produced same key as before")
+	}
+
+	// New key must NOT decrypt envelope encrypted under old key.
+	if _, err := OpenEnvelope(newKey, env); !errors.Is(err, ErrAEAD) {
+		t.Fatalf("rotate didn't invalidate old ciphertext: %v", err)
+	}
+}
+
+func TestSessionKey_WipeBlocksBytes(t *testing.T) {
+	sk, err := NewSessionKey()
+	if err != nil {
+		t.Fatalf("setup: %v", err)
+	}
+	sk.Wipe()
+	if _, err := sk.Bytes(); !errors.Is(err, ErrSessionKey) {
+		t.Fatalf("want ErrSessionKey after wipe, got %v", err)
+	}
+}
+
+func freshWrapKey(t *testing.T) []byte {
+	t.Helper()
+	wk := make([]byte, HKDFKeySize)
+	if _, err := rand.Read(wk); err != nil {
+		t.Fatalf("rand: %v", err)
+	}
+	return wk
+}
+
+func TestSessionKey_PersistAndLoad(t *testing.T) {
+	wk := freshWrapKey(t)
+	sk, err := NewSessionKey()
+	if err != nil {
+		t.Fatalf("setup: %v", err)
+	}
+	want, _ := sk.Bytes()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "sessions", "abc", "keys.bin")
+	if err := sk.Persist(path, wk); err != nil {
+		t.Fatalf("persist: %v", err)
+	}
+
+	loaded, err := LoadSessionKey(path, wk)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	got, _ := loaded.Bytes()
+	if !bytes.Equal(want, got) {
+		t.Fatal("loaded session key differs from persisted")
+	}
+	if loaded.KeyVersion() != sk.KeyVersion() {
+		t.Fatalf("keyVer mismatch: %d vs %d", loaded.KeyVersion(), sk.KeyVersion())
+	}
+}
+
+func TestSessionKey_LoadWithWrongWrapKeyFails(t *testing.T) {
+	wk1 := freshWrapKey(t)
+	wk2 := freshWrapKey(t)
+	sk, _ := NewSessionKey()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "keys.bin")
+	if err := sk.Persist(path, wk1); err != nil {
+		t.Fatalf("persist: %v", err)
+	}
+	if _, err := LoadSessionKey(path, wk2); !errors.Is(err, ErrSessionKey) {
+		t.Fatalf("want ErrSessionKey on wrong wrap key, got %v", err)
+	}
+}
+
+func TestSessionKey_LoadCorruptedFails(t *testing.T) {
+	wk := freshWrapKey(t)
+	sk, _ := NewSessionKey()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "keys.bin")
+	if err := sk.Persist(path, wk); err != nil {
+		t.Fatalf("persist: %v", err)
+	}
+	// Truncate the on-disk file.
+	if err := writeBytes(path, []byte{0x01, 0x02, 0x03}); err != nil {
+		t.Fatalf("trunc: %v", err)
+	}
+	if _, err := LoadSessionKey(path, wk); !errors.Is(err, ErrSessionKey) {
+		t.Fatalf("want ErrSessionKey on corrupt file, got %v", err)
+	}
+}
+
+func TestSessionKey_PersistRotateLoadRoundTrip(t *testing.T) {
+	// Spec §11.B B4 fingerprint: rotate (cc session start) → persist →
+	// daemon "restart" (LoadSessionKey) recovers the SAME post-rotate key.
+	wk := freshWrapKey(t)
+	sk, _ := NewSessionKey()
+	if err := sk.Rotate(); err != nil {
+		t.Fatalf("rotate: %v", err)
+	}
+	postRotate, _ := sk.Bytes()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "keys.bin")
+	if err := sk.Persist(path, wk); err != nil {
+		t.Fatalf("persist: %v", err)
+	}
+	loaded, err := LoadSessionKey(path, wk)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	got, _ := loaded.Bytes()
+	if !bytes.Equal(postRotate, got) {
+		t.Fatal("post-rotate key not recovered from disk — daemon-restart unsafe")
+	}
+}
+
+func TestDeletePersisted_Idempotent(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "keys.bin")
+	// Missing file is OK.
+	if err := DeletePersisted(path); err != nil {
+		t.Fatalf("delete missing: %v", err)
+	}
+	// Create then delete.
+	wk := freshWrapKey(t)
+	sk, _ := NewSessionKey()
+	if err := sk.Persist(path, wk); err != nil {
+		t.Fatalf("persist: %v", err)
+	}
+	if err := DeletePersisted(path); err != nil {
+		t.Fatalf("delete present: %v", err)
+	}
+	if _, err := LoadSessionKey(path, wk); !errors.Is(err, ErrSessionKey) {
+		t.Fatalf("post-delete load should fail, got %v", err)
+	}
+}
+
+// writeBytes overwrites a file with raw content for corruption tests.
+func writeBytes(path string, b []byte) error {
+	return atomicWriteFile(path, b, 0o600)
+}

--- a/internal/crypto/x25519.go
+++ b/internal/crypto/x25519.go
@@ -1,0 +1,94 @@
+package crypto
+
+import (
+	"crypto/rand"
+	"errors"
+	"fmt"
+	"io"
+
+	"golang.org/x/crypto/curve25519"
+)
+
+// X25519KeySize is the byte length of every X25519 scalar / point used in
+// this package — both private and public keys are 32 bytes (RFC 7748 §5).
+const X25519KeySize = 32
+
+// SharedSecretSize is the byte length of the raw output of curve25519.X25519
+// (the unhashed shared secret). HKDF (hkdf.go) takes this as IKM.
+const SharedSecretSize = 32
+
+// ErrInvalidX25519Key is returned when an X25519 key has the wrong length or
+// fails curve25519 validation (e.g. a low-order public key, which would
+// produce an all-zero shared secret per RFC 7748 §6.1).
+var ErrInvalidX25519Key = errors.New("crypto: invalid X25519 key")
+
+// X25519KeyPair is one side of a device-pair handshake. It is intentionally
+// NOT the long-term identity material on its own — the wrap_key derivation
+// in pairing.go is what cements pairing identity.
+//
+// Cross-Rust interop: bytes are identical to what x25519-dalek's
+// `StaticSecret` (private) and `PublicKey` (public) `to_bytes()` returns.
+// 32 bytes, little-endian scalar form per RFC 7748 §5.
+type X25519KeyPair struct {
+	Private [X25519KeySize]byte
+	Public  [X25519KeySize]byte
+}
+
+// GenerateX25519KeyPair generates a fresh X25519 keypair using crypto/rand.
+// Per RFC 7748 §5 the X25519 function clamps the scalar internally, so we
+// pass random 32 bytes through directly without manual clamping. (The Go
+// curve25519 package's X25519(_, basepoint) likewise clamps inside.)
+func GenerateX25519KeyPair() (*X25519KeyPair, error) {
+	return generateX25519KeyPairFrom(rand.Reader)
+}
+
+// generateX25519KeyPairFrom is the testable entry point — tests can pass a
+// deterministic reader (e.g. bytes.NewReader of a known seed) to make
+// pairing-flow tests reproducible.
+func generateX25519KeyPairFrom(r io.Reader) (*X25519KeyPair, error) {
+	kp := &X25519KeyPair{}
+	if _, err := io.ReadFull(r, kp.Private[:]); err != nil {
+		return nil, fmt.Errorf("crypto: read X25519 private: %w", err)
+	}
+	pub, err := curve25519.X25519(kp.Private[:], curve25519.Basepoint)
+	if err != nil {
+		return nil, fmt.Errorf("crypto: derive X25519 public: %w", err)
+	}
+	copy(kp.Public[:], pub)
+	return kp, nil
+}
+
+// basepointMul derives the X25519 public key from a private scalar by
+// multiplying the basepoint. Used by pairing.go to recover our own
+// pubkey when only the private scalar is on hand.
+func basepointMul(private []byte) ([]byte, error) {
+	if len(private) != X25519KeySize {
+		return nil, ErrInvalidX25519Key
+	}
+	pub, err := curve25519.X25519(private, curve25519.Basepoint)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %v", ErrInvalidX25519Key, err)
+	}
+	return pub, nil
+}
+
+// X25519SharedSecret computes the ECDH shared secret between our private key
+// and a peer's public key. The output is the raw 32-byte point — callers
+// MUST run it through HKDF (hkdf.go) before using as a symmetric key, per
+// RFC 7748 §6.1 and the spec §11.C derivation chain
+// (device_pair_secret → HKDF → wrap_key).
+//
+// Returns ErrInvalidX25519Key if the peer public key has wrong length or
+// produces the all-zero output (low-order point — possible MITM signal).
+func X25519SharedSecret(privateKey, peerPublicKey []byte) ([]byte, error) {
+	if len(privateKey) != X25519KeySize || len(peerPublicKey) != X25519KeySize {
+		return nil, ErrInvalidX25519Key
+	}
+	shared, err := curve25519.X25519(privateKey, peerPublicKey)
+	if err != nil {
+		// curve25519.X25519 returns an error specifically when the result
+		// would be the all-zero output (low-order public key attack).
+		return nil, fmt.Errorf("%w: %v", ErrInvalidX25519Key, err)
+	}
+	return shared, nil
+}

--- a/internal/crypto/x25519_test.go
+++ b/internal/crypto/x25519_test.go
@@ -1,0 +1,104 @@
+package crypto
+
+import (
+	"bytes"
+	"errors"
+	"testing"
+)
+
+func TestGenerateX25519KeyPair_Random(t *testing.T) {
+	a, err := GenerateX25519KeyPair()
+	if err != nil {
+		t.Fatalf("first generate: %v", err)
+	}
+	b, err := GenerateX25519KeyPair()
+	if err != nil {
+		t.Fatalf("second generate: %v", err)
+	}
+	if a.Private == b.Private {
+		t.Fatal("two crypto/rand-driven keypairs should not collide")
+	}
+	if a.Public == b.Public {
+		t.Fatal("derived publics should not match for random privates")
+	}
+}
+
+func TestX25519SharedSecret_RoundTrip(t *testing.T) {
+	alice, err := GenerateX25519KeyPair()
+	if err != nil {
+		t.Fatalf("alice: %v", err)
+	}
+	bob, err := GenerateX25519KeyPair()
+	if err != nil {
+		t.Fatalf("bob: %v", err)
+	}
+	ssAlice, err := X25519SharedSecret(alice.Private[:], bob.Public[:])
+	if err != nil {
+		t.Fatalf("alice shared: %v", err)
+	}
+	ssBob, err := X25519SharedSecret(bob.Private[:], alice.Public[:])
+	if err != nil {
+		t.Fatalf("bob shared: %v", err)
+	}
+	if !bytes.Equal(ssAlice, ssBob) {
+		t.Fatal("ECDH outputs differ between Alice and Bob — DH symmetry broken")
+	}
+	if len(ssAlice) != SharedSecretSize {
+		t.Fatalf("shared secret length = %d, want %d", len(ssAlice), SharedSecretSize)
+	}
+}
+
+func TestX25519SharedSecret_BadInputs(t *testing.T) {
+	good, err := GenerateX25519KeyPair()
+	if err != nil {
+		t.Fatalf("setup: %v", err)
+	}
+	cases := []struct {
+		name string
+		priv []byte
+		peer []byte
+	}{
+		{"short private", make([]byte, X25519KeySize-1), good.Public[:]},
+		{"long peer", good.Private[:], make([]byte, X25519KeySize+1)},
+		{"empty private", []byte{}, good.Public[:]},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := X25519SharedSecret(tc.priv, tc.peer)
+			if !errors.Is(err, ErrInvalidX25519Key) {
+				t.Fatalf("want ErrInvalidX25519Key, got %v", err)
+			}
+		})
+	}
+}
+
+func TestX25519SharedSecret_LowOrderPoint(t *testing.T) {
+	// The all-zero public key is the canonical low-order point: any
+	// private key DH'd with it yields all-zero output, and curve25519.X25519
+	// returns an error rather than the zero output.
+	priv, err := GenerateX25519KeyPair()
+	if err != nil {
+		t.Fatalf("setup: %v", err)
+	}
+	zero := make([]byte, X25519KeySize)
+	_, err = X25519SharedSecret(priv.Private[:], zero)
+	if !errors.Is(err, ErrInvalidX25519Key) {
+		t.Fatalf("want ErrInvalidX25519Key for zero peer, got %v", err)
+	}
+}
+
+func TestGenerateX25519KeyPair_DeterministicReader(t *testing.T) {
+	// Reproducibility check: same seed → same key.
+	seed := bytes.Repeat([]byte{0x42}, X25519KeySize)
+	a, err := generateX25519KeyPairFrom(bytes.NewReader(seed))
+	if err != nil {
+		t.Fatalf("first: %v", err)
+	}
+	b, err := generateX25519KeyPairFrom(bytes.NewReader(seed))
+	if err != nil {
+		t.Fatalf("second: %v", err)
+	}
+	if a.Private != b.Private || a.Public != b.Public {
+		t.Fatal("deterministic seed produced different keypairs")
+	}
+}

--- a/internal/crypto/xchacha20poly1305.go
+++ b/internal/crypto/xchacha20poly1305.go
@@ -1,0 +1,284 @@
+package crypto
+
+import (
+	"crypto/cipher"
+	"crypto/rand"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"io"
+
+	"golang.org/x/crypto/chacha20poly1305"
+)
+
+// newAEADKey wraps chacha20poly1305.NewX into our error vocabulary so other
+// files (session.go, pairing.go) can reuse it without re-importing the
+// chacha20poly1305 package.
+func newAEADKey(key []byte) (cipher.AEAD, error) {
+	if len(key) != AEADKeySize {
+		return nil, fmt.Errorf("%w: AEAD key must be %d bytes", ErrAEAD, AEADKeySize)
+	}
+	aead, err := chacha20poly1305.NewX(key)
+	if err != nil {
+		return nil, fmt.Errorf("%w: new XChaCha20-Poly1305: %v", ErrAEAD, err)
+	}
+	return aead, nil
+}
+
+// AEAD constants — XChaCha20-Poly1305 per RFC 8439 / draft-irtf-cfrg-xchacha.
+const (
+	AEADKeySize   = chacha20poly1305.KeySize   // 32
+	AEADNonceSize = chacha20poly1305.NonceSizeX // 24
+	AEADTagSize   = chacha20poly1305.Overhead   // 16
+)
+
+// ErrAEAD is returned when AEAD seal/open fails or inputs are malformed.
+// Keep distinct from ErrInvalidX25519Key so callers can branch on cause.
+var ErrAEAD = errors.New("crypto: AEAD failure")
+
+// Envelope is the wire format produced by SealEnvelope. It is the unit of
+// encrypted data the daemon hands to the server (which only sees the
+// metadata fields and the opaque Ciphertext).
+//
+// # Wire serialization layout (Cross-Rust interop contract)
+//
+// Big-endian throughout. The exact byte sequence Marshal() produces is:
+//
+//	+----+----+--------+----+--------+----+--------+----+----+----+----+--------+----+--------+
+//	| K  | S_len      | sessionId | F_len | fromDeviceId | T_len | toDeviceId  | keyVersion | nonce(24) | ct_len(4) | ciphertext |
+//	+----+------------+-----------+-------+--------------+-------+-------------+------------+-----------+-----------+------------+
+//	  1B   2B (BE)     S_len B     2B BE   F_len B        2B BE   T_len B       4B BE         24B         4B BE       ct_len B
+//
+// Where K = wire format version (currently 1).
+//
+// The same byte layout is what the Tauri Mobile (Rust) side must emit/parse
+// to interoperate. Recommended Rust impl: bincode is NOT compatible — write
+// a hand-rolled encoder using `byteorder::BigEndian` + length-prefixed
+// strings. The 4-byte ciphertext length covers ciphertext+tag (Poly1305
+// tag is appended by AEAD.seal as the last 16 bytes — Rust's
+// chacha20poly1305 crate does the same).
+//
+// Ciphertext = XChaCha20-Poly1305.Seal(session_key, Nonce, plaintext, AD)
+// where AD is the deterministic concatenation BuildAD produces. Both sides
+// MUST construct AD identically.
+type Envelope struct {
+	WireVersion  uint8 // currently 1
+	SessionID    string
+	FromDeviceID string
+	ToDeviceID   string
+	KeyVersion   uint32 // spec §11.C v0.1 = 1; bump on algo upgrade
+	Nonce        [AEADNonceSize]byte
+	Ciphertext   []byte // includes 16B Poly1305 tag suffix
+}
+
+// EnvelopeWireV1 is the current wire format version. Bumping this requires
+// dual-write/read fallback during the cutover window.
+const EnvelopeWireV1 uint8 = 1
+
+// BuildAD constructs the deterministic Additional Data for an envelope.
+// Per spec §11.C:
+//
+//	AD = sessionId || fromDeviceId || toDeviceId || keyVersion(BE)
+//
+// We use length-prefixed concatenation (each 2-byte BE length + bytes,
+// keyVersion as raw 4B BE) to make the construction unambiguous — naive
+// concatenation would let an attacker shift bytes between the IDs to
+// produce equivalent AD for different routing.
+//
+// Rust mirror: same 2B BE length prefixes, same UTF-8 string bytes,
+// same trailing 4B BE keyVersion.
+func BuildAD(sessionID, fromDeviceID, toDeviceID string, keyVersion uint32) []byte {
+	out := make([]byte, 0, 2+len(sessionID)+2+len(fromDeviceID)+2+len(toDeviceID)+4)
+	out = appendLPString(out, sessionID)
+	out = appendLPString(out, fromDeviceID)
+	out = appendLPString(out, toDeviceID)
+	out = binary.BigEndian.AppendUint32(out, keyVersion)
+	return out
+}
+
+// SealEnvelope encrypts plaintext under sessionKey, producing an Envelope
+// with a freshly-generated 24-byte random nonce.
+//
+// sessionKey MUST be 32 bytes (typically a session_key from session.go).
+// keyVersion is currently always 1 — see spec §11.C.
+//
+// On success the returned Envelope can be wire-marshaled by Marshal and
+// fed into the queue layer. Server peers MUST NOT attempt to open it.
+func SealEnvelope(sessionKey []byte, sessionID, fromDeviceID, toDeviceID string, keyVersion uint32, plaintext []byte) (*Envelope, error) {
+	if len(sessionKey) != AEADKeySize {
+		return nil, fmt.Errorf("%w: session key must be %d bytes", ErrAEAD, AEADKeySize)
+	}
+	aead, err := chacha20poly1305.NewX(sessionKey)
+	if err != nil {
+		return nil, fmt.Errorf("%w: new XChaCha20-Poly1305: %v", ErrAEAD, err)
+	}
+	env := &Envelope{
+		WireVersion:  EnvelopeWireV1,
+		SessionID:    sessionID,
+		FromDeviceID: fromDeviceID,
+		ToDeviceID:   toDeviceID,
+		KeyVersion:   keyVersion,
+	}
+	if _, err := io.ReadFull(rand.Reader, env.Nonce[:]); err != nil {
+		return nil, fmt.Errorf("%w: read nonce: %v", ErrAEAD, err)
+	}
+	ad := BuildAD(sessionID, fromDeviceID, toDeviceID, keyVersion)
+	env.Ciphertext = aead.Seal(nil, env.Nonce[:], plaintext, ad)
+	return env, nil
+}
+
+// OpenEnvelope verifies + decrypts an Envelope produced by SealEnvelope (or
+// the Rust equivalent). Returns the plaintext bytes on success. Auth
+// failure surfaces as a wrapped ErrAEAD — caller MUST treat this as a hard
+// failure (do NOT log the ciphertext, do NOT retry with a different key).
+func OpenEnvelope(sessionKey []byte, env *Envelope) ([]byte, error) {
+	if env == nil {
+		return nil, fmt.Errorf("%w: nil envelope", ErrAEAD)
+	}
+	if len(sessionKey) != AEADKeySize {
+		return nil, fmt.Errorf("%w: session key must be %d bytes", ErrAEAD, AEADKeySize)
+	}
+	if len(env.Ciphertext) < AEADTagSize {
+		return nil, fmt.Errorf("%w: ciphertext too short", ErrAEAD)
+	}
+	aead, err := chacha20poly1305.NewX(sessionKey)
+	if err != nil {
+		return nil, fmt.Errorf("%w: new XChaCha20-Poly1305: %v", ErrAEAD, err)
+	}
+	ad := BuildAD(env.SessionID, env.FromDeviceID, env.ToDeviceID, env.KeyVersion)
+	pt, err := aead.Open(nil, env.Nonce[:], env.Ciphertext, ad)
+	if err != nil {
+		return nil, fmt.Errorf("%w: open: %v", ErrAEAD, err)
+	}
+	return pt, nil
+}
+
+// Marshal serializes an Envelope to the wire bytes documented above.
+// Cross-Rust interop: the inverse operation on the Rust side reads the
+// fields in this exact order using big-endian length prefixes.
+func (e *Envelope) Marshal() ([]byte, error) {
+	if e == nil {
+		return nil, fmt.Errorf("%w: nil envelope", ErrAEAD)
+	}
+	if len(e.SessionID) > 0xFFFF || len(e.FromDeviceID) > 0xFFFF || len(e.ToDeviceID) > 0xFFFF {
+		return nil, fmt.Errorf("%w: identifier length exceeds 65535", ErrAEAD)
+	}
+	if len(e.Ciphertext) > 0xFFFFFFFF {
+		return nil, fmt.Errorf("%w: ciphertext length exceeds uint32 max", ErrAEAD)
+	}
+	out := make([]byte, 0, 1+2+len(e.SessionID)+2+len(e.FromDeviceID)+2+len(e.ToDeviceID)+4+AEADNonceSize+4+len(e.Ciphertext))
+	out = append(out, e.WireVersion)
+	out = appendLPString(out, e.SessionID)
+	out = appendLPString(out, e.FromDeviceID)
+	out = appendLPString(out, e.ToDeviceID)
+	out = binary.BigEndian.AppendUint32(out, e.KeyVersion)
+	out = append(out, e.Nonce[:]...)
+	out = binary.BigEndian.AppendUint32(out, uint32(len(e.Ciphertext)))
+	out = append(out, e.Ciphertext...)
+	return out, nil
+}
+
+// UnmarshalEnvelope is the inverse of Envelope.Marshal. Rejects unknown
+// wire versions early so a future format bump doesn't silently corrupt.
+func UnmarshalEnvelope(buf []byte) (*Envelope, error) {
+	r := newByteReader(buf)
+	ver, err := r.readByte()
+	if err != nil {
+		return nil, fmt.Errorf("%w: read wire version: %v", ErrAEAD, err)
+	}
+	if ver != EnvelopeWireV1 {
+		return nil, fmt.Errorf("%w: unsupported wire version %d", ErrAEAD, ver)
+	}
+	env := &Envelope{WireVersion: ver}
+	if env.SessionID, err = r.readLPString(); err != nil {
+		return nil, fmt.Errorf("%w: sessionId: %v", ErrAEAD, err)
+	}
+	if env.FromDeviceID, err = r.readLPString(); err != nil {
+		return nil, fmt.Errorf("%w: fromDeviceId: %v", ErrAEAD, err)
+	}
+	if env.ToDeviceID, err = r.readLPString(); err != nil {
+		return nil, fmt.Errorf("%w: toDeviceId: %v", ErrAEAD, err)
+	}
+	if env.KeyVersion, err = r.readUint32(); err != nil {
+		return nil, fmt.Errorf("%w: keyVersion: %v", ErrAEAD, err)
+	}
+	nonceBytes, err := r.readN(AEADNonceSize)
+	if err != nil {
+		return nil, fmt.Errorf("%w: nonce: %v", ErrAEAD, err)
+	}
+	copy(env.Nonce[:], nonceBytes)
+	ctLen, err := r.readUint32()
+	if err != nil {
+		return nil, fmt.Errorf("%w: ciphertext length: %v", ErrAEAD, err)
+	}
+	if env.Ciphertext, err = r.readN(int(ctLen)); err != nil {
+		return nil, fmt.Errorf("%w: ciphertext body: %v", ErrAEAD, err)
+	}
+	if r.remaining() != 0 {
+		return nil, fmt.Errorf("%w: trailing bytes after ciphertext", ErrAEAD)
+	}
+	return env, nil
+}
+
+// --- internal helpers ---
+
+func appendLPString(out []byte, s string) []byte {
+	out = binary.BigEndian.AppendUint16(out, uint16(len(s)))
+	out = append(out, s...)
+	return out
+}
+
+type byteReader struct {
+	buf []byte
+	pos int
+}
+
+func newByteReader(b []byte) *byteReader { return &byteReader{buf: b} }
+
+func (r *byteReader) remaining() int { return len(r.buf) - r.pos }
+
+func (r *byteReader) readByte() (byte, error) {
+	if r.remaining() < 1 {
+		return 0, io.ErrUnexpectedEOF
+	}
+	b := r.buf[r.pos]
+	r.pos++
+	return b, nil
+}
+
+func (r *byteReader) readN(n int) ([]byte, error) {
+	if n < 0 || r.remaining() < n {
+		return nil, io.ErrUnexpectedEOF
+	}
+	out := r.buf[r.pos : r.pos+n]
+	r.pos += n
+	return out, nil
+}
+
+func (r *byteReader) readUint16() (uint16, error) {
+	b, err := r.readN(2)
+	if err != nil {
+		return 0, err
+	}
+	return binary.BigEndian.Uint16(b), nil
+}
+
+func (r *byteReader) readUint32() (uint32, error) {
+	b, err := r.readN(4)
+	if err != nil {
+		return 0, err
+	}
+	return binary.BigEndian.Uint32(b), nil
+}
+
+func (r *byteReader) readLPString() (string, error) {
+	n, err := r.readUint16()
+	if err != nil {
+		return "", err
+	}
+	body, err := r.readN(int(n))
+	if err != nil {
+		return "", err
+	}
+	return string(body), nil
+}

--- a/internal/crypto/xchacha20poly1305_test.go
+++ b/internal/crypto/xchacha20poly1305_test.go
@@ -1,0 +1,164 @@
+package crypto
+
+import (
+	"bytes"
+	"crypto/rand"
+	"errors"
+	"testing"
+)
+
+func freshKey(t *testing.T) []byte {
+	t.Helper()
+	k := make([]byte, AEADKeySize)
+	if _, err := rand.Read(k); err != nil {
+		t.Fatalf("rand: %v", err)
+	}
+	return k
+}
+
+func TestSealOpen_RoundTrip(t *testing.T) {
+	key := freshKey(t)
+	plaintext := []byte("hello tether — server can't read this")
+	env, err := SealEnvelope(key, "sess-1", "cli-A", "mob-B", 1, plaintext)
+	if err != nil {
+		t.Fatalf("seal: %v", err)
+	}
+	if env.WireVersion != EnvelopeWireV1 {
+		t.Fatalf("wire version = %d", env.WireVersion)
+	}
+	if len(env.Ciphertext) < AEADTagSize {
+		t.Fatal("ciphertext shorter than AEAD tag")
+	}
+	got, err := OpenEnvelope(key, env)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	if !bytes.Equal(got, plaintext) {
+		t.Fatalf("plaintext mismatch: %q != %q", got, plaintext)
+	}
+}
+
+func TestOpen_WrongKeyFails(t *testing.T) {
+	key := freshKey(t)
+	otherKey := freshKey(t)
+	env, err := SealEnvelope(key, "s", "f", "t", 1, []byte("payload"))
+	if err != nil {
+		t.Fatalf("seal: %v", err)
+	}
+	if _, err := OpenEnvelope(otherKey, env); !errors.Is(err, ErrAEAD) {
+		t.Fatalf("want ErrAEAD on wrong key, got %v", err)
+	}
+}
+
+func TestOpen_TamperedCiphertextFails(t *testing.T) {
+	key := freshKey(t)
+	env, err := SealEnvelope(key, "s", "f", "t", 1, []byte("p"))
+	if err != nil {
+		t.Fatalf("seal: %v", err)
+	}
+	env.Ciphertext[0] ^= 0xFF
+	if _, err := OpenEnvelope(key, env); !errors.Is(err, ErrAEAD) {
+		t.Fatalf("want ErrAEAD on tamper, got %v", err)
+	}
+}
+
+func TestOpen_TamperedADFails(t *testing.T) {
+	key := freshKey(t)
+	env, err := SealEnvelope(key, "session-A", "from", "to", 1, []byte("p"))
+	if err != nil {
+		t.Fatalf("seal: %v", err)
+	}
+	env.SessionID = "session-B" // attacker swaps routing metadata
+	if _, err := OpenEnvelope(key, env); !errors.Is(err, ErrAEAD) {
+		t.Fatalf("want ErrAEAD on AD tamper, got %v", err)
+	}
+}
+
+func TestOpen_NonceUniqueness(t *testing.T) {
+	key := freshKey(t)
+	envA, _ := SealEnvelope(key, "s", "f", "t", 1, []byte("x"))
+	envB, _ := SealEnvelope(key, "s", "f", "t", 1, []byte("x"))
+	if envA.Nonce == envB.Nonce {
+		// 24-byte random nonce collision is statistically impossible. If
+		// this fires we have an RNG bug.
+		t.Fatal("two seals with same plaintext+key produced identical nonce")
+	}
+	if bytes.Equal(envA.Ciphertext, envB.Ciphertext) {
+		t.Fatal("ciphertext should differ when nonces differ")
+	}
+}
+
+func TestSeal_BadKeySize(t *testing.T) {
+	if _, err := SealEnvelope([]byte{0x01, 0x02}, "s", "f", "t", 1, []byte("p")); !errors.Is(err, ErrAEAD) {
+		t.Fatalf("want ErrAEAD on short key, got %v", err)
+	}
+}
+
+func TestEnvelope_MarshalRoundTrip(t *testing.T) {
+	key := freshKey(t)
+	env, err := SealEnvelope(key, "session-id-42", "device-from-X", "device-to-Y", 7, []byte("hello"))
+	if err != nil {
+		t.Fatalf("seal: %v", err)
+	}
+	wire, err := env.Marshal()
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	back, err := UnmarshalEnvelope(wire)
+	if err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if back.SessionID != env.SessionID || back.FromDeviceID != env.FromDeviceID ||
+		back.ToDeviceID != env.ToDeviceID || back.KeyVersion != env.KeyVersion ||
+		back.Nonce != env.Nonce || !bytes.Equal(back.Ciphertext, env.Ciphertext) {
+		t.Fatal("round-tripped envelope differs from original")
+	}
+	pt, err := OpenEnvelope(key, back)
+	if err != nil {
+		t.Fatalf("open after wire round-trip: %v", err)
+	}
+	if !bytes.Equal(pt, []byte("hello")) {
+		t.Fatalf("plaintext: %q", pt)
+	}
+}
+
+func TestUnmarshal_BadVersion(t *testing.T) {
+	// Hand-construct a wire frame with a bad version byte.
+	bad := []byte{0xFF, 0x00, 0x00}
+	if _, err := UnmarshalEnvelope(bad); !errors.Is(err, ErrAEAD) {
+		t.Fatalf("want ErrAEAD on bad wire version, got %v", err)
+	}
+}
+
+func TestUnmarshal_TruncatedTrailing(t *testing.T) {
+	key := freshKey(t)
+	env, _ := SealEnvelope(key, "s", "f", "t", 1, []byte("payload"))
+	wire, _ := env.Marshal()
+	// Drop trailing byte → ciphertext too short.
+	if _, err := UnmarshalEnvelope(wire[:len(wire)-1]); !errors.Is(err, ErrAEAD) {
+		t.Fatalf("want ErrAEAD on truncated, got %v", err)
+	}
+	// Append trailing junk → should also fail (trailing-bytes check).
+	junked := append(append([]byte{}, wire...), 0xAA, 0xBB)
+	if _, err := UnmarshalEnvelope(junked); !errors.Is(err, ErrAEAD) {
+		t.Fatalf("want ErrAEAD on trailing junk, got %v", err)
+	}
+}
+
+func TestBuildAD_Deterministic(t *testing.T) {
+	a := BuildAD("sess", "from", "to", 1)
+	b := BuildAD("sess", "from", "to", 1)
+	if !bytes.Equal(a, b) {
+		t.Fatal("BuildAD must be deterministic")
+	}
+	c := BuildAD("sess", "from", "to", 2)
+	if bytes.Equal(a, c) {
+		t.Fatal("different keyVersion must change AD")
+	}
+	// Length-prefix shielding: "ab"+"c" must not collide with "a"+"bc".
+	d := BuildAD("ab", "c", "to", 1)
+	e := BuildAD("a", "bc", "to", 1)
+	if bytes.Equal(d, e) {
+		t.Fatal("length-prefix shielding broken: AD collision across boundary shifts")
+	}
+}


### PR DESCRIPTION
## Summary

- Implements Epic #5 E2E C1 crypto layer in `internal/crypto/`: X25519 ECDH, XChaCha20-Poly1305 envelope AEAD with length-prefixed AD, HKDF-SHA256 (frozen info strings), session_key lifecycle (create/rotate/wipe/persist), QR fingerprint, 6-digit SAS, ReplayGuard (LRU + 5-min skew window).
- Bumps Go toolchain `1.24.6 → 1.25.0` (required by `golang.org/x/crypto v0.50.0`). Aligned across all wave-1 Go PRs.
- Freezes byte-level Go↔Rust interop at `tether-doc/wiki/specs/2026-05-06-crypto-wire-format.md` — required reading before any Tauri Mobile crypto work.

LOC: ~686 production + ~860 tests. Covers spec §11.C (D-12 C1) + §11.M + §11.J.

## Test plan

- [x] `go test ./internal/crypto/...` — 46 passing
- [x] `go test -race ./internal/crypto/...` — clean
- [x] `go vet ./...` — clean
- [x] `go build ./...` — clean
- [x] Integration round-trip: pair → derive session_key → seal → marshal → unmarshal → guard → open
- [x] Server-compromise negative test (server-side metadata cannot decrypt)

## Open follow-ups (intentionally NOT in this PR)

1. **Dev decrypt backdoor** (`TETHER_DEV_DECRYPT=1`, build-tag `tether_dev`, ~30 LOC) — belongs in daemon binary entrypoint (Epic #3), not crypto core. Tracked in `.workspace/memory/local/v1-epics.md`.
2. **CI grep guard** for `tether_dev` symbol leak — release-pipeline ticket.
3. **session_key control envelope routing** (wrap_key-encrypted at session start) — primitive ready (`SealEnvelope`); routing is upper-layer.
4. **`internal/pairing/`** — QR encode/parse + auth-token + server-mediated SAS fallback build atop these primitives.
5. **Hardware-backed keys** (TPM, Secure Enclave) — v0.2.