### PR TITLE
Epic #8 Skill system — manifest + pool + cc adapter + CLI

### DIFF
--- a/cmd/tether/blob.go
+++ b/cmd/tether/blob.go
@@ -1,0 +1,19 @@
+package main
+
+import (
+	"fmt"
+	"os"
+)
+
+// blobRegisterCmd is the v0.1 forward-compat stub for D-18 #3
+// (`/blob/<sha256>` proxy). Spec §11.AA: v0.1 reserves the path/CLI shape
+// so future skill code can target it stably; v0.2 lands the real
+// blob-proxy + DAG skill that uses it.
+func blobRegisterCmd(args []string) int {
+	if len(args) != 1 {
+		fmt.Fprintln(os.Stderr, "usage: tether tether-blob-register <path>")
+		return 2
+	}
+	fmt.Fprintln(os.Stderr, "tether-blob-register: not implemented in v0.1 (reserved for v0.2 blob proxy)")
+	return 1
+}

--- a/cmd/tether/main.go
+++ b/cmd/tether/main.go
@@ -1,0 +1,40 @@
+// Command tether is the v0.1 user-facing CLI. Today it only exposes the
+// skill subsystem (Epic #8) and a `tether-blob-register` forward-compat
+// stub (D-18 #3); daemon/spawn surfaces land in later epics.
+package main
+
+import (
+	"fmt"
+	"os"
+)
+
+func main() {
+	if len(os.Args) < 2 {
+		usage(os.Stderr)
+		os.Exit(2)
+	}
+	switch os.Args[1] {
+	case "skill":
+		os.Exit(skillCmd(os.Args[2:]))
+	case "tether-blob-register":
+		os.Exit(blobRegisterCmd(os.Args[2:]))
+	case "-h", "--help", "help":
+		usage(os.Stdout)
+		os.Exit(0)
+	default:
+		fmt.Fprintf(os.Stderr, "tether: unknown subcommand %q\n\n", os.Args[1])
+		usage(os.Stderr)
+		os.Exit(2)
+	}
+}
+
+func usage(w *os.File) {
+	fmt.Fprintln(w, "usage: tether <command> [args...]")
+	fmt.Fprintln(w, "")
+	fmt.Fprintln(w, "commands:")
+	fmt.Fprintln(w, "  skill install <name|git-url>   install a skill into the global pool")
+	fmt.Fprintln(w, "  skill list                     list installed skills")
+	fmt.Fprintln(w, "  skill remove <name>            uninstall a skill")
+	fmt.Fprintln(w, "  skill info <name>              print manifest details for an installed skill")
+	fmt.Fprintln(w, "  tether-blob-register <path>    (v0.1 stub) reserve blob URL for a workspace path")
+}

--- a/cmd/tether/skill.go
+++ b/cmd/tether/skill.go
@@ -1,0 +1,191 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/piaobeizu/tether/internal/skill"
+)
+
+// skillCmd dispatches `tether skill <verb> ...`.
+func skillCmd(args []string) int {
+	if len(args) < 1 {
+		fmt.Fprintln(os.Stderr, "tether skill: missing verb (install|list|remove|info)")
+		return 2
+	}
+	switch args[0] {
+	case "install":
+		return skillInstall(args[1:])
+	case "list":
+		return skillList(args[1:])
+	case "remove", "uninstall":
+		return skillRemove(args[1:])
+	case "info", "show":
+		return skillInfo(args[1:])
+	default:
+		fmt.Fprintf(os.Stderr, "tether skill: unknown verb %q\n", args[0])
+		return 2
+	}
+}
+
+func skillInstall(args []string) int {
+	fs := flag.NewFlagSet("tether skill install", flag.ContinueOnError)
+	force := fs.Bool("force", false, "overwrite existing installation")
+	listPath := fs.String("blessed-list", "", "path to skills.toml (default: ./skills.toml if present)")
+	if err := fs.Parse(args); err != nil {
+		return 2
+	}
+	if fs.NArg() != 1 {
+		fmt.Fprintln(os.Stderr, "usage: tether skill install <name|git-url> [--force] [--blessed-list path]")
+		return 2
+	}
+	arg := fs.Arg(0)
+
+	pool, err := skill.DefaultPool()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		return 1
+	}
+	list, err := loadBlessedListWithFallback(*listPath)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		return 1
+	}
+	url, name, err := skill.ResolveSource(arg, list)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		return 1
+	}
+	ref := ""
+	if list != nil {
+		if entry, ok := list.Skills[name]; ok {
+			ref = entry.Ref
+		}
+	}
+	ctx := context.Background()
+	m, err := pool.Install(ctx, url, name, skill.InstallOptions{Force: *force, Ref: ref})
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		return 1
+	}
+	fmt.Printf("installed: %s\n", filepath.Join(pool.Root, name))
+	if m != nil {
+		fmt.Printf("  name:    %s\n", m.Skill.Name)
+		fmt.Printf("  version: %s\n", m.Skill.Version)
+		if m.Skill.Description != "" {
+			fmt.Printf("  desc:    %s\n", m.Skill.Description)
+		}
+	} else {
+		fmt.Println("  (no tether.toml — installed as plain cc plugin)")
+	}
+	return 0
+}
+
+func skillList(args []string) int {
+	if len(args) > 0 {
+		fmt.Fprintln(os.Stderr, "usage: tether skill list")
+		return 2
+	}
+	pool, err := skill.DefaultPool()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		return 1
+	}
+	names, err := pool.List()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		return 1
+	}
+	if len(names) == 0 {
+		fmt.Printf("(no skills installed in %s)\n", pool.Root)
+		return 0
+	}
+	for _, n := range names {
+		m, _ := pool.Info(n)
+		if m != nil {
+			fmt.Printf("%-24s %s\n", n, m.Skill.Version)
+		} else {
+			fmt.Printf("%-24s (no tether.toml)\n", n)
+		}
+	}
+	return 0
+}
+
+func skillRemove(args []string) int {
+	if len(args) != 1 {
+		fmt.Fprintln(os.Stderr, "usage: tether skill remove <name>")
+		return 2
+	}
+	pool, err := skill.DefaultPool()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		return 1
+	}
+	if !pool.Has(args[0]) {
+		fmt.Fprintf(os.Stderr, "tether skill: %q is not installed\n", args[0])
+		return 1
+	}
+	if err := pool.Remove(args[0]); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		return 1
+	}
+	fmt.Printf("removed: %s\n", args[0])
+	return 0
+}
+
+func skillInfo(args []string) int {
+	if len(args) != 1 {
+		fmt.Fprintln(os.Stderr, "usage: tether skill info <name>")
+		return 2
+	}
+	pool, err := skill.DefaultPool()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		return 1
+	}
+	m, err := pool.Info(args[0])
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		return 1
+	}
+	fmt.Printf("name:    %s\n", args[0])
+	fmt.Printf("path:    %s\n", pool.SkillDir(args[0]))
+	if m == nil {
+		fmt.Println("manifest: (no tether.toml — plain cc plugin)")
+		return 0
+	}
+	fmt.Printf("version: %s\n", m.Skill.Version)
+	if m.Skill.Description != "" {
+		fmt.Printf("desc:    %s\n", m.Skill.Description)
+	}
+	if m.Skill.Agents.Primary != "" {
+		fmt.Printf("agent:   %s (tested: %v)\n", m.Skill.Agents.Primary, m.Skill.Agents.Tested)
+	}
+	if len(m.Tether.FencedBlocks.Emits) > 0 {
+		fmt.Printf("emits:   %v\n", m.Tether.FencedBlocks.Emits)
+	}
+	if m.Tether.State.WorkspaceDir != "" {
+		fmt.Printf("state:   %s (lock=%t, gitignore=%t)\n",
+			m.Tether.State.WorkspaceDir,
+			m.Tether.State.FileLock,
+			m.Tether.State.GitignoreDefault)
+	}
+	return 0
+}
+
+// loadBlessedListWithFallback resolves the blessed list source in priority order:
+//  1. --blessed-list <path> when explicitly passed
+//  2. ./skills.toml next to cwd (developer override)
+//  3. embedded copy compiled into the binary from internal/skill/skills.toml
+func loadBlessedListWithFallback(explicit string) (*skill.BlessedList, error) {
+	if explicit != "" {
+		return skill.LoadBlessedList(explicit)
+	}
+	if _, err := os.Stat(skill.BlessedListPath); err == nil {
+		return skill.LoadBlessedList(skill.BlessedListPath)
+	}
+	return skill.EmbeddedBlessedList()
+}

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/piaobeizu/tether
 go 1.25.0
 
 require (
+	github.com/BurntSushi/toml v1.6.0
 	github.com/fsnotify/fsnotify v1.9.0
 	golang.org/x/crypto v0.50.0
 )

--- a/go.sum
+++ b/go.sum
@@ -1,11 +1,8 @@
-<<<<<<< HEAD
+github.com/BurntSushi/toml v1.6.0 h1:dRaEfpa2VI55EwlIW72hMRHdWouJeRF7TPYhI+AUQjk=
+github.com/BurntSushi/toml v1.6.0/go.mod h1:ukJfTF/6rtPPRCnwkur4qwRxa8vTRFBF0uk2lLoLwho=
 github.com/fsnotify/fsnotify v1.9.0 h1:2Ml+OJNzbYCTzsxtv8vKSFD9PbJjmhYF14k/jKC7S9k=
 github.com/fsnotify/fsnotify v1.9.0/go.mod h1:8jBTzvmWwFyi3Pb8djgCCO5IBqzKJ/Jwo8TRcHyHii0=
 golang.org/x/crypto v0.50.0 h1:zO47/JPrL6vsNkINmLoo/PH1gcxpls50DNogFvB5ZGI=
 golang.org/x/crypto v0.50.0/go.mod h1:3muZ7vA7PBCE6xgPX7nkzzjiUq87kRItoJQM1Yo8S+Q=
 golang.org/x/sys v0.43.0 h1:Rlag2XtaFTxp19wS8MXlJwTvoh8ArU6ezoyFsMyCTNI=
 golang.org/x/sys v0.43.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
-=======
-github.com/BurntSushi/toml v1.6.0 h1:dRaEfpa2VI55EwlIW72hMRHdWouJeRF7TPYhI+AUQjk=
-github.com/BurntSushi/toml v1.6.0/go.mod h1:ukJfTF/6rtPPRCnwkur4qwRxa8vTRFBF0uk2lLoLwho=
->>>>>>> 1a6c1c6 (feat(skill): Epic #8 — manifest + global pool + cc adapter + CLI)

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,11 @@
+<<<<<<< HEAD
 github.com/fsnotify/fsnotify v1.9.0 h1:2Ml+OJNzbYCTzsxtv8vKSFD9PbJjmhYF14k/jKC7S9k=
 github.com/fsnotify/fsnotify v1.9.0/go.mod h1:8jBTzvmWwFyi3Pb8djgCCO5IBqzKJ/Jwo8TRcHyHii0=
 golang.org/x/crypto v0.50.0 h1:zO47/JPrL6vsNkINmLoo/PH1gcxpls50DNogFvB5ZGI=
 golang.org/x/crypto v0.50.0/go.mod h1:3muZ7vA7PBCE6xgPX7nkzzjiUq87kRItoJQM1Yo8S+Q=
 golang.org/x/sys v0.43.0 h1:Rlag2XtaFTxp19wS8MXlJwTvoh8ArU6ezoyFsMyCTNI=
 golang.org/x/sys v0.43.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
+=======
+github.com/BurntSushi/toml v1.6.0 h1:dRaEfpa2VI55EwlIW72hMRHdWouJeRF7TPYhI+AUQjk=
+github.com/BurntSushi/toml v1.6.0/go.mod h1:ukJfTF/6rtPPRCnwkur4qwRxa8vTRFBF0uk2lLoLwho=
+>>>>>>> 1a6c1c6 (feat(skill): Epic #8 — manifest + global pool + cc adapter + CLI)

--- a/internal/skill/adapter/aider.go
+++ b/internal/skill/adapter/aider.go
@@ -1,0 +1,15 @@
+package adapter
+
+// Aider is a v0.1 stub. Spec §11.Z.4: v0.2 lossy adapter — concat
+// SKILL.md content into CONVENTIONS.md, drop hooks with a warning.
+type Aider struct{}
+
+// Materialise panics — aider adapter is not implemented in v0.1.
+func (Aider) Materialise(workspaceDir, skillName, skillSourceDir string) error {
+	panic("adapter/aider: not impl in v0.1")
+}
+
+// Unmaterialise panics — aider adapter is not implemented in v0.1.
+func (Aider) Unmaterialise(workspaceDir, skillName string) error {
+	panic("adapter/aider: not impl in v0.1")
+}

--- a/internal/skill/adapter/cc.go
+++ b/internal/skill/adapter/cc.go
@@ -1,0 +1,99 @@
+package adapter
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// CCPluginsSubdir is the workspace-relative directory that cc's plugin
+// loader scans (spec §11.Z.6 step 2). Each enabled skill becomes a
+// symlink at <workspace>/.claude/plugins/<skill> pointing at the global
+// pool entry.
+const CCPluginsSubdir = ".claude/plugins"
+
+// CC is the v0.1 cc adapter. It owns nothing but the symlink contract:
+//
+//	<global-pool>/<skill>  →  <workspace>/.claude/plugins/<skill>
+//
+// Spec §11.Z.4: pure symlink, no copy/rewrite, no plugin.json generation
+// (skill ships its own .claude/plugin.json).
+type CC struct{}
+
+// Materialise links one skill into the workspace. If the link target
+// already exists and points at the same source, it is left alone
+// (idempotent re-spawn). Any non-symlink at the destination path is a
+// hard error — we refuse to clobber a real directory the user might
+// have committed by hand.
+func (CC) Materialise(workspaceDir, skillName, skillSourceDir string) error {
+	if workspaceDir == "" {
+		return errors.New("adapter/cc: empty workspaceDir")
+	}
+	if skillName == "" {
+		return errors.New("adapter/cc: empty skillName")
+	}
+	if skillSourceDir == "" {
+		return errors.New("adapter/cc: empty skillSourceDir")
+	}
+	if st, err := os.Stat(skillSourceDir); err != nil {
+		return fmt.Errorf("adapter/cc: skill source %s: %w", skillSourceDir, err)
+	} else if !st.IsDir() {
+		return fmt.Errorf("adapter/cc: skill source %s is not a directory", skillSourceDir)
+	}
+
+	pluginsDir := filepath.Join(workspaceDir, CCPluginsSubdir)
+	if err := os.MkdirAll(pluginsDir, 0o755); err != nil {
+		return fmt.Errorf("adapter/cc: ensure %s: %w", pluginsDir, err)
+	}
+	link := filepath.Join(pluginsDir, skillName)
+
+	// Resolve absolute source so the symlink is portable across cwd
+	// changes (cc spawns with workspace cwd; absolute is safest).
+	absSource, err := filepath.Abs(skillSourceDir)
+	if err != nil {
+		return fmt.Errorf("adapter/cc: abs source: %w", err)
+	}
+
+	// Inspect the existing entry, if any.
+	if fi, err := os.Lstat(link); err == nil {
+		if fi.Mode()&os.ModeSymlink == 0 {
+			return fmt.Errorf("adapter/cc: %s exists and is not a symlink (refusing to clobber)", link)
+		}
+		current, rerr := os.Readlink(link)
+		if rerr == nil && current == absSource {
+			return nil // already correct
+		}
+		// Stale or wrong target — replace it.
+		if err := os.Remove(link); err != nil {
+			return fmt.Errorf("adapter/cc: remove stale link %s: %w", link, err)
+		}
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("adapter/cc: stat %s: %w", link, err)
+	}
+
+	if err := os.Symlink(absSource, link); err != nil {
+		return fmt.Errorf("adapter/cc: symlink %s -> %s: %w", link, absSource, err)
+	}
+	return nil
+}
+
+// Unmaterialise removes the workspace symlink for a skill. No-op if the
+// link is absent. Refuses to delete real directories.
+func (CC) Unmaterialise(workspaceDir, skillName string) error {
+	link := filepath.Join(workspaceDir, CCPluginsSubdir, skillName)
+	fi, err := os.Lstat(link)
+	if errors.Is(err, os.ErrNotExist) {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("adapter/cc: stat %s: %w", link, err)
+	}
+	if fi.Mode()&os.ModeSymlink == 0 {
+		return fmt.Errorf("adapter/cc: %s is not a symlink (refusing to remove)", link)
+	}
+	if err := os.Remove(link); err != nil {
+		return fmt.Errorf("adapter/cc: remove %s: %w", link, err)
+	}
+	return nil
+}

--- a/internal/skill/adapter/cc_test.go
+++ b/internal/skill/adapter/cc_test.go
@@ -1,0 +1,122 @@
+package adapter
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestCC_Materialise_CreatesSymlink(t *testing.T) {
+	pool := t.TempDir()
+	ws := t.TempDir()
+	src := filepath.Join(pool, "dag")
+	if err := os.MkdirAll(src, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := (CC{}).Materialise(ws, "dag", src); err != nil {
+		t.Fatalf("Materialise: %v", err)
+	}
+	link := filepath.Join(ws, ".claude/plugins/dag")
+	fi, err := os.Lstat(link)
+	if err != nil {
+		t.Fatalf("Lstat: %v", err)
+	}
+	if fi.Mode()&os.ModeSymlink == 0 {
+		t.Errorf("expected symlink at %s, got mode %v", link, fi.Mode())
+	}
+	target, err := os.Readlink(link)
+	if err != nil {
+		t.Fatalf("Readlink: %v", err)
+	}
+	want, _ := filepath.Abs(src)
+	if target != want {
+		t.Errorf("symlink target: got %q want %q", target, want)
+	}
+}
+
+func TestCC_Materialise_Idempotent(t *testing.T) {
+	pool := t.TempDir()
+	ws := t.TempDir()
+	src := filepath.Join(pool, "dag")
+	if err := os.MkdirAll(src, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	cc := CC{}
+	for i := 0; i < 3; i++ {
+		if err := cc.Materialise(ws, "dag", src); err != nil {
+			t.Fatalf("call %d: %v", i, err)
+		}
+	}
+}
+
+func TestCC_Materialise_RefusesToClobberRealDir(t *testing.T) {
+	pool := t.TempDir()
+	ws := t.TempDir()
+	src := filepath.Join(pool, "dag")
+	if err := os.MkdirAll(src, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	link := filepath.Join(ws, ".claude/plugins/dag")
+	if err := os.MkdirAll(link, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := (CC{}).Materialise(ws, "dag", src); err == nil {
+		t.Errorf("expected error when destination is a real directory")
+	}
+}
+
+func TestCC_Materialise_RewritesStaleSymlink(t *testing.T) {
+	pool := t.TempDir()
+	ws := t.TempDir()
+	src := filepath.Join(pool, "dag")
+	if err := os.MkdirAll(src, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	old := filepath.Join(pool, "old")
+	if err := os.MkdirAll(old, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(ws, ".claude/plugins"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	link := filepath.Join(ws, ".claude/plugins/dag")
+	absOld, _ := filepath.Abs(old)
+	if err := os.Symlink(absOld, link); err != nil {
+		t.Fatal(err)
+	}
+	if err := (CC{}).Materialise(ws, "dag", src); err != nil {
+		t.Fatalf("Materialise: %v", err)
+	}
+	target, err := os.Readlink(link)
+	if err != nil {
+		t.Fatal(err)
+	}
+	wantAbs, _ := filepath.Abs(src)
+	if target != wantAbs {
+		t.Errorf("expected stale link rewritten to %q, got %q", wantAbs, target)
+	}
+}
+
+func TestCC_Unmaterialise(t *testing.T) {
+	pool := t.TempDir()
+	ws := t.TempDir()
+	src := filepath.Join(pool, "dag")
+	if err := os.MkdirAll(src, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	cc := CC{}
+	if err := cc.Materialise(ws, "dag", src); err != nil {
+		t.Fatal(err)
+	}
+	if err := cc.Unmaterialise(ws, "dag"); err != nil {
+		t.Fatalf("Unmaterialise: %v", err)
+	}
+	link := filepath.Join(ws, ".claude/plugins/dag")
+	if _, err := os.Lstat(link); !os.IsNotExist(err) {
+		t.Errorf("expected link removed; lstat err=%v", err)
+	}
+	// Unmaterialising again is a no-op.
+	if err := cc.Unmaterialise(ws, "dag"); err != nil {
+		t.Errorf("idempotent unmaterialise: %v", err)
+	}
+}

--- a/internal/skill/adapter/codex.go
+++ b/internal/skill/adapter/codex.go
@@ -1,0 +1,15 @@
+package adapter
+
+// Codex is a v0.1 stub. Spec §11.Z.4: v0.2 will implement textual rewrite
+// of skills/ + .codex-plugin/plugin.json generation (~200 LOC).
+type Codex struct{}
+
+// Materialise panics — codex adapter is not implemented in v0.1.
+func (Codex) Materialise(workspaceDir, skillName, skillSourceDir string) error {
+	panic("adapter/codex: not impl in v0.1")
+}
+
+// Unmaterialise panics — codex adapter is not implemented in v0.1.
+func (Codex) Unmaterialise(workspaceDir, skillName string) error {
+	panic("adapter/codex: not impl in v0.1")
+}

--- a/internal/skill/adapter/cursor.go
+++ b/internal/skill/adapter/cursor.go
@@ -1,0 +1,15 @@
+package adapter
+
+// Cursor is a v0.1 stub. Spec §11.Z.4: v0.2 lossy adapter — concat
+// SKILL.md into .cursor/rules/, drop hooks with a warning.
+type Cursor struct{}
+
+// Materialise panics — cursor adapter is not implemented in v0.1.
+func (Cursor) Materialise(workspaceDir, skillName, skillSourceDir string) error {
+	panic("adapter/cursor: not impl in v0.1")
+}
+
+// Unmaterialise panics — cursor adapter is not implemented in v0.1.
+func (Cursor) Unmaterialise(workspaceDir, skillName string) error {
+	panic("adapter/cursor: not impl in v0.1")
+}

--- a/internal/skill/adapter/doc.go
+++ b/internal/skill/adapter/doc.go
@@ -1,0 +1,5 @@
+// Package adapter wires installed skills into a workspace for a specific
+// agent backend. Spec §11.Z.4: in v0.1 only cc is implemented as a pure
+// symlink (~70 LOC); codex/opencode/aider/cursor are stubs that panic so
+// the seam is named from day 1 (matches D-17 AgentProvider discipline).
+package adapter

--- a/internal/skill/adapter/opencode.go
+++ b/internal/skill/adapter/opencode.go
@@ -1,0 +1,16 @@
+package adapter
+
+// Opencode is a v0.1 stub. Spec §11.Z.4: v0.2 partial implementation
+// (commands/agents pass through; hooks need a separate .ts file authored
+// per the opencode hook model).
+type Opencode struct{}
+
+// Materialise panics — opencode adapter is not implemented in v0.1.
+func (Opencode) Materialise(workspaceDir, skillName, skillSourceDir string) error {
+	panic("adapter/opencode: not impl in v0.1")
+}
+
+// Unmaterialise panics — opencode adapter is not implemented in v0.1.
+func (Opencode) Unmaterialise(workspaceDir, skillName string) error {
+	panic("adapter/opencode: not impl in v0.1")
+}

--- a/internal/skill/blessed_embed.go
+++ b/internal/skill/blessed_embed.go
@@ -1,0 +1,27 @@
+package skill
+
+import (
+	_ "embed"
+	"fmt"
+
+	"github.com/BurntSushi/toml"
+)
+
+//go:embed skills.toml
+var embeddedBlessedListTOML []byte
+
+// EmbeddedBlessedList returns the blessed list compiled into the binary
+// at build time from internal/skill/skills.toml. Used as the deterministic
+// default when the user passes neither --blessed-list nor a local file.
+//
+// v0.1 ships with an empty list — entries are added per-PR as skills mature.
+func EmbeddedBlessedList() (*BlessedList, error) {
+	var l BlessedList
+	if err := toml.Unmarshal(embeddedBlessedListTOML, &l); err != nil {
+		return nil, fmt.Errorf("skill: parse embedded blessed list: %w", err)
+	}
+	if l.Skills == nil {
+		l.Skills = map[string]BlessedEntry{}
+	}
+	return &l, nil
+}

--- a/internal/skill/doc.go
+++ b/internal/skill/doc.go
@@ -1,0 +1,19 @@
+// Package skill implements the v0.1 tether skill model: cc plugin standard
+// directory layout + an optional supplemental tether.toml manifest. See
+// spec §11.Z (D-20) for the full design.
+//
+// Boundary contract: the daemon (internal/backend/claude, internal/agent)
+// MUST NOT import this package. Skill execution is delegated entirely to
+// cc's plugin loader + hook system; this package only handles install,
+// manifest parsing, workspace materialisation (symlink), and CLI surface.
+//
+// Packages:
+//
+//   - internal/skill              manifest + install + workspace resolve
+//   - internal/skill/adapter      per-agent materialisers; cc.go is the
+//     only real implementation in v0.1, the rest are
+//     panicking stubs reserved for v0.2.
+//
+// Forward-compat seams (D-18): blob-register CLI is wired but stubs out
+// "not implemented in v0.1" so future skill code can reference it stably.
+package skill

--- a/internal/skill/install.go
+++ b/internal/skill/install.go
@@ -1,0 +1,369 @@
+package skill
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/BurntSushi/toml"
+)
+
+// DefaultPoolSubdir is the path beneath the user's home dir that holds the
+// global skill pool (spec §11.Z.6 + §11 Q7).
+const DefaultPoolSubdir = ".tether/skills"
+
+// BlessedListPath is the path inside the main tether repo where the
+// short-name → git URL mapping is checked in. The CLI bundles this list
+// at build time / falls back to an embedded copy; until then we look on
+// the filesystem next to the binary or under the workspace root.
+const BlessedListPath = "skills.toml"
+
+// BlessedList is the shape of the main-repo skills.toml. Schema is small
+// on purpose — short-name → git URL is enough for v0.1; richer metadata
+// (rev pinning, signature, channel) is deferred to v0.1.x. See open
+// questions in PR description.
+type BlessedList struct {
+	// Skills is keyed by short name. Each entry carries the upstream git
+	// URL plus optional pinning data we may honour later.
+	Skills map[string]BlessedEntry `toml:"skills"`
+}
+
+// BlessedEntry is one row in the blessed list.
+type BlessedEntry struct {
+	URL         string `toml:"url"`
+	Ref         string `toml:"ref"`         // optional branch/tag/sha
+	Description string `toml:"description"` // surfaced by `tether skill info`
+}
+
+// LoadBlessedList parses a skills.toml at the given path. Missing file is
+// not an error — callers fall back to "user must supply git URL".
+func LoadBlessedList(path string) (*BlessedList, error) {
+	b, err := os.ReadFile(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return &BlessedList{Skills: map[string]BlessedEntry{}}, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("skill: read blessed list %s: %w", path, err)
+	}
+	var l BlessedList
+	if err := toml.Unmarshal(b, &l); err != nil {
+		return nil, fmt.Errorf("skill: parse blessed list %s: %w", path, err)
+	}
+	if l.Skills == nil {
+		l.Skills = map[string]BlessedEntry{}
+	}
+	return &l, nil
+}
+
+// Pool is the global skills directory (default: ~/.tether/skills/). All
+// install / list / remove / info operations route through here.
+type Pool struct {
+	Root string
+}
+
+// DefaultPool returns the user-default pool rooted at $HOME/.tether/skills.
+func DefaultPool() (*Pool, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return nil, fmt.Errorf("skill: locate home dir: %w", err)
+	}
+	return &Pool{Root: filepath.Join(home, DefaultPoolSubdir)}, nil
+}
+
+// Ensure mkdirs the pool root. Idempotent.
+func (p *Pool) Ensure() error {
+	if err := os.MkdirAll(p.Root, 0o755); err != nil {
+		return fmt.Errorf("skill: ensure pool %s: %w", p.Root, err)
+	}
+	return nil
+}
+
+// SkillDir returns <pool>/<name>. Validation is the caller's responsibility.
+func (p *Pool) SkillDir(name string) string {
+	return filepath.Join(p.Root, name)
+}
+
+// Has reports whether <pool>/<name> exists as a directory.
+func (p *Pool) Has(name string) bool {
+	st, err := os.Stat(p.SkillDir(name))
+	return err == nil && st.IsDir()
+}
+
+// List enumerates installed skills (lexicographic). Hidden entries
+// (dotfiles) are skipped so future bookkeeping files don't leak.
+func (p *Pool) List() ([]string, error) {
+	entries, err := os.ReadDir(p.Root)
+	if errors.Is(err, os.ErrNotExist) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("skill: list pool %s: %w", p.Root, err)
+	}
+	out := make([]string, 0, len(entries))
+	for _, e := range entries {
+		if !e.IsDir() {
+			continue
+		}
+		name := e.Name()
+		if strings.HasPrefix(name, ".") {
+			continue
+		}
+		out = append(out, name)
+	}
+	sort.Strings(out)
+	return out, nil
+}
+
+// Remove deletes <pool>/<name>. No-op if absent.
+func (p *Pool) Remove(name string) error {
+	if !SkillNameRe.MatchString(name) {
+		return fmt.Errorf("skill: invalid name %q", name)
+	}
+	dir := p.SkillDir(name)
+	if _, err := os.Stat(dir); errors.Is(err, os.ErrNotExist) {
+		return nil
+	}
+	if err := os.RemoveAll(dir); err != nil {
+		return fmt.Errorf("skill: remove %s: %w", dir, err)
+	}
+	return nil
+}
+
+// ResolveSource turns a CLI argument (short-name or git URL) into a clone
+// URL using the blessed list. Returns the resolved URL plus the canonical
+// short name to install under.
+func ResolveSource(arg string, list *BlessedList) (url, name string, err error) {
+	if isGitURL(arg) {
+		// User-supplied URL: derive name from the last path segment
+		// minus a trailing .git, mirroring git's own default.
+		return arg, gitURLBase(arg), nil
+	}
+	if !SkillNameRe.MatchString(arg) {
+		return "", "", fmt.Errorf("skill: argument %q is neither a skill name nor a git URL", arg)
+	}
+	if list == nil {
+		return "", "", fmt.Errorf("skill: no blessed list available; pass full git URL")
+	}
+	entry, ok := list.Skills[arg]
+	if !ok {
+		return "", "", fmt.Errorf("skill: %q not in blessed list (try a git URL)", arg)
+	}
+	if entry.URL == "" {
+		return "", "", fmt.Errorf("skill: blessed entry %q has empty url", arg)
+	}
+	return entry.URL, arg, nil
+}
+
+// Cloner is the git-clone abstraction. Production uses GitCloneCmd;
+// tests inject a fake.
+type Cloner func(ctx context.Context, url, dest, ref string) error
+
+// GitCloneCmd shells out to `git clone --depth=1 [--branch ref] <url> <dest>`.
+func GitCloneCmd(ctx context.Context, url, dest, ref string) error {
+	args := []string{"clone", "--depth=1"}
+	if ref != "" {
+		args = append(args, "--branch", ref)
+	}
+	args = append(args, url, dest)
+	cmd := exec.CommandContext(ctx, "git", args...)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("skill: git clone %s: %w", url, err)
+	}
+	return nil
+}
+
+// InstallOptions tweaks Install. Force re-clones on top of an existing
+// directory; Cloner overrides the default for tests.
+type InstallOptions struct {
+	Force  bool
+	Cloner Cloner
+	Ref    string
+}
+
+// Install clones <url> into <pool>/<name>. Returns the parsed manifest
+// when one exists at the expected path (otherwise nil — a skill without
+// tether.toml is still valid, see §11.Z.1).
+func (p *Pool) Install(ctx context.Context, url, name string, opts InstallOptions) (*Manifest, error) {
+	if !SkillNameRe.MatchString(name) {
+		return nil, fmt.Errorf("skill: invalid name %q", name)
+	}
+	if err := p.Ensure(); err != nil {
+		return nil, err
+	}
+	dest := p.SkillDir(name)
+	if _, err := os.Stat(dest); err == nil {
+		if !opts.Force {
+			return nil, fmt.Errorf("skill: %s already installed (use --force to overwrite)", name)
+		}
+		if err := os.RemoveAll(dest); err != nil {
+			return nil, fmt.Errorf("skill: clear existing %s: %w", dest, err)
+		}
+	}
+	cloner := opts.Cloner
+	if cloner == nil {
+		cloner = GitCloneCmd
+	}
+	if err := cloner(ctx, url, dest, opts.Ref); err != nil {
+		return nil, err
+	}
+	m, err := readManifestIfPresent(dest)
+	if err != nil {
+		// Bad tether.toml is a hard error — the file is present and broken.
+		// Roll back the install so the user can retry.
+		_ = os.RemoveAll(dest)
+		return nil, err
+	}
+	return m, nil
+}
+
+func readManifestIfPresent(dir string) (*Manifest, error) {
+	path := filepath.Join(dir, "tether.toml")
+	if _, err := os.Stat(path); errors.Is(err, os.ErrNotExist) {
+		return nil, nil
+	}
+	return LoadManifest(path)
+}
+
+// Info returns the parsed manifest for an installed skill, or nil if the
+// skill exists but ships no tether.toml.
+func (p *Pool) Info(name string) (*Manifest, error) {
+	if !p.Has(name) {
+		return nil, fmt.Errorf("skill: %q not installed", name)
+	}
+	return readManifestIfPresent(p.SkillDir(name))
+}
+
+// MissingSkills reports which entries of `enabled` aren't yet in the pool.
+// Used by the B-6 fallback (spec §11.Z.11) and by `tether spawn`.
+func (p *Pool) MissingSkills(enabled []string) []string {
+	var missing []string
+	for _, n := range enabled {
+		if !p.Has(n) {
+			missing = append(missing, n)
+		}
+	}
+	return missing
+}
+
+// FallbackMode encodes the B-6 resolution policy.
+type FallbackMode int
+
+const (
+	// FallbackFail (default) — error out with a helpful message.
+	FallbackFail FallbackMode = iota
+	// FallbackAutoInstall — clone missing skills via the blessed list.
+	FallbackAutoInstall
+	// FallbackAllowMissing — proceed with whatever is installed.
+	FallbackAllowMissing
+)
+
+// ResolveSkills realises the B-6 fallback (spec §11.Z.11). Behaviour:
+//   - FallbackFail: returns an error listing missing skills + repair hint.
+//   - FallbackAutoInstall: tries to clone each missing skill via the
+//     blessed list; on any failure falls back to FallbackFail's error.
+//   - FallbackAllowMissing: returns the subset of enabled that are present
+//     and a non-fatal warning string (printed by the caller).
+//
+// The function never spawns cc — it exists so daemon/CLI startup paths
+// can decide whether to proceed.
+func ResolveSkills(
+	ctx context.Context,
+	pool *Pool,
+	list *BlessedList,
+	workspacePath string,
+	enabled []string,
+	mode FallbackMode,
+	cloner Cloner,
+) (resolved []string, warning string, err error) {
+	missing := pool.MissingSkills(enabled)
+	if len(missing) == 0 {
+		return enabled, "", nil
+	}
+	switch mode {
+	case FallbackFail:
+		return nil, "", missingSkillError(workspacePath, missing)
+	case FallbackAutoInstall:
+		if list == nil {
+			return nil, "", fmt.Errorf("skill: --auto-install requires a blessed list")
+		}
+		for _, name := range missing {
+			url, _, rerr := ResolveSource(name, list)
+			if rerr != nil {
+				return nil, "", fmt.Errorf("auto-install: %w", missingSkillError(workspacePath, missing))
+			}
+			ref := list.Skills[name].Ref
+			if _, ierr := pool.Install(ctx, url, name, InstallOptions{Cloner: cloner, Ref: ref}); ierr != nil {
+				return nil, "", fmt.Errorf("auto-install %s failed: %w", name, ierr)
+			}
+		}
+		return enabled, "", nil
+	case FallbackAllowMissing:
+		out := make([]string, 0, len(enabled)-len(missing))
+		for _, n := range enabled {
+			if pool.Has(n) {
+				out = append(out, n)
+			}
+		}
+		return out, fmt.Sprintf("warning: skipped missing skills: %s", strings.Join(missing, ", ")), nil
+	default:
+		return nil, "", fmt.Errorf("skill: unknown fallback mode %d", mode)
+	}
+}
+
+func missingSkillError(workspacePath string, missing []string) error {
+	var b strings.Builder
+	if workspacePath == "" {
+		b.WriteString("workspace requires skills not in global pool:\n")
+	} else {
+		fmt.Fprintf(&b, "workspace %s requires skills not in global pool:\n", workspacePath)
+	}
+	for _, n := range missing {
+		fmt.Fprintf(&b, "  - %s (enabled in tether.toml)\n", n)
+	}
+	b.WriteString("\ninstall with:\n")
+	for _, n := range missing {
+		fmt.Fprintf(&b, "  tether skill install %s\n", n)
+	}
+	b.WriteString("\nor spawn with available skills only:\n")
+	if workspacePath == "" {
+		b.WriteString("  tether spawn --allow-missing <workspace>\n")
+	} else {
+		fmt.Fprintf(&b, "  tether spawn --allow-missing %s\n", workspacePath)
+	}
+	return errors.New(b.String())
+}
+
+// --- helpers --------------------------------------------------------
+
+func isGitURL(s string) bool {
+	switch {
+	case strings.HasPrefix(s, "http://"),
+		strings.HasPrefix(s, "https://"),
+		strings.HasPrefix(s, "git@"),
+		strings.HasPrefix(s, "ssh://"),
+		strings.HasPrefix(s, "git://"):
+		return true
+	}
+	return strings.HasSuffix(s, ".git")
+}
+
+// gitURLBase derives "y" from "https://github.com/x/y(.git)" / "git@github.com:x/y(.git)".
+func gitURLBase(url string) string {
+	u := strings.TrimSuffix(url, ".git")
+	u = strings.TrimSuffix(u, "/")
+	// strip protocol + auth + host
+	if i := strings.LastIndex(u, "/"); i >= 0 {
+		u = u[i+1:]
+	}
+	if i := strings.LastIndex(u, ":"); i >= 0 {
+		u = u[i+1:]
+	}
+	return u
+}

--- a/internal/skill/install_test.go
+++ b/internal/skill/install_test.go
@@ -1,0 +1,249 @@
+package skill
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// fakeCloner pretends to clone a skill by writing a stand-in directory
+// (and optionally a tether.toml). Lets install_test exercise the full
+// pool layout without spawning git.
+type fakeCloner struct {
+	manifestSrc string // empty = skip manifest write
+	failOn      string // url that should error out
+}
+
+func (f *fakeCloner) clone(ctx context.Context, url, dest, ref string) error {
+	if f.failOn != "" && f.failOn == url {
+		return errors.New("fakeCloner: synthetic failure")
+	}
+	if err := os.MkdirAll(dest, 0o755); err != nil {
+		return err
+	}
+	// Always drop a marker so we can detect what got cloned.
+	if err := os.WriteFile(filepath.Join(dest, ".cloned-from"), []byte(url), 0o644); err != nil {
+		return err
+	}
+	if f.manifestSrc != "" {
+		if err := os.WriteFile(filepath.Join(dest, "tether.toml"), []byte(f.manifestSrc), 0o644); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func TestPool_InstallLayoutAndInfo(t *testing.T) {
+	pool := &Pool{Root: t.TempDir()}
+	fc := &fakeCloner{manifestSrc: minimalManifest}
+
+	m, err := pool.Install(context.Background(), "https://x/y.git", "dag", InstallOptions{Cloner: fc.clone})
+	if err != nil {
+		t.Fatalf("Install: %v", err)
+	}
+	if m == nil || m.Skill.Name != "dag" {
+		t.Fatalf("manifest not parsed; got %+v", m)
+	}
+	if !pool.Has("dag") {
+		t.Errorf("Has(dag) = false after install")
+	}
+	want := filepath.Join(pool.Root, "dag", ".cloned-from")
+	if _, err := os.Stat(want); err != nil {
+		t.Errorf("expected %s to exist: %v", want, err)
+	}
+
+	// Re-install without --force is a hard error
+	if _, err := pool.Install(context.Background(), "https://x/y.git", "dag", InstallOptions{Cloner: fc.clone}); err == nil {
+		t.Errorf("re-install without force expected to fail")
+	}
+
+	// With --force it succeeds
+	if _, err := pool.Install(context.Background(), "https://x/y.git", "dag", InstallOptions{Force: true, Cloner: fc.clone}); err != nil {
+		t.Errorf("re-install with force: %v", err)
+	}
+}
+
+func TestPool_InstallNoManifestIsValid(t *testing.T) {
+	pool := &Pool{Root: t.TempDir()}
+	fc := &fakeCloner{} // no manifest written
+	m, err := pool.Install(context.Background(), "https://x/y.git", "plain", InstallOptions{Cloner: fc.clone})
+	if err != nil {
+		t.Fatalf("Install: %v", err)
+	}
+	if m != nil {
+		t.Errorf("expected nil manifest for plain plugin, got %+v", m)
+	}
+}
+
+func TestPool_InstallBadManifestRollsBack(t *testing.T) {
+	pool := &Pool{Root: t.TempDir()}
+	fc := &fakeCloner{manifestSrc: "[skill]\nname =\n"} // broken toml
+	if _, err := pool.Install(context.Background(), "https://x/y.git", "broken", InstallOptions{Cloner: fc.clone}); err == nil {
+		t.Fatalf("expected install to fail on bad manifest")
+	}
+	if pool.Has("broken") {
+		t.Errorf("expected pool dir to be cleaned up after bad-manifest rollback")
+	}
+}
+
+func TestPool_ListAndRemove(t *testing.T) {
+	pool := &Pool{Root: t.TempDir()}
+	fc := &fakeCloner{manifestSrc: minimalManifest}
+	for _, n := range []string{"dag", "media-review", "writing-plans"} {
+		if _, err := pool.Install(context.Background(), "https://x/"+n+".git", n, InstallOptions{Cloner: fc.clone}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	got, err := pool.List()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 3 || got[0] != "dag" || got[1] != "media-review" || got[2] != "writing-plans" {
+		t.Errorf("List: got %v", got)
+	}
+	if err := pool.Remove("dag"); err != nil {
+		t.Fatal(err)
+	}
+	if pool.Has("dag") {
+		t.Errorf("Has(dag) still true after remove")
+	}
+	// Remove of absent skill is a no-op.
+	if err := pool.Remove("not-there"); err != nil {
+		t.Errorf("Remove(absent) returned %v", err)
+	}
+}
+
+func TestResolveSource(t *testing.T) {
+	list := &BlessedList{Skills: map[string]BlessedEntry{
+		"dag": {URL: "https://github.com/tether/skill-dag.git"},
+	}}
+
+	cases := []struct {
+		arg      string
+		wantURL  string
+		wantName string
+		wantErr  bool
+	}{
+		{"dag", "https://github.com/tether/skill-dag.git", "dag", false},
+		{"https://github.com/x/y.git", "https://github.com/x/y.git", "y", false},
+		{"git@github.com:foo/bar.git", "git@github.com:foo/bar.git", "bar", false},
+		{"unknown", "", "", true},
+		{"with spaces", "", "", true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.arg, func(t *testing.T) {
+			url, name, err := ResolveSource(tc.arg, list)
+			if tc.wantErr {
+				if err == nil {
+					t.Errorf("expected error")
+				}
+				return
+			}
+			if err != nil {
+				t.Errorf("unexpected err: %v", err)
+			}
+			if url != tc.wantURL {
+				t.Errorf("url: got %q want %q", url, tc.wantURL)
+			}
+			if name != tc.wantName {
+				t.Errorf("name: got %q want %q", name, tc.wantName)
+			}
+		})
+	}
+}
+
+func TestResolveSkills_FailDefault(t *testing.T) {
+	pool := &Pool{Root: t.TempDir()}
+	_, _, err := ResolveSkills(context.Background(), pool, nil, "/work/xiyou", []string{"dag"}, FallbackFail, nil)
+	if err == nil {
+		t.Fatal("expected error on missing skill")
+	}
+	msg := err.Error()
+	for _, want := range []string{"workspace /work/xiyou requires skills not in global pool", "tether skill install dag", "--allow-missing /work/xiyou"} {
+		if !strings.Contains(msg, want) {
+			t.Errorf("error missing %q\n%s", want, msg)
+		}
+	}
+}
+
+func TestResolveSkills_FailDefault_NoWorkspacePath(t *testing.T) {
+	pool := &Pool{Root: t.TempDir()}
+	_, _, err := ResolveSkills(context.Background(), pool, nil, "", []string{"dag"}, FallbackFail, nil)
+	if err == nil {
+		t.Fatal("expected error on missing skill")
+	}
+	if !strings.Contains(err.Error(), "<workspace>") {
+		t.Errorf("expected fallback placeholder when workspace path empty; got:\n%s", err.Error())
+	}
+}
+
+func TestResolveSkills_AllowMissing(t *testing.T) {
+	pool := &Pool{Root: t.TempDir()}
+	fc := &fakeCloner{manifestSrc: minimalManifest}
+	if _, err := pool.Install(context.Background(), "https://x/dag.git", "dag", InstallOptions{Cloner: fc.clone}); err != nil {
+		t.Fatal(err)
+	}
+	resolved, warn, err := ResolveSkills(context.Background(), pool, nil, "", []string{"dag", "media-review"}, FallbackAllowMissing, nil)
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if len(resolved) != 1 || resolved[0] != "dag" {
+		t.Errorf("resolved: got %v", resolved)
+	}
+	if !strings.Contains(warn, "media-review") {
+		t.Errorf("warning missing skill name: %q", warn)
+	}
+}
+
+func TestResolveSkills_AutoInstall(t *testing.T) {
+	pool := &Pool{Root: t.TempDir()}
+	list := &BlessedList{Skills: map[string]BlessedEntry{
+		"dag": {URL: "https://x/dag.git"},
+	}}
+	fc := &fakeCloner{manifestSrc: minimalManifest}
+	resolved, _, err := ResolveSkills(context.Background(), pool, list, "", []string{"dag"}, FallbackAutoInstall, fc.clone)
+	if err != nil {
+		t.Fatalf("auto-install: %v", err)
+	}
+	if len(resolved) != 1 || resolved[0] != "dag" {
+		t.Errorf("resolved: %v", resolved)
+	}
+	if !pool.Has("dag") {
+		t.Errorf("dag was not installed by auto-install path")
+	}
+}
+
+func TestResolveSkills_AutoInstallFallsBackOnUnknownName(t *testing.T) {
+	pool := &Pool{Root: t.TempDir()}
+	list := &BlessedList{Skills: map[string]BlessedEntry{}}
+	_, _, err := ResolveSkills(context.Background(), pool, list, "", []string{"missing"}, FallbackAutoInstall, nil)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "auto-install") {
+		t.Errorf("expected auto-install context in error: %v", err)
+	}
+}
+
+func TestLoadBlessedList_Absent(t *testing.T) {
+	dir := t.TempDir()
+	bl, err := LoadBlessedList(filepath.Join(dir, "skills.toml"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(bl.Skills) != 0 {
+		t.Errorf("expected empty list, got %v", bl.Skills)
+	}
+}
+
+const minimalManifest = `
+[skill]
+name = "dag"
+version = "0.1.0"
+
+[skill.agents]
+primary = "cc"
+`

--- a/internal/skill/manifest.go
+++ b/internal/skill/manifest.go
@@ -21,16 +21,16 @@ var SkillNameRe = regexp.MustCompile(`^[a-zA-Z0-9_-]+$`)
 // to a "plain cc plugin" — still installable, just no tether-specific
 // hints).
 type Manifest struct {
-	Skill         SkillSection         `toml:"skill"`
-	Tether        TetherSection        `toml:"tether"`
+	Skill  SkillSection  `toml:"skill"`
+	Tether TetherSection `toml:"tether"`
 }
 
 // SkillSection is the required identity block.
 type SkillSection struct {
-	Name        string       `toml:"name"`
-	Version     string       `toml:"version"`
-	Description string       `toml:"description"`
-	Agents      AgentsBlock  `toml:"agents"`
+	Name        string      `toml:"name"`
+	Version     string      `toml:"version"`
+	Description string      `toml:"description"`
+	Agents      AgentsBlock `toml:"agents"`
 }
 
 // AgentsBlock declares which agent backends a skill is authored for.

--- a/internal/skill/manifest.go
+++ b/internal/skill/manifest.go
@@ -1,0 +1,142 @@
+package skill
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+
+	"github.com/BurntSushi/toml"
+)
+
+// SkillNameRe is the canonical skill-name validator, shared with the
+// fence-tag suffix grammar (spec §11.AA.1) and the install path naming
+// rule (§11.Z.6). Kept here so manifest + CLI + adapter agree on one
+// definition.
+var SkillNameRe = regexp.MustCompile(`^[a-zA-Z0-9_-]+$`)
+
+// Manifest mirrors the v0.1 tether.toml schema (spec §11.Z.2). Every
+// section except [skill] is optional; absence is a valid skill (degrades
+// to a "plain cc plugin" — still installable, just no tether-specific
+// hints).
+type Manifest struct {
+	Skill         SkillSection         `toml:"skill"`
+	Tether        TetherSection        `toml:"tether"`
+}
+
+// SkillSection is the required identity block.
+type SkillSection struct {
+	Name        string       `toml:"name"`
+	Version     string       `toml:"version"`
+	Description string       `toml:"description"`
+	Agents      AgentsBlock  `toml:"agents"`
+}
+
+// AgentsBlock declares which agent backends a skill is authored for.
+// v0.1 only honours `primary` for the cc adapter; `tested` is metadata.
+type AgentsBlock struct {
+	Primary string   `toml:"primary"`
+	Tested  []string `toml:"tested"`
+}
+
+// TetherSection groups all tether-specific optional hints.
+type TetherSection struct {
+	FencedBlocks FencedBlocksBlock `toml:"fenced_blocks"`
+	Mobile       MobileBlock       `toml:"mobile"`
+	State        StateBlock        `toml:"state"`
+}
+
+// FencedBlocksBlock pre-registers the block kinds a skill emits, so the
+// App can wire renderers eagerly (spec §11.Z.2 + §11.AA).
+type FencedBlocksBlock struct {
+	Emits           []string `toml:"emits"`
+	PreferredLayout string   `toml:"preferred_layout"`
+	MobileDefault   string   `toml:"mobile_default"`
+}
+
+// MobileBlock holds mobile-only UI hints (spec §11.Z.2).
+type MobileBlock struct {
+	DefaultCardLayout string   `toml:"default_card_layout"`
+	QuickActions      []string `toml:"quick_actions"`
+}
+
+// StateBlock describes the skill's workspace state-file protocol
+// (spec §11.Z.9). daemon never reads these files; the values here are
+// enforced/used by skill scripts and `tether spawn`.
+type StateBlock struct {
+	WorkspaceDir     string `toml:"workspace_dir"`
+	FileLock         bool   `toml:"file_lock"`
+	GitignoreDefault bool   `toml:"gitignore_default"`
+}
+
+// WorkspaceManifest is the workspace-level tether.toml: who is enabled
+// for this user workspace (spec §11.Z.6).
+type WorkspaceManifest struct {
+	Skills WorkspaceSkillsBlock `toml:"skills"`
+}
+
+// WorkspaceSkillsBlock holds the enabled-skill resolver result.
+type WorkspaceSkillsBlock struct {
+	Enabled []string `toml:"enabled"`
+}
+
+// LoadManifest reads + validates a per-skill tether.toml.
+func LoadManifest(path string) (*Manifest, error) {
+	b, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("skill: read manifest %s: %w", path, err)
+	}
+	var m Manifest
+	if err := toml.Unmarshal(b, &m); err != nil {
+		return nil, fmt.Errorf("skill: parse manifest %s: %w", path, err)
+	}
+	if err := m.Validate(); err != nil {
+		return nil, fmt.Errorf("skill: invalid manifest %s: %w", path, err)
+	}
+	return &m, nil
+}
+
+// Validate enforces the minimum field set for a v0.1 manifest.
+func (m *Manifest) Validate() error {
+	if m.Skill.Name == "" {
+		return errors.New("[skill].name is required")
+	}
+	if !SkillNameRe.MatchString(m.Skill.Name) {
+		return fmt.Errorf("[skill].name %q must match %s", m.Skill.Name, SkillNameRe.String())
+	}
+	if m.Skill.Version == "" {
+		return errors.New("[skill].version is required")
+	}
+	if m.Skill.Agents.Primary == "" {
+		return errors.New("[skill.agents].primary is required (v0.1: must be \"cc\")")
+	}
+	return nil
+}
+
+// LoadWorkspaceManifest reads the workspace tether.toml; missing file is
+// treated as "no skills enabled" rather than an error.
+func LoadWorkspaceManifest(workspaceDir string) (*WorkspaceManifest, error) {
+	path := filepath.Join(workspaceDir, "tether.toml")
+	b, err := os.ReadFile(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return &WorkspaceManifest{}, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("skill: read workspace manifest %s: %w", path, err)
+	}
+	var w WorkspaceManifest
+	if err := toml.Unmarshal(b, &w); err != nil {
+		return nil, fmt.Errorf("skill: parse workspace manifest %s: %w", path, err)
+	}
+	return &w, nil
+}
+
+// EnabledSkills is a thin accessor used by `tether spawn` and resolveSkills
+// (B-6 fallback path; spec §11.Z.11).
+func (w *WorkspaceManifest) EnabledSkills() []string {
+	if w == nil {
+		return nil
+	}
+	return w.Skills.Enabled
+}

--- a/internal/skill/manifest_test.go
+++ b/internal/skill/manifest_test.go
@@ -1,0 +1,169 @@
+package skill
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestLoadManifest_HappyPath(t *testing.T) {
+	const src = `
+[skill]
+name = "dag"
+version = "0.1.0"
+description = "DAG-driven multi-step planning + execution skill"
+
+[skill.agents]
+primary = "cc"
+tested = ["cc"]
+
+[tether.fenced_blocks]
+emits = ["dag", "media"]
+preferred_layout = "full"
+mobile_default = "compact"
+
+[tether.mobile]
+default_card_layout = "compact"
+quick_actions = ["rollback", "approve"]
+
+[tether.state]
+workspace_dir = ".tether/dag/"
+file_lock = true
+gitignore_default = true
+`
+	path := writeTmp(t, "tether.toml", src)
+	m, err := LoadManifest(path)
+	if err != nil {
+		t.Fatalf("LoadManifest: %v", err)
+	}
+	if m.Skill.Name != "dag" {
+		t.Errorf("name: got %q want dag", m.Skill.Name)
+	}
+	if m.Skill.Version != "0.1.0" {
+		t.Errorf("version: got %q", m.Skill.Version)
+	}
+	if m.Skill.Agents.Primary != "cc" {
+		t.Errorf("agents.primary: got %q", m.Skill.Agents.Primary)
+	}
+	if got := m.Tether.FencedBlocks.Emits; len(got) != 2 || got[0] != "dag" || got[1] != "media" {
+		t.Errorf("fenced_blocks.emits: got %v", got)
+	}
+	if !m.Tether.State.FileLock || !m.Tether.State.GitignoreDefault {
+		t.Errorf("tether.state booleans not parsed: %+v", m.Tether.State)
+	}
+	if m.Tether.State.WorkspaceDir != ".tether/dag/" {
+		t.Errorf("workspace_dir: got %q", m.Tether.State.WorkspaceDir)
+	}
+	if got := m.Tether.Mobile.QuickActions; len(got) != 2 {
+		t.Errorf("quick_actions: %v", got)
+	}
+}
+
+func TestLoadManifest_MinimalValid(t *testing.T) {
+	// Only required fields; everything else absent.
+	const src = `
+[skill]
+name = "foo"
+version = "1.0.0"
+
+[skill.agents]
+primary = "cc"
+`
+	path := writeTmp(t, "tether.toml", src)
+	m, err := LoadManifest(path)
+	if err != nil {
+		t.Fatalf("LoadManifest: %v", err)
+	}
+	if m.Skill.Name != "foo" {
+		t.Errorf("name: got %q", m.Skill.Name)
+	}
+	if len(m.Tether.FencedBlocks.Emits) != 0 {
+		t.Errorf("expected no emits, got %v", m.Tether.FencedBlocks.Emits)
+	}
+}
+
+func TestLoadManifest_Malformed(t *testing.T) {
+	cases := []struct {
+		name    string
+		src     string
+		wantSub string
+	}{
+		{
+			name:    "missing name",
+			src:     "[skill]\nversion = \"1\"\n[skill.agents]\nprimary = \"cc\"\n",
+			wantSub: "[skill].name is required",
+		},
+		{
+			name:    "missing version",
+			src:     "[skill]\nname = \"foo\"\n[skill.agents]\nprimary = \"cc\"\n",
+			wantSub: "[skill].version is required",
+		},
+		{
+			name:    "missing primary agent",
+			src:     "[skill]\nname = \"foo\"\nversion = \"1\"\n",
+			wantSub: "[skill.agents].primary is required",
+		},
+		{
+			name:    "invalid name chars",
+			src:     "[skill]\nname = \"bad name\"\nversion = \"1\"\n[skill.agents]\nprimary = \"cc\"\n",
+			wantSub: "must match",
+		},
+		{
+			name:    "broken toml syntax",
+			src:     "[skill]\nname =\n",
+			wantSub: "parse manifest",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			path := writeTmp(t, "tether.toml", tc.src)
+			_, err := LoadManifest(path)
+			if err == nil {
+				t.Fatalf("expected error, got nil")
+			}
+			if !strings.Contains(err.Error(), tc.wantSub) {
+				t.Errorf("error %q missing substring %q", err.Error(), tc.wantSub)
+			}
+		})
+	}
+}
+
+func TestLoadWorkspaceManifest_AbsentMeansNoSkills(t *testing.T) {
+	dir := t.TempDir()
+	w, err := LoadWorkspaceManifest(dir)
+	if err != nil {
+		t.Fatalf("LoadWorkspaceManifest: %v", err)
+	}
+	if got := w.EnabledSkills(); len(got) != 0 {
+		t.Errorf("expected empty enabled, got %v", got)
+	}
+}
+
+func TestLoadWorkspaceManifest_HappyPath(t *testing.T) {
+	dir := t.TempDir()
+	src := "[skills]\nenabled = [\"dag\", \"writing-plans\"]\n"
+	if err := os.WriteFile(filepath.Join(dir, "tether.toml"), []byte(src), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	w, err := LoadWorkspaceManifest(dir)
+	if err != nil {
+		t.Fatalf("LoadWorkspaceManifest: %v", err)
+	}
+	got := w.EnabledSkills()
+	if len(got) != 2 || got[0] != "dag" || got[1] != "writing-plans" {
+		t.Errorf("enabled: got %v", got)
+	}
+}
+
+// --- helpers --------------------------------------------------------
+
+func writeTmp(t *testing.T, name, content string) string {
+	t.Helper()
+	dir := t.TempDir()
+	p := filepath.Join(dir, name)
+	if err := os.WriteFile(p, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return p
+}

--- a/internal/skill/skills.toml
+++ b/internal/skill/skills.toml
@@ -1,0 +1,7 @@
+# Tether blessed skill list — embedded into the binary at build time
+# via internal/skill/blessed_embed.go. Edit this file and rebuild to
+# update the default short-name → git URL mapping.
+#
+# Empty for v0.1 — entries land per-skill via PR. See spec §11.Z.6.
+
+[skills]


### PR DESCRIPTION
## Summary

- Implements Epic #8 Skill system in `internal/skill/`: tether.toml manifest parser, global pool (`~/.tether/skills/`), pure-symlink cc adapter (only real adapter for v0.1), 4 panic stubs (codex/opencode/aider/cursor), workspace `[skills].enabled` resolver with B-6 fallback (FailDefault/AutoInstall/AllowMissing), `//go:embed`-backed blessed list, and D-18 `tether-blob-register` CLI stub.
- CLI (`cmd/tether/`): `skill {install|list|remove|info}`.
- B-6 fallback error message includes workspace path when known (matches spec §11.Z.11 example `tether spawn ~/work/xiyou`).
- Bumps Go toolchain `1.24.6 → 1.25.0` (workspace-wide; aligns with `e2e-c1-crypto` PR).
- Daemon does NOT depend on `internal/skill/` — verified via grep guard.

LOC: ~750 production + ~530 tests. Covers spec §11.Z (D-20) + §11.AA fence-tag-suffix syntax precondition.

## Test plan

- [x] `go test ./internal/skill/...` — pass
- [x] `go vet ./...` — clean
- [x] `go build ./...` — clean
- [x] `tether skill list` smoke against empty pool — produces expected stub output
- [x] `tether tether-blob-register /tmp/foo` — exits 1 with "not implemented in v0.1"

## Open follow-ups

1. **Blessed list maintenance flow**: schema landed via `//go:embed internal/skill/skills.toml` (empty for v0.1). When first dag/skill matures, add a row + rebuild.
2. **Daemon spawn-time skill integration** (~10 LOC): glue in Epic #3 daemon to call `adapter/cc.go` symlink at `tether spawn`. Tracked in v1-epics follow-ups.
3. **`--auto-install` for non-blessed names**: currently rejects unknown short-names (no implicit URL guessing). Confirm or relax.
4. **`tether skill` vs `tether skills` naming** — used singular per spec §11.Z.6 examples.