### PR TITLE
Epic #3 sub-task #6: Lock state machine (§11.D)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/piaobeizu/tether
 
-go 1.24.6
+go 1.25.0

--- a/internal/lock/doc.go
+++ b/internal/lock/doc.go
@@ -1,0 +1,41 @@
+// Package lock implements the per-session writer-lock state machine that
+// gates "who can write PTY bytes" for a tether session (spec §8 + §11.D).
+//
+// PoC-1 (F-10/F-11) showed cc itself enforces a 3-layer permission model
+// (plan / safe-cmd allowlist / mode+hook+TUI; see spec §5.5). That means
+// tether's lock does NOT need to also gate "what mode cc is in" — the lock
+// is single-layered and only governs writes to the PTY.
+//
+// Concrete contract (spec §11.D table):
+//
+//   - Holder is *ClientID; nil means "no holder" (anyone may write next).
+//   - First byte from any client when holder=nil → that client takes the
+//     lock implicitly (Acquire with reason=AcquireFirstByte).
+//   - First byte from a non-holder when the current holder has been idle
+//     longer than the auto-release window (default 60s) → the new client
+//     takes over implicitly (auto-release fires before grant).
+//   - First byte from a non-holder when the holder is active → rejected.
+//     The caller is expected to surface an "in use" banner / 4xx-style
+//     hint and offer ForceTakeover.
+//   - ForceTakeover (terminal Ctrl+\ Ctrl+T or Mobile App "take over"
+//     button) always succeeds for the requesting client.
+//   - The current holder MUST call Touch on every PTY write so the
+//     auto-release timer slides forward. The package does NOT assume any
+//     ambient timer; the caller's input gate (or a periodic Sweep call)
+//     drives auto-release.
+//   - Every state change appends a TakeoverEvent to History so callers can
+//     persist an audit log (spec §11.D "Audit log" requirement; the
+//     write-to-disk side lives in the daemon, this package only collects
+//     the in-memory record).
+//
+// Concurrency: Lock is safe for concurrent use. All mutating methods take
+// an internal mutex; History returns a defensive copy.
+//
+// Out-of-scope (deferred):
+//   - persisting the audit log to ~/.tether/.../lock.log (daemon's job)
+//   - mode switching RPC (separate from lock; only the current holder is
+//     allowed but that policy lives at the daemon RPC handler — this
+//     package exposes IsHolder so the handler can enforce it cleanly)
+//   - view-only attach / multi-holder fan-out (v0.1 not in scope per
+//     §11.D)
+package lock

--- a/internal/lock/lock.go
+++ b/internal/lock/lock.go
@@ -1,0 +1,378 @@
+package lock
+
+import (
+	"errors"
+	"sync"
+	"time"
+)
+
+// DefaultAutoReleaseWindow is the spec §11.D auto-release threshold: a
+// holder that has been idle (no Touch / TryAcquire / ForceTakeover) for
+// this long is treated as having released the lock, so a different client
+// may take over without ForceTakeover.
+const DefaultAutoReleaseWindow = 60 * time.Second
+
+// ClientID identifies who holds (or wants) the lock. The Kind values are
+// the only ones v0.1 emits — Mobile App ("mobile") and any local terminal
+// attach ("terminal", whether the same machine or SSH'd in per §11.U).
+// DeviceID is the per-pairing device identifier from devices.json so the
+// audit log can attribute force-takeovers to specific phones / shells.
+type ClientID struct {
+	Kind     string
+	DeviceID string
+}
+
+// Predefined Kind values. Other values are not rejected (the package is
+// kind-agnostic) but the daemon's own handlers should stick to these so
+// the audit log stays grep-able.
+const (
+	KindMobile   = "mobile"
+	KindTerminal = "terminal"
+)
+
+// Equal reports whether two ClientIDs identify the same client. The zero
+// ClientID is never equal to a non-zero ClientID; this is intentional so
+// callers can use the zero value to mean "anonymous / not applicable"
+// without it accidentally matching a real client.
+func (c ClientID) Equal(o ClientID) bool {
+	if c.Kind == "" && c.DeviceID == "" {
+		return false
+	}
+	return c.Kind == o.Kind && c.DeviceID == o.DeviceID
+}
+
+// AcquireReason classifies how the lock was taken. It distinguishes the
+// implicit-on-first-byte path from explicit Mobile App / terminal force
+// takeover, and the implicit-on-stale-holder path that fires when the
+// previous holder went idle past AutoReleaseWindow.
+type AcquireReason string
+
+const (
+	// AcquireFirstByte: the lock was unheld and the requesting client
+	// became holder.
+	AcquireFirstByte AcquireReason = "first-byte"
+	// AcquireStaleTakeover: the previous holder had been idle past
+	// AutoReleaseWindow; the requesting client took over implicitly.
+	AcquireStaleTakeover AcquireReason = "stale-takeover"
+	// AcquireForce: the requesting client invoked ForceTakeover (Ctrl+\
+	// Ctrl+T from terminal or "Take over" UI from Mobile App).
+	AcquireForce AcquireReason = "force-takeover"
+	// ReleaseAuto: not an acquire reason — used in History entries
+	// emitted by Sweep when an idle holder is auto-released without
+	// another client taking over.
+	ReleaseAuto AcquireReason = "auto-release"
+	// ReleaseExplicit: holder called Release.
+	ReleaseExplicit AcquireReason = "release"
+)
+
+// TakeoverEvent records one state change in the lock's history. Holder
+// fields use ClientID-by-value (not pointer) — a zero ClientID
+// (Kind=="" && DeviceID=="") means "no holder", matching the wire
+// shape used in audit logs.
+type TakeoverEvent struct {
+	At         time.Time
+	Reason     AcquireReason
+	PrevHolder ClientID // zero ClientID = was unheld
+	NewHolder  ClientID // zero ClientID = now unheld (only on auto-release / explicit release)
+}
+
+// ErrInUse is returned by TryAcquire when an active (non-stale) holder
+// owns the lock and the requester is not the holder. The caller is
+// expected to surface a "session in use" message and offer the
+// force-takeover affordance.
+var ErrInUse = errors.New("lock: held by another client")
+
+// ErrNotHolder is returned by Touch / Release when called with a client
+// that does not currently hold the lock. Defense against caller bugs
+// (mistakenly Touch'ing on behalf of a different attach session).
+var ErrNotHolder = errors.New("lock: caller is not current holder")
+
+// nowFunc is the time source. Tests override via WithClock; production
+// uses time.Now.
+type nowFunc func() time.Time
+
+// Lock is the per-session writer-lock state machine. It's safe for
+// concurrent use. Construct via New.
+//
+// The lock is a passive data structure: it does not run any goroutine.
+// The auto-release window is checked at every TryAcquire / Touch, and
+// Sweep is exposed for callers who want to actively reap idle holders
+// (e.g. to fire an audit-log entry the moment a holder goes stale rather
+// than waiting for the next acquire attempt).
+type Lock struct {
+	mu                sync.Mutex
+	holder            ClientID  // zero = no holder
+	lastWriteAt       time.Time // valid only when holder != zero
+	autoReleaseWindow time.Duration
+	now               nowFunc
+	history           []TakeoverEvent
+}
+
+// Option configures Lock at construction time.
+type Option func(*Lock)
+
+// WithAutoReleaseWindow overrides the default 60s auto-release window.
+// Useful for tests; production should keep the spec default.
+func WithAutoReleaseWindow(d time.Duration) Option {
+	return func(l *Lock) {
+		if d > 0 {
+			l.autoReleaseWindow = d
+		}
+	}
+}
+
+// WithClock overrides the time source. Test-only — production omits this
+// and gets time.Now.
+func WithClock(now func() time.Time) Option {
+	return func(l *Lock) {
+		if now != nil {
+			l.now = now
+		}
+	}
+}
+
+// New constructs a Lock with no holder. Default auto-release window is
+// DefaultAutoReleaseWindow; default clock is time.Now. Options override.
+func New(opts ...Option) *Lock {
+	l := &Lock{
+		autoReleaseWindow: DefaultAutoReleaseWindow,
+		now:               time.Now,
+	}
+	for _, opt := range opts {
+		opt(l)
+	}
+	return l
+}
+
+// AutoReleaseWindow reports the configured idle threshold. Exposed for
+// daemon health pages / debug introspection; not part of the lock
+// protocol.
+func (l *Lock) AutoReleaseWindow() time.Duration {
+	return l.autoReleaseWindow
+}
+
+// Holder returns the current holder ClientID and a flag indicating
+// whether the lock is held. The flag is false (and the returned ClientID
+// zero) when the lock is unheld OR the current holder has gone stale
+// past AutoReleaseWindow at the moment of this call. Holder DOES advance
+// the state machine when it observes a stale holder — that observation
+// is recorded as an auto-release TakeoverEvent so callers reading the
+// audit log see exactly when staleness was detected.
+func (l *Lock) Holder() (ClientID, bool) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	l.reapStaleLocked()
+	if l.holderZero() {
+		return ClientID{}, false
+	}
+	return l.holder, true
+}
+
+// IsHolder reports whether c is the current holder. Convenience wrapper;
+// equivalent to comparing Holder() to c manually but cheaper because it
+// doesn't allocate the returned tuple at the call site. Stale holders
+// are reaped before the comparison, matching Holder's semantics.
+func (l *Lock) IsHolder(c ClientID) bool {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	l.reapStaleLocked()
+	return !l.holderZero() && l.holder.Equal(c)
+}
+
+// LastWriteAt returns the timestamp of the most recent Touch (or the
+// time of the most recent acquire if Touch hasn't been called since).
+// Returns zero time when the lock is unheld. Useful for "lock idle" UI.
+func (l *Lock) LastWriteAt() time.Time {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	if l.holderZero() {
+		return time.Time{}
+	}
+	return l.lastWriteAt
+}
+
+// TryAcquire is the implicit-acquire path the input gate calls before
+// every write attempt. Returns nil and grants the lock to c when:
+//   - the lock was unheld (records reason=AcquireFirstByte), or
+//   - the previous holder was idle past AutoReleaseWindow (reason=
+//     AcquireStaleTakeover, with the prior holder visible in the
+//     emitted TakeoverEvent), or
+//   - c is already the current holder (no state change, no event
+//     appended; LastWriteAt is NOT updated — call Touch for that).
+//
+// Returns ErrInUse and does not mutate state when an active holder owns
+// the lock and is someone other than c. The caller should surface an
+// in-use UI affordance and may follow up with ForceTakeover.
+//
+// c.Equal(zero) clients are rejected with ErrNotHolder — anonymous
+// callers must explicitly ForceTakeover (which also rejects the zero
+// ClientID for the same reason: every audit-log entry needs a real
+// attribution).
+func (l *Lock) TryAcquire(c ClientID) error {
+	if c.Kind == "" && c.DeviceID == "" {
+		// Zero ClientID — never accept implicitly. Equal() also rejects
+		// the zero value to keep "anonymous" from accidentally matching
+		// a real client; that policy + this guard means daemon code can
+		// safely use the zero ClientID as "not applicable" sentinel.
+		return ErrNotHolder
+	}
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	now := l.now()
+	if l.holderZero() {
+		l.grantLocked(c, now, AcquireFirstByte)
+		return nil
+	}
+	if l.holder.Equal(c) {
+		// Already holder. No-op; caller may follow with Touch on actual
+		// write. Do not extend the window here — extending on TryAcquire
+		// alone would let a buggy caller indefinitely "hold" without
+		// ever writing.
+		return nil
+	}
+	// Different client wants in. Reap stale holder if applicable.
+	if now.Sub(l.lastWriteAt) > l.autoReleaseWindow {
+		l.grantLocked(c, now, AcquireStaleTakeover)
+		return nil
+	}
+	return ErrInUse
+}
+
+// ForceTakeover always grants the lock to c, regardless of current
+// holder. Records reason=AcquireForce in the audit log so the prior
+// holder shows up in History (spec §11.D "Audit log" requirement: every
+// state change writes an entry — force takeovers in particular need to
+// be visible).
+//
+// c must be a non-zero ClientID; zero is rejected with ErrNotHolder.
+func (l *Lock) ForceTakeover(c ClientID) error {
+	if c.Kind == "" && c.DeviceID == "" {
+		return ErrNotHolder
+	}
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	if !l.holderZero() && l.holder.Equal(c) {
+		// Already holder. Still slide the window forward — a force
+		// takeover when you ARE the holder is most likely a UI button
+		// re-press and we shouldn't surprise the user by leaving the
+		// timer near expiry.
+		l.lastWriteAt = l.now()
+		return nil
+	}
+	l.grantLocked(c, l.now(), AcquireForce)
+	return nil
+}
+
+// Touch slides the auto-release timer forward to "now". Called by the
+// input gate AFTER each successful PTY write so an active holder doesn't
+// get stale-reaped mid-session.
+//
+// Returns ErrNotHolder if c is not the current holder (defends against
+// the caller mistakenly Touching on behalf of a different attach
+// session). Does NOT auto-acquire; pair with TryAcquire to acquire then
+// Touch on confirm.
+func (l *Lock) Touch(c ClientID) error {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	if l.holderZero() || !l.holder.Equal(c) {
+		return ErrNotHolder
+	}
+	l.lastWriteAt = l.now()
+	return nil
+}
+
+// Release explicitly drops the lock. Only the current holder may release
+// (returns ErrNotHolder otherwise). Records a TakeoverEvent with reason
+// =ReleaseExplicit so the audit trail shows a clean handoff distinct
+// from auto-release.
+//
+// After Release returns nil, the lock is unheld and the next TryAcquire
+// from any client takes it.
+func (l *Lock) Release(c ClientID) error {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	if l.holderZero() || !l.holder.Equal(c) {
+		return ErrNotHolder
+	}
+	prev := l.holder
+	l.holder = ClientID{}
+	l.lastWriteAt = time.Time{}
+	l.history = append(l.history, TakeoverEvent{
+		At:         l.now(),
+		Reason:     ReleaseExplicit,
+		PrevHolder: prev,
+		NewHolder:  ClientID{},
+	})
+	return nil
+}
+
+// Sweep checks whether the current holder has been idle past
+// AutoReleaseWindow and, if so, releases the lock and appends an
+// auto-release TakeoverEvent. Returns true when a sweep actually fired
+// (state changed); false otherwise (no holder, or holder still active).
+//
+// Sweep is optional — TryAcquire reaps stale holders lazily — but a
+// daemon that wants to emit audit-log entries promptly (e.g. so the
+// "lock idle for >60s" line appears at the moment it goes idle, not when
+// the next attach client tries to write) can call Sweep on a periodic
+// timer.
+func (l *Lock) Sweep() bool {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	return l.reapStaleLocked()
+}
+
+// History returns a defensive copy of the audit-log slice. Callers are
+// free to mutate the returned slice; doing so does not affect the lock.
+// Order is chronological (oldest first); each call re-snapshots so
+// callers polling for new entries should track length.
+func (l *Lock) History() []TakeoverEvent {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	out := make([]TakeoverEvent, len(l.history))
+	copy(out, l.history)
+	return out
+}
+
+// --- locked helpers (caller already holds l.mu) ---------------------------
+
+// holderZero reports whether the holder field is the zero ClientID.
+// Centralized so the "what counts as unheld" question has one answer.
+func (l *Lock) holderZero() bool {
+	return l.holder.Kind == "" && l.holder.DeviceID == ""
+}
+
+// grantLocked records a transition to a new holder. Used by all three
+// acquire paths (first-byte, stale-takeover, force).
+func (l *Lock) grantLocked(c ClientID, at time.Time, reason AcquireReason) {
+	prev := l.holder
+	l.holder = c
+	l.lastWriteAt = at
+	l.history = append(l.history, TakeoverEvent{
+		At:         at,
+		Reason:     reason,
+		PrevHolder: prev,
+		NewHolder:  c,
+	})
+}
+
+// reapStaleLocked checks staleness of the current holder and releases if
+// applicable. Returns true when state actually changed. Idempotent.
+func (l *Lock) reapStaleLocked() bool {
+	if l.holderZero() {
+		return false
+	}
+	if l.now().Sub(l.lastWriteAt) <= l.autoReleaseWindow {
+		return false
+	}
+	prev := l.holder
+	l.holder = ClientID{}
+	l.lastWriteAt = time.Time{}
+	l.history = append(l.history, TakeoverEvent{
+		At:         l.now(),
+		Reason:     ReleaseAuto,
+		PrevHolder: prev,
+		NewHolder:  ClientID{},
+	})
+	return true
+}

--- a/internal/lock/lock_test.go
+++ b/internal/lock/lock_test.go
@@ -1,0 +1,507 @@
+package lock
+
+import (
+	"errors"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// fakeClock is a manually-advanced time source for deterministic
+// auto-release tests. atomic.Int64 holds unix-nanos; tests adjust via
+// add() / set().
+type fakeClock struct {
+	nanos atomic.Int64
+}
+
+func newFakeClock(start time.Time) *fakeClock {
+	c := &fakeClock{}
+	c.nanos.Store(start.UnixNano())
+	return c
+}
+
+func (c *fakeClock) Now() time.Time { return time.Unix(0, c.nanos.Load()) }
+
+func (c *fakeClock) Advance(d time.Duration) {
+	c.nanos.Add(d.Nanoseconds())
+}
+
+// helper: build a fresh Lock with fake clock + 60s window (the spec
+// default). Tests that need a different window override.
+func newLockForTest(t *testing.T, start time.Time) (*Lock, *fakeClock) {
+	t.Helper()
+	clk := newFakeClock(start)
+	l := New(WithClock(clk.Now))
+	return l, clk
+}
+
+var (
+	mobileA   = ClientID{Kind: KindMobile, DeviceID: "device-a"}
+	mobileB   = ClientID{Kind: KindMobile, DeviceID: "device-b"}
+	terminalA = ClientID{Kind: KindTerminal, DeviceID: "term-a"}
+	zeroC     = ClientID{}
+)
+
+// --- ClientID -----------------------------------------------------------
+
+func TestClientID_Equal(t *testing.T) {
+	if mobileA.Equal(mobileB) {
+		t.Errorf("different DeviceID should not be Equal")
+	}
+	if !mobileA.Equal(mobileA) {
+		t.Errorf("same ClientID should be Equal")
+	}
+	// Zero is intentionally not equal to itself — see ClientID.Equal doc.
+	if zeroC.Equal(zeroC) {
+		t.Errorf("zero ClientID must not be Equal to itself (sentinel rule)")
+	}
+	if zeroC.Equal(mobileA) || mobileA.Equal(zeroC) {
+		t.Errorf("zero ClientID must not match a real client")
+	}
+}
+
+// --- Initial state ------------------------------------------------------
+
+func TestLock_NewIsUnheld(t *testing.T) {
+	l := New()
+	if h, held := l.Holder(); held {
+		t.Errorf("fresh Lock reported holder=%v held=true", h)
+	}
+	if !l.LastWriteAt().IsZero() {
+		t.Errorf("fresh Lock LastWriteAt should be zero")
+	}
+	if got := l.AutoReleaseWindow(); got != DefaultAutoReleaseWindow {
+		t.Errorf("default AutoReleaseWindow: got %v want %v", got, DefaultAutoReleaseWindow)
+	}
+}
+
+func TestLock_WithAutoReleaseWindow(t *testing.T) {
+	l := New(WithAutoReleaseWindow(5 * time.Second))
+	if got := l.AutoReleaseWindow(); got != 5*time.Second {
+		t.Errorf("override AutoReleaseWindow: got %v want 5s", got)
+	}
+	// Negative / zero overrides ignored.
+	l2 := New(WithAutoReleaseWindow(0))
+	if got := l2.AutoReleaseWindow(); got != DefaultAutoReleaseWindow {
+		t.Errorf("zero override should be ignored, got %v", got)
+	}
+}
+
+// --- TryAcquire: the three acquire paths --------------------------------
+
+func TestTryAcquire_FirstByte(t *testing.T) {
+	l, _ := newLockForTest(t, time.Date(2026, 5, 6, 0, 0, 0, 0, time.UTC))
+	if err := l.TryAcquire(mobileA); err != nil {
+		t.Fatalf("TryAcquire on unheld: %v", err)
+	}
+	h, held := l.Holder()
+	if !held || !h.Equal(mobileA) {
+		t.Errorf("after first-byte: holder=%v held=%v want mobileA held=true", h, held)
+	}
+	hist := l.History()
+	if len(hist) != 1 {
+		t.Fatalf("History len: got %d want 1", len(hist))
+	}
+	if hist[0].Reason != AcquireFirstByte {
+		t.Errorf("History[0].Reason: got %s want %s", hist[0].Reason, AcquireFirstByte)
+	}
+	if hist[0].NewHolder != mobileA {
+		t.Errorf("History[0].NewHolder: got %v want %v", hist[0].NewHolder, mobileA)
+	}
+	if hist[0].PrevHolder != zeroC {
+		t.Errorf("History[0].PrevHolder: got %v want zero", hist[0].PrevHolder)
+	}
+}
+
+func TestTryAcquire_HolderRepeatNoOp(t *testing.T) {
+	l, _ := newLockForTest(t, time.Now())
+	_ = l.TryAcquire(mobileA)
+	before := l.History()
+	if err := l.TryAcquire(mobileA); err != nil {
+		t.Fatalf("repeat TryAcquire by holder: %v", err)
+	}
+	after := l.History()
+	if len(after) != len(before) {
+		t.Errorf("repeat TryAcquire by holder must not append history (got %d->%d)", len(before), len(after))
+	}
+}
+
+func TestTryAcquire_ActiveHolderRejects(t *testing.T) {
+	l, clk := newLockForTest(t, time.Now())
+	_ = l.TryAcquire(mobileA)
+	clk.Advance(30 * time.Second) // still within 60s window
+	err := l.TryAcquire(mobileB)
+	if !errors.Is(err, ErrInUse) {
+		t.Fatalf("TryAcquire by other client (active): got %v want ErrInUse", err)
+	}
+	h, _ := l.Holder()
+	if !h.Equal(mobileA) {
+		t.Errorf("rejected TryAcquire must not change holder; got %v", h)
+	}
+	// History must NOT have grown — failed acquires don't audit.
+	if len(l.History()) != 1 {
+		t.Errorf("rejected TryAcquire should not append history; got %d entries", len(l.History()))
+	}
+}
+
+func TestTryAcquire_StaleTakeover(t *testing.T) {
+	l, clk := newLockForTest(t, time.Now())
+	_ = l.TryAcquire(mobileA)
+	clk.Advance(61 * time.Second) // past 60s window
+	if err := l.TryAcquire(mobileB); err != nil {
+		t.Fatalf("stale takeover: %v", err)
+	}
+	h, _ := l.Holder()
+	if !h.Equal(mobileB) {
+		t.Errorf("after stale takeover holder=%v want mobileB", h)
+	}
+	hist := l.History()
+	if len(hist) != 2 {
+		t.Fatalf("History len: got %d want 2 (acquire + stale-takeover)", len(hist))
+	}
+	if hist[1].Reason != AcquireStaleTakeover {
+		t.Errorf("stale takeover reason: got %s want %s", hist[1].Reason, AcquireStaleTakeover)
+	}
+	if hist[1].PrevHolder != mobileA || hist[1].NewHolder != mobileB {
+		t.Errorf("stale takeover holders: prev=%v new=%v want %v -> %v",
+			hist[1].PrevHolder, hist[1].NewHolder, mobileA, mobileB)
+	}
+}
+
+func TestTryAcquire_ZeroClientRejected(t *testing.T) {
+	l := New()
+	if err := l.TryAcquire(zeroC); !errors.Is(err, ErrNotHolder) {
+		t.Errorf("zero ClientID TryAcquire: got %v want ErrNotHolder", err)
+	}
+	if _, held := l.Holder(); held {
+		t.Errorf("rejected zero TryAcquire should not have granted")
+	}
+}
+
+// --- ForceTakeover -------------------------------------------------------
+
+func TestForceTakeover_FromUnheld(t *testing.T) {
+	l, _ := newLockForTest(t, time.Now())
+	if err := l.ForceTakeover(mobileA); err != nil {
+		t.Fatalf("ForceTakeover on unheld: %v", err)
+	}
+	hist := l.History()
+	if len(hist) != 1 || hist[0].Reason != AcquireForce {
+		t.Errorf("ForceTakeover history: got %+v", hist)
+	}
+}
+
+func TestForceTakeover_FromActiveHolder(t *testing.T) {
+	l, _ := newLockForTest(t, time.Now())
+	_ = l.TryAcquire(mobileA)
+	if err := l.ForceTakeover(terminalA); err != nil {
+		t.Fatalf("force takeover from active holder: %v", err)
+	}
+	h, _ := l.Holder()
+	if !h.Equal(terminalA) {
+		t.Errorf("after force takeover holder=%v want terminalA", h)
+	}
+	hist := l.History()
+	if len(hist) != 2 || hist[1].Reason != AcquireForce {
+		t.Errorf("force takeover history: got %+v", hist)
+	}
+	if hist[1].PrevHolder != mobileA {
+		t.Errorf("force takeover prevHolder: got %v want mobileA", hist[1].PrevHolder)
+	}
+}
+
+func TestForceTakeover_BySameHolderSlidesWindow(t *testing.T) {
+	l, clk := newLockForTest(t, time.Now())
+	_ = l.TryAcquire(mobileA)
+	clk.Advance(40 * time.Second)
+	beforeLen := len(l.History())
+	if err := l.ForceTakeover(mobileA); err != nil {
+		t.Fatalf("force by same holder: %v", err)
+	}
+	if len(l.History()) != beforeLen {
+		t.Errorf("force by same holder should not append history; got %d->%d", beforeLen, len(l.History()))
+	}
+	// Window must have slid: advance 50s more (total 90s past acquire,
+	// but only 50s past force) — must still be active.
+	clk.Advance(50 * time.Second)
+	if err := l.TryAcquire(mobileB); !errors.Is(err, ErrInUse) {
+		t.Errorf("force-takeover by same holder must slide window; got %v", err)
+	}
+}
+
+func TestForceTakeover_ZeroClientRejected(t *testing.T) {
+	l := New()
+	if err := l.ForceTakeover(zeroC); !errors.Is(err, ErrNotHolder) {
+		t.Errorf("zero ForceTakeover: got %v want ErrNotHolder", err)
+	}
+}
+
+// --- Touch ---------------------------------------------------------------
+
+func TestTouch_HolderSlidesWindow(t *testing.T) {
+	l, clk := newLockForTest(t, time.Now())
+	_ = l.TryAcquire(mobileA)
+	clk.Advance(50 * time.Second)
+	if err := l.Touch(mobileA); err != nil {
+		t.Fatalf("Touch by holder: %v", err)
+	}
+	clk.Advance(40 * time.Second) // total 90s past acquire, 40s past Touch
+	// Holder should still be mobileA — Touch slid window.
+	if _, held := l.Holder(); !held {
+		t.Errorf("Touch must slide auto-release window")
+	}
+}
+
+func TestTouch_NonHolderRejected(t *testing.T) {
+	l := New()
+	_ = l.TryAcquire(mobileA)
+	if err := l.Touch(mobileB); !errors.Is(err, ErrNotHolder) {
+		t.Errorf("Touch by non-holder: got %v want ErrNotHolder", err)
+	}
+	if err := l.Touch(zeroC); !errors.Is(err, ErrNotHolder) {
+		t.Errorf("Touch by zero: got %v want ErrNotHolder", err)
+	}
+}
+
+func TestTouch_OnUnheldRejected(t *testing.T) {
+	l := New()
+	if err := l.Touch(mobileA); !errors.Is(err, ErrNotHolder) {
+		t.Errorf("Touch on unheld: got %v want ErrNotHolder", err)
+	}
+}
+
+// --- Release -------------------------------------------------------------
+
+func TestRelease_Holder(t *testing.T) {
+	l, _ := newLockForTest(t, time.Now())
+	_ = l.TryAcquire(mobileA)
+	if err := l.Release(mobileA); err != nil {
+		t.Fatalf("Release by holder: %v", err)
+	}
+	if _, held := l.Holder(); held {
+		t.Errorf("after Release lock should be unheld")
+	}
+	hist := l.History()
+	if len(hist) != 2 {
+		t.Fatalf("History len: got %d want 2", len(hist))
+	}
+	if hist[1].Reason != ReleaseExplicit {
+		t.Errorf("Release reason: got %s want %s", hist[1].Reason, ReleaseExplicit)
+	}
+	if hist[1].PrevHolder != mobileA || hist[1].NewHolder != zeroC {
+		t.Errorf("Release event holders: prev=%v new=%v", hist[1].PrevHolder, hist[1].NewHolder)
+	}
+}
+
+func TestRelease_NonHolderRejected(t *testing.T) {
+	l := New()
+	_ = l.TryAcquire(mobileA)
+	if err := l.Release(mobileB); !errors.Is(err, ErrNotHolder) {
+		t.Errorf("Release by non-holder: got %v want ErrNotHolder", err)
+	}
+	// State unchanged.
+	if h, _ := l.Holder(); !h.Equal(mobileA) {
+		t.Errorf("rejected Release must not mutate holder")
+	}
+}
+
+func TestRelease_OnUnheld(t *testing.T) {
+	l := New()
+	if err := l.Release(mobileA); !errors.Is(err, ErrNotHolder) {
+		t.Errorf("Release on unheld: got %v want ErrNotHolder", err)
+	}
+}
+
+// --- Sweep / Holder lazy reap --------------------------------------------
+
+func TestSweep_FiresOnStaleHolder(t *testing.T) {
+	l, clk := newLockForTest(t, time.Now())
+	_ = l.TryAcquire(mobileA)
+	if l.Sweep() {
+		t.Errorf("Sweep on fresh holder should be no-op")
+	}
+	clk.Advance(61 * time.Second)
+	if !l.Sweep() {
+		t.Errorf("Sweep on stale holder should fire")
+	}
+	if _, held := l.Holder(); held {
+		t.Errorf("after Sweep lock should be unheld")
+	}
+	hist := l.History()
+	if len(hist) != 2 || hist[1].Reason != ReleaseAuto {
+		t.Errorf("Sweep history: got %+v want last reason=%s", hist, ReleaseAuto)
+	}
+}
+
+func TestSweep_NoOpWhenUnheld(t *testing.T) {
+	l := New()
+	if l.Sweep() {
+		t.Errorf("Sweep on unheld should be no-op")
+	}
+}
+
+func TestSweep_Idempotent(t *testing.T) {
+	l, clk := newLockForTest(t, time.Now())
+	_ = l.TryAcquire(mobileA)
+	clk.Advance(61 * time.Second)
+	if !l.Sweep() {
+		t.Fatalf("first Sweep should fire")
+	}
+	if l.Sweep() {
+		t.Errorf("second Sweep should be no-op (already reaped)")
+	}
+}
+
+func TestHolder_LazyReapsStale(t *testing.T) {
+	// Holder() also reaps — needed so callers checking IsHolder before
+	// proceeding don't see a stale "yes" right after the window expires.
+	l, clk := newLockForTest(t, time.Now())
+	_ = l.TryAcquire(mobileA)
+	clk.Advance(61 * time.Second)
+	if _, held := l.Holder(); held {
+		t.Errorf("Holder() must reap stale holder")
+	}
+	if l.IsHolder(mobileA) {
+		t.Errorf("IsHolder() must reap stale holder")
+	}
+	// Auto-release event recorded.
+	hist := l.History()
+	if len(hist) != 2 || hist[1].Reason != ReleaseAuto {
+		t.Errorf("lazy reap should append auto-release event; got %+v", hist)
+	}
+}
+
+// --- LastWriteAt ---------------------------------------------------------
+
+func TestLastWriteAt_TracksTouch(t *testing.T) {
+	l, clk := newLockForTest(t, time.Now())
+	_ = l.TryAcquire(mobileA)
+	t0 := l.LastWriteAt()
+	if t0.IsZero() {
+		t.Fatalf("LastWriteAt zero after acquire")
+	}
+	clk.Advance(10 * time.Second)
+	if err := l.Touch(mobileA); err != nil {
+		t.Fatalf("Touch: %v", err)
+	}
+	t1 := l.LastWriteAt()
+	if !t1.After(t0) {
+		t.Errorf("Touch must advance LastWriteAt; got t0=%v t1=%v", t0, t1)
+	}
+}
+
+func TestLastWriteAt_ZeroWhenUnheld(t *testing.T) {
+	l := New()
+	if !l.LastWriteAt().IsZero() {
+		t.Errorf("unheld LastWriteAt should be zero")
+	}
+	_ = l.TryAcquire(mobileA)
+	_ = l.Release(mobileA)
+	if !l.LastWriteAt().IsZero() {
+		t.Errorf("after Release LastWriteAt should be zero")
+	}
+}
+
+// --- History defensiveness -----------------------------------------------
+
+func TestHistory_ReturnsCopy(t *testing.T) {
+	l := New()
+	_ = l.TryAcquire(mobileA)
+	hist := l.History()
+	if len(hist) != 1 {
+		t.Fatalf("History len: got %d want 1", len(hist))
+	}
+	hist[0].Reason = "tamper"
+	again := l.History()
+	if again[0].Reason != AcquireFirstByte {
+		t.Errorf("History return must be a copy; mutation leaked: got %s", again[0].Reason)
+	}
+}
+
+// --- Concurrency --------------------------------------------------------
+
+// TestConcurrentAcquire stresses the contended-acquire path under -race.
+// One winner, all losers see ErrInUse or stale-takeover (never panic /
+// inconsistent state).
+func TestConcurrentAcquire(t *testing.T) {
+	l := New()
+	const N = 32
+	var wg sync.WaitGroup
+	wg.Add(N)
+	results := make(chan error, N)
+	for i := 0; i < N; i++ {
+		i := i
+		go func() {
+			defer wg.Done()
+			c := ClientID{Kind: KindMobile, DeviceID: idForN(i)}
+			results <- l.TryAcquire(c)
+		}()
+	}
+	wg.Wait()
+	close(results)
+	wins := 0
+	losses := 0
+	for err := range results {
+		switch {
+		case err == nil:
+			wins++
+		case errors.Is(err, ErrInUse):
+			losses++
+		default:
+			t.Errorf("unexpected error from concurrent TryAcquire: %v", err)
+		}
+	}
+	if wins != 1 {
+		t.Errorf("concurrent TryAcquire: got %d winners, want exactly 1", wins)
+	}
+	if wins+losses != N {
+		t.Errorf("counts mismatch: wins=%d losses=%d total=%d", wins, losses, N)
+	}
+	// State consistent.
+	if _, held := l.Holder(); !held {
+		t.Errorf("after concurrent TryAcquire lock should be held")
+	}
+	hist := l.History()
+	// Exactly one acquire entry — no spurious extras from contention.
+	if len(hist) != 1 {
+		t.Errorf("concurrent: history len=%d want 1", len(hist))
+	}
+}
+
+func idForN(i int) string {
+	const hex = "0123456789abcdef"
+	return string([]byte{hex[(i>>4)&0xf], hex[i&0xf]})
+}
+
+// TestConcurrentForceTakeover validates force-takeover is well-ordered:
+// final holder must equal one of the participants and history length =
+// 1 (initial acquire) + N (each force-takeover) since each force always
+// records.
+func TestConcurrentForceTakeover(t *testing.T) {
+	l := New()
+	_ = l.TryAcquire(mobileA)
+	const N = 16
+	var wg sync.WaitGroup
+	wg.Add(N)
+	for i := 0; i < N; i++ {
+		i := i
+		go func() {
+			defer wg.Done()
+			c := ClientID{Kind: KindTerminal, DeviceID: idForN(i)}
+			_ = l.ForceTakeover(c)
+		}()
+	}
+	wg.Wait()
+	hist := l.History()
+	// 1 initial acquire + N force takeovers = N+1.
+	if len(hist) != N+1 {
+		t.Errorf("force-takeover history: got %d want %d", len(hist), N+1)
+	}
+	// All entries after the first must be AcquireForce.
+	for i, ev := range hist[1:] {
+		if ev.Reason != AcquireForce {
+			t.Errorf("history[%d].Reason: got %s want %s", i+1, ev.Reason, AcquireForce)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- Implements Epic #3 sub-task #6 — Lock state machine in `internal/lock/`. Single-layer lock + 60s auto-release window + force takeover, per spec §8 / §11.D.
- API: `TryAcquire / ForceTakeover / Touch / Release / Sweep / Holder / IsHolder / LastWriteAt / History`. Sentinel errors `ErrInUse`, `ErrNotHolder`. Defaults: `60s` auto-release window.
- Foundation for: terminal attach, mobile attach RPC, mode-switch RPC, audit-log writer. (File persistence is intentionally deferred to the daemon — daemon owns FS layout and atomic-write story.)
- Bumps Go toolchain `1.24.6 → 1.25.0` (workspace-wide; aligns with `e2e-c1-crypto` PR).
- Updates `.workspace/memory/local/v1-epics.md` with full Epic #3 sub-task status table (3 partial from gh-13 + 1 done now + 8 remaining) so the next slice has clear context.

## Test plan

- [x] `go test ./internal/lock/...` — 26 tests passing
- [x] `go test -race ./...` — clean (concurrent stress tests included)
- [x] `go vet ./...` — clean
- [x] Full repo `go test ./...` — green

## Open follow-ups (in v1-epics ledger)

1. **Audit-log file persistence**: caller should drain `History()` after each state change and append to `~/.tether/users/default/sessions/<id>/lock.log`. To be wired in daemon-side ticket.
2. **Mobile force-takeover UI confirmation gate**: lives in Epic #6 App UI. The daemon RPC handler may want defense-in-depth re-check when wiring lands.
3. **Next slice candidates**: sub-task #4 (JSONL watcher + mapper, biggest LOC cluster, unblocks #11) or #2 (daemon main/watchdog skeleton, small + foundational).