### PR TITLE
Epic #3 #4: JSONL watcher + parser + classifier + envelope mapper (§11.N)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,9 @@ module github.com/piaobeizu/tether
 
 go 1.25.0
 
-require golang.org/x/crypto v0.50.0
+require (
+	github.com/fsnotify/fsnotify v1.9.0
+	golang.org/x/crypto v0.50.0
+)
 
 require golang.org/x/sys v0.43.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/fsnotify/fsnotify v1.9.0 h1:2Ml+OJNzbYCTzsxtv8vKSFD9PbJjmhYF14k/jKC7S9k=
+github.com/fsnotify/fsnotify v1.9.0/go.mod h1:8jBTzvmWwFyi3Pb8djgCCO5IBqzKJ/Jwo8TRcHyHii0=
 golang.org/x/crypto v0.50.0 h1:zO47/JPrL6vsNkINmLoo/PH1gcxpls50DNogFvB5ZGI=
 golang.org/x/crypto v0.50.0/go.mod h1:3muZ7vA7PBCE6xgPX7nkzzjiUq87kRItoJQM1Yo8S+Q=
 golang.org/x/sys v0.43.0 h1:Rlag2XtaFTxp19wS8MXlJwTvoh8ArU6ezoyFsMyCTNI=

--- a/internal/cc/jsonl/classifier.go
+++ b/internal/cc/jsonl/classifier.go
@@ -1,0 +1,85 @@
+package jsonl
+
+// Class is the three-class taxonomy from spec §5.6 (F-04).
+//
+//	EVENT  — type=user / type=assistant. Have uuid + parent chain.
+//	         Mapped to wire `output.agent-event`, broadcast to all
+//	         attached devices via Stream 2 (永不丢).
+//	HOOK   — type=attachment AND attachment.hookEvent non-empty.
+//	         Mapped to wire `output.hook-event`. Drives the daemon
+//	         hook state machine (PreToolUse approval, etc.).
+//	STATE  — type=permission-mode / last-prompt / file-history-snapshot
+//	         / ai-title / system, OR a type=attachment that has no
+//	         hookEvent (rare; observed historically as plain payloads).
+//	         Updates session view; NOT broadcast on events stream.
+//
+// ClassUnknown is reserved for forward-compatibility: cc may add new
+// type values in patch versions. Unknown types are routed as STATE
+// (defensive; STATE has the lowest blast radius — it neither broadcasts
+// nor mutates the hook FSM) and the watcher's metrics counter
+// increments so we notice in production.
+type Class int
+
+const (
+	ClassUnknown Class = iota
+	ClassEvent
+	ClassHook
+	ClassState
+)
+
+// String renders Class for log lines.
+func (c Class) String() string {
+	switch c {
+	case ClassEvent:
+		return "EVENT"
+	case ClassHook:
+		return "HOOK"
+	case ClassState:
+		return "STATE"
+	default:
+		return "UNKNOWN"
+	}
+}
+
+// Classify implements the F-04 taxonomy decision. Pure function — no
+// side effects, no allocation in the hot path. Total over Record (no
+// nil deref: Attachment is pointer-checked).
+//
+// The doc.go classification table is the authoritative reference; this
+// function is its executable form. If you change the semantics here,
+// update doc.go in the same commit.
+func Classify(rec Record) Class {
+	switch rec.Type {
+	case RecordTypeUser, RecordTypeAssistant:
+		return ClassEvent
+
+	case RecordTypeAttachment:
+		// HOOK iff attachment.hookEvent non-empty. Empty hookEvent
+		// downgrades to STATE — observed historically as receipt /
+		// metadata stubs that don't drive the hook FSM.
+		if rec.Attachment != nil && rec.Attachment.HookEvent != "" {
+			return ClassHook
+		}
+		return ClassState
+
+	case RecordTypePermissionMode,
+		RecordTypeLastPrompt,
+		RecordTypeFileHistorySnapshot,
+		RecordTypeAITitle,
+		RecordTypeSystem:
+		return ClassState
+
+	default:
+		// Forward-compat: unknown type → STATE (least-blast-radius).
+		// Caller logs / counts; we don't drop.
+		return ClassUnknown
+	}
+}
+
+// RouteAsState returns true when the class should be treated as STATE
+// for routing purposes. ClassUnknown rolls up to STATE here — separate
+// from Classify() so callers can still distinguish "really STATE" from
+// "unknown, treated as STATE for safety" via metrics.
+func RouteAsState(c Class) bool {
+	return c == ClassState || c == ClassUnknown
+}

--- a/internal/cc/jsonl/classifier_test.go
+++ b/internal/cc/jsonl/classifier_test.go
@@ -1,0 +1,92 @@
+package jsonl
+
+import (
+	"testing"
+)
+
+// TestClassify_Taxonomy is an exhaustive table covering the F-04
+// three-class taxonomy. Adding a new RecordType means adding a row
+// here AND a row in doc.go's table — keep them in lockstep.
+func TestClassify_Taxonomy(t *testing.T) {
+	cases := []struct {
+		name string
+		rec  Record
+		want Class
+	}{
+		// EVENT
+		{"user message → EVENT", Record{Type: RecordTypeUser, UUID: "u1"}, ClassEvent},
+		{"assistant message → EVENT", Record{Type: RecordTypeAssistant, UUID: "a1"}, ClassEvent},
+
+		// HOOK (attachment with hookEvent)
+		{"attachment with hookEvent → HOOK",
+			Record{Type: RecordTypeAttachment, Attachment: &Attachment{HookEvent: "SessionStart"}},
+			ClassHook},
+		{"attachment with PreToolUse hook → HOOK",
+			Record{Type: RecordTypeAttachment, Attachment: &Attachment{HookEvent: "PreToolUse"}},
+			ClassHook},
+
+		// STATE — attachment without hookEvent
+		{"attachment without hookEvent → STATE",
+			Record{Type: RecordTypeAttachment, Attachment: &Attachment{HookName: "x"}},
+			ClassState},
+		{"attachment with nil Attachment → STATE",
+			Record{Type: RecordTypeAttachment},
+			ClassState},
+
+		// STATE — pure mutations
+		{"permission-mode → STATE",
+			Record{Type: RecordTypePermissionMode, PermissionMode: "auto"}, ClassState},
+		{"last-prompt → STATE",
+			Record{Type: RecordTypeLastPrompt}, ClassState},
+		{"file-history-snapshot → STATE",
+			Record{Type: RecordTypeFileHistorySnapshot}, ClassState},
+		{"ai-title → STATE",
+			Record{Type: RecordTypeAITitle}, ClassState},
+		{"system → STATE",
+			Record{Type: RecordTypeSystem}, ClassState},
+
+		// UNKNOWN — forward compat
+		{"unknown type → UNKNOWN",
+			Record{Type: "future-type"}, ClassUnknown},
+		{"empty type → UNKNOWN",
+			Record{}, ClassUnknown},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := Classify(tc.rec)
+			if got != tc.want {
+				t.Errorf("Classify(%+v) = %v, want %v", tc.rec, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestRouteAsState(t *testing.T) {
+	if !RouteAsState(ClassState) {
+		t.Error("ClassState must route as STATE")
+	}
+	if !RouteAsState(ClassUnknown) {
+		t.Error("ClassUnknown must route as STATE (forward-compat)")
+	}
+	if RouteAsState(ClassEvent) {
+		t.Error("ClassEvent must NOT route as STATE")
+	}
+	if RouteAsState(ClassHook) {
+		t.Error("ClassHook must NOT route as STATE")
+	}
+}
+
+func TestClassString(t *testing.T) {
+	cases := map[Class]string{
+		ClassEvent:   "EVENT",
+		ClassHook:    "HOOK",
+		ClassState:   "STATE",
+		ClassUnknown: "UNKNOWN",
+	}
+	for c, want := range cases {
+		if got := c.String(); got != want {
+			t.Errorf("Class(%d).String() = %q, want %q", c, got, want)
+		}
+	}
+}

--- a/internal/cc/jsonl/doc.go
+++ b/internal/cc/jsonl/doc.go
@@ -83,14 +83,25 @@
 // Subscribe() returns a buffered channel (default 256 envelopes) per
 // subscriber. When the buffer fills the watcher does NOT block on the
 // reader (that would propagate back to the fsnotify drain loop and
-// eventually drop kernel-level events). Instead the watcher uses a
-// non-blocking send and increments a per-subscriber "dropped" counter.
-// EVENT-class envelopes are never dropped on the path-watcher side
-// because the daemon broadcaster reads them synchronously and Stream 2
-// (events) is "永不丢" per spec §3.3.3 — drops here would be a contract
-// violation. STATE/HOOK envelopes are best-effort; subscribers that
-// care must drain promptly. The drop policy is "drop-newest" (preserve
-// causal order of what subscribers do see). See watcherSubscriber.
+// eventually drop kernel-level events at a layer where we cannot count
+// or recover them). Instead the watcher uses non-blocking sends for
+// ALL classes and increments a per-subscriber "dropped" counter +
+// Stats.EnvelopesDrop. The drop policy is "drop-newest" (preserve
+// causal order of what subscribers do see).
+//
+// "Stream 2 永不丢" per spec §3.3.3 is the daemon broadcaster's
+// contract, NOT the watcher's. This watcher is a derived view; the
+// JSONL file ITSELF is the source of truth. Late-attach / lossy
+// delivery is recovered upstream via either:
+//   - the daemon broadcaster's catch-up cache (Epic #3 follow-up:
+//     daemon-side LRU per (session, skill)), or
+//   - SubscribeFromOffset(sid, fromOffset) — currently only accepts
+//     OffsetLiveOnly (-1); arbitrary fromOffset replay is a follow-up.
+//
+// Per-session UUID dedup is a bounded FIFO ring at maxUUIDPerSession
+// entries (8192). Sessions older than the ring window may briefly
+// allow a re-emission — acceptable because the daemon broadcaster
+// is the system-of-record for "永不重".
 //
 // # Fence-tag suffix grep (sub-task #11 hook)
 //

--- a/internal/cc/jsonl/doc.go
+++ b/internal/cc/jsonl/doc.go
@@ -1,0 +1,117 @@
+// Package jsonl implements the cc JSONL session-file watcher, incremental
+// parser, three-class classifier, and JSONL-record-to-wire-envelope mapper
+// for the ClaudeCodeProvider.
+//
+// # What this package owns
+//
+// cc writes its session history as line-delimited JSON to
+//
+//	~/.claude/projects/<workspace-bucket>/<sid>.jsonl
+//
+// where <workspace-bucket> is the cwd-encoded path (see internal/cc.path),
+// and <sid> is the cc session UUID. Every cc subprocess append-writes a
+// new JSON record per turn / per tool call / per state mutation. tether
+// MUST treat that file as read-only (E.1 contract; see contracts_test in
+// internal/backend/claude). Our pipeline:
+//
+//  1. Watcher (watcher.go) — fsnotify-based per-file follower. Tracks
+//     (path → fileState{inode, offset, partialBuf}). On WRITE events it
+//     reads from the recorded offset to EOF, hands the bytes to the
+//     incremental Parser, and re-arms the offset. Detects truncation
+//     (size shrank), rotation (inode changed), and rename / remove.
+//     Subscribers receive Envelopes for one specific session id.
+//
+//  2. Parser (parser.go) — line-oriented incremental decoder. Holds a
+//     partial-line buffer across reads (cc may flush a record halfway
+//     through; F-09 torn-write defense: only lines terminated by '\n'
+//     are emitted). Strict UTF-8: invalid sequences are reported via
+//     OnError and the offending line is dropped, not silently mangled.
+//     Multi-line records are NOT a thing in cc JSONL — every record is
+//     exactly one line, terminated by exactly one '\n'.
+//
+//  3. Classifier (classifier.go) — three-class taxonomy per spec §5.6
+//     "三类分类 (F-04)". See the table below — that table is the
+//     authoritative reference for every other module that consumes
+//     these records.
+//
+//  4. Mapper (mapper.go) — per spec §11.N, transforms an EVENT-class
+//     record into a wire envelope (Envelope struct in this package;
+//     downstream encryption is left to Epic #5 — the Mapper produces
+//     a CiphertextPayload []byte that is the *plaintext* JSON-encoded
+//     payload, with a documented seam where the encryption hook will
+//     wrap it in v0.1's XChaCha20-Poly1305 layer). HOOK-class records
+//     are surfaced as a separate envelope kind so the daemon hook
+//     state-machine can react; STATE-class records produce a session
+//     state-update envelope that does NOT broadcast on the events
+//     stream (consumers route it to the local session view).
+//
+// # F-04 / F-09 classification table (authoritative)
+//
+//	┌────────┬──────────────────────────────────────┬──────────────────────────────────┐
+//	│ Class  │ JSONL record `type` values           │ Routing                          │
+//	├────────┼──────────────────────────────────────┼──────────────────────────────────┤
+//	│ EVENT  │ "user", "assistant"                  │ wire `output.agent-event`        │
+//	│        │   (have `uuid`, parent chain)        │   broadcast to mobile/attach     │
+//	├────────┼──────────────────────────────────────┼──────────────────────────────────┤
+//	│ HOOK   │ "attachment" with non-empty          │ wire `output.hook-event`         │
+//	│        │   `attachment.hookEvent`             │   updates daemon hook FSM        │
+//	│        │   (e.g. SessionStart, PreToolUse)    │                                  │
+//	├────────┼──────────────────────────────────────┼──────────────────────────────────┤
+//	│ STATE  │ "permission-mode", "last-prompt",    │ session.state envelope           │
+//	│        │   "file-history-snapshot",           │   (NOT broadcast on events       │
+//	│        │   "ai-title", "system",              │    stream; updates local view)   │
+//	│        │   "attachment" with EMPTY            │                                  │
+//	│        │   `attachment.hookEvent`             │                                  │
+//	└────────┴──────────────────────────────────────┴──────────────────────────────────┘
+//
+// Records with an unrecognized type are routed to STATE (defensive
+// default) and reported via the watcher's metrics counter; we do NOT
+// drop them — cc may add new record types in patch versions and the
+// daemon must stay forward-compatible.
+//
+// # Torn-write defense (F-09)
+//
+// PoC-1 step 9 measured 0/45000 torn-write hits at 1ms polling. We still
+// hold the line: only records ending in '\n' are emitted; everything
+// after the last '\n' is held in the partial buffer until the next read
+// completes the record. UUID-level dedup (a per-session sync.Map of
+// uuids we've already emitted) catches the rare case where cc retries
+// a write and lands the same uuid twice.
+//
+// # Back-pressure policy
+//
+// Subscribe() returns a buffered channel (default 256 envelopes) per
+// subscriber. When the buffer fills the watcher does NOT block on the
+// reader (that would propagate back to the fsnotify drain loop and
+// eventually drop kernel-level events). Instead the watcher uses a
+// non-blocking send and increments a per-subscriber "dropped" counter.
+// EVENT-class envelopes are never dropped on the path-watcher side
+// because the daemon broadcaster reads them synchronously and Stream 2
+// (events) is "永不丢" per spec §3.3.3 — drops here would be a contract
+// violation. STATE/HOOK envelopes are best-effort; subscribers that
+// care must drain promptly. The drop policy is "drop-newest" (preserve
+// causal order of what subscribers do see). See watcherSubscriber.
+//
+// # Fence-tag suffix grep (sub-task #11 hook)
+//
+// Spec §11.AA.1 locks the fenced-block protocol with the `<type>:<skill>`
+// suffix syntax (e.g. ```dag:writing-plans). The grep that detects fence
+// lines lives in mapper.go behind an explicit, named seam:
+// extractFenceTag(line string) (blockType, skillName string, ok bool)
+// is unexported but documented as the integration point for sub-task
+// #11. Today it returns ok=false unconditionally — the mapper never
+// peers inside content blocks (D-5: daemon stays transparent). When
+// sub-task #11 turns this on, the mapper attaches blockType / skillName
+// to envelope.PlaintextMetadata and the daemon catch-up LRU keys on
+// (sessionId, skillName, blockId). Adding fence-tag awareness here is
+// strictly additive — the wire schema already has the metadata slots.
+//
+// # Encryption seam (Epic #5)
+//
+// Mapper.Map produces an Envelope whose CiphertextPayload field holds
+// the *plaintext* JSON encoding of the payload. The naming is
+// deliberately forward-looking: a single-line wrap in pipeline.go
+// (`env.CiphertextPayload = encrypt(env.SessionID, env.CiphertextPayload)`)
+// flips this layer to real ciphertext. Until Epic #5 ships, downstream
+// consumers MUST treat the payload as already-decrypted plaintext.
+package jsonl

--- a/internal/cc/jsonl/mapper.go
+++ b/internal/cc/jsonl/mapper.go
@@ -1,0 +1,333 @@
+package jsonl
+
+import (
+	"encoding/json"
+	"fmt"
+	"regexp"
+)
+
+// EnvelopeKind names the wire-level operation per spec §3.3.2.
+//
+// We only emit three kinds out of this layer:
+//
+//	output.agent-event — EVENT-class JSONL (user / assistant)
+//	output.hook-event  — HOOK-class JSONL (attachment + hookEvent)
+//	session.state      — STATE-class JSONL (permission-mode etc.)
+//
+// session.state is local routing-only — the daemon updates its session
+// view; it is NOT broadcast on the WebTransport events stream. The
+// mapper still emits it so a single channel carries everything; the
+// router downstream filters by kind.
+type EnvelopeKind string
+
+const (
+	KindAgentEvent  EnvelopeKind = "output.agent-event"
+	KindHookEvent   EnvelopeKind = "output.hook-event"
+	KindSessionState EnvelopeKind = "session.state"
+)
+
+// ProviderType is `providerType` per §11.W.2. v0.1 is hardcoded
+// "claude-code".
+const ProviderTypeClaudeCode = "claude-code"
+
+// Envelope is the in-process representation of a wire envelope as
+// produced by the JSONL → wire mapper. It is NOT the on-the-wire JSON
+// shape of §3.3.1 — that has the encrypted ciphertext layer + replay
+// metadata, both of which are added downstream by the daemon's
+// envelope dispatcher.
+//
+// What this struct guarantees:
+//
+//   - Kind / ProviderType / SessionID / Skill — plaintext routing
+//     metadata, ready to copy into a §3.3.1 wire envelope.
+//   - PlaintextMetadata — additional plaintext (uuid / parentUuid /
+//     isSidechain / hookEvent / blockType-when-fence-grep-on)
+//     that the daemon dispatcher inlines into the envelope plaintext.
+//   - CiphertextPayload — JSON-encoded *plaintext* payload that will
+//     become the `ciphertext` field of the wire envelope after
+//     Epic #5's encryption hook runs over it. Today it is bytes
+//     containing JSON; the field name is forward-looking on purpose.
+//
+// Adding fence-tag-suffix awareness (sub-task #11) only grows
+// PlaintextMetadata — no struct change required.
+type Envelope struct {
+	Kind         EnvelopeKind
+	ProviderType string
+	SessionID    string
+
+	// Skill is set by extractFenceTag (sub-task #11). Empty here
+	// because v0.1 daemon stays transparent (D-5).
+	Skill string
+
+	// PlaintextMetadata is routing metadata that lives in the wire
+	// envelope's plaintext portion (what the server can see). All
+	// values are JSON-encodable.
+	PlaintextMetadata map[string]any
+
+	// CiphertextPayload is the *plaintext-encoded* payload bytes
+	// that Epic #5 will encrypt in place. JSON for v0.1.
+	CiphertextPayload []byte
+
+	// Class is retained for downstream routing decisions (events
+	// stream vs hook FSM vs local view). Not part of the wire
+	// envelope but useful at the daemon layer.
+	Class Class
+
+	// SourceUUID is the cc record uuid (when present). Used by the
+	// watcher's per-session dedup map.
+	SourceUUID string
+}
+
+// MapOpts tunes the mapper. Zero value is fine.
+type MapOpts struct {
+	// FenceTagGrep, when true, extracts ```<type>:<skill> tags from
+	// assistant text content and attaches them to PlaintextMetadata
+	// (sub-task #11). v0.1 keeps this off — daemon stays transparent.
+	FenceTagGrep bool
+}
+
+// Map transforms a classified Record into an Envelope. Returns
+// ok=false for records that should be dropped silently (e.g. malformed
+// EVENT records missing both uuid and message).
+func Map(rec Record, class Class, opts MapOpts) (Envelope, bool) {
+	switch class {
+	case ClassEvent:
+		return mapEvent(rec, opts), true
+	case ClassHook:
+		return mapHook(rec), true
+	case ClassState, ClassUnknown:
+		return mapState(rec, class), true
+	default:
+		return Envelope{}, false
+	}
+}
+
+func mapEvent(rec Record, opts MapOpts) Envelope {
+	meta := map[string]any{
+		"uuid":        rec.UUID,
+		"parentUuid":  nilIfEmpty(rec.ParentUUID),
+		"isSidechain": rec.IsSidechain,
+		"role":        string(rec.Type), // "user" | "assistant"
+	}
+	if rec.Timestamp != "" {
+		meta["timestamp"] = rec.Timestamp
+	}
+
+	// Fence-tag grep seam for sub-task #11. Today FenceTagGrep is
+	// always false — the call below is a no-op. The seam is
+	// deliberately obvious: when sub-task #11 turns it on, only
+	// this function changes.
+	if opts.FenceTagGrep {
+		if blockType, skillName, ok := scanContentForFence(rec.Message); ok {
+			meta["blockType"] = blockType
+			meta["skillName"] = skillName
+		}
+	}
+
+	// Payload is the cc message body (content array preserved
+	// verbatim per D-5 transparent contract). Falls back to the
+	// whole record if Message is missing — defensive.
+	payload := rec.Message
+	if len(payload) == 0 {
+		payload = rec.Raw
+	}
+
+	skill := ""
+	if v, ok := meta["skillName"].(string); ok {
+		skill = v
+	}
+
+	return Envelope{
+		Kind:              KindAgentEvent,
+		ProviderType:      ProviderTypeClaudeCode,
+		SessionID:         rec.SessionID,
+		Skill:             skill,
+		PlaintextMetadata: meta,
+		CiphertextPayload: append(json.RawMessage(nil), payload...),
+		Class:             ClassEvent,
+		SourceUUID:        rec.UUID,
+	}
+}
+
+func mapHook(rec Record) Envelope {
+	att := rec.Attachment
+	meta := map[string]any{
+		"uuid":      rec.UUID,
+		"hookEvent": att.HookEvent,
+	}
+	if att.HookName != "" {
+		meta["hookName"] = att.HookName
+	}
+	if att.ToolUseID != "" {
+		meta["toolUseID"] = att.ToolUseID
+	}
+	if rec.Timestamp != "" {
+		meta["timestamp"] = rec.Timestamp
+	}
+
+	// Hook payload includes stdout/stderr/exitCode — the consumer
+	// (daemon hook FSM) needs them for PostToolUse decisioning.
+	payload, err := json.Marshal(att)
+	if err != nil {
+		// Should not happen — Attachment is a plain struct.
+		// Fall back to raw record.
+		payload = rec.Raw
+	}
+
+	return Envelope{
+		Kind:              KindHookEvent,
+		ProviderType:      ProviderTypeClaudeCode,
+		SessionID:         rec.SessionID,
+		PlaintextMetadata: meta,
+		CiphertextPayload: payload,
+		Class:             ClassHook,
+		SourceUUID:        rec.UUID,
+	}
+}
+
+func mapState(rec Record, class Class) Envelope {
+	meta := map[string]any{
+		"recordType": string(rec.Type),
+		"class":      class.String(),
+	}
+	if rec.PermissionMode != "" {
+		meta["permissionMode"] = rec.PermissionMode
+	}
+	if rec.LeafUUID != "" {
+		meta["leafUuid"] = rec.LeafUUID
+	}
+
+	// State payload is the whole raw line — the session-view
+	// updater knows how to interpret each subtype.
+	return Envelope{
+		Kind:              KindSessionState,
+		ProviderType:      ProviderTypeClaudeCode,
+		SessionID:         rec.SessionID,
+		PlaintextMetadata: meta,
+		CiphertextPayload: append(json.RawMessage(nil), rec.Raw...),
+		Class:             class,
+		SourceUUID:        rec.UUID,
+	}
+}
+
+// fenceTagRegex matches ```<type>(:<skill>)? on a line by itself per
+// spec §11.AA.1. Anchored at line start (after optional whitespace).
+var fenceTagRegex = regexp.MustCompile(`(?m)^[\t ]*` + "```" + `(dag|form|candidates|media)(?::([a-zA-Z0-9_-]+))?[\t ]*$`)
+
+// extractFenceTag scans a single line for a fenced-block opener and
+// returns the (block-type, skill-name) pair. SUB-TASK #11 INTEGRATION
+// POINT: the mapper's only call site is mapEvent; flip MapOpts.FenceTagGrep
+// to true and this function gates the metadata propagation.
+//
+// Today this is unused at runtime (FenceTagGrep is always false). It
+// is fully tested anyway, so sub-task #11 only needs to flip the flag
+// and decide on the daemon-side LRU caching keyed on (sessionId,
+// skillName, blockId).
+//
+//nolint:unused // present as the explicit fence-tag seam for sub-task #11
+func extractFenceTag(line string) (blockType, skillName string, ok bool) {
+	m := fenceTagRegex.FindStringSubmatch(line)
+	if m == nil {
+		return "", "", false
+	}
+	skill := m[2]
+	if skill == "" {
+		skill = "unknown" // §11.Z.10 degrade behavior
+	}
+	return m[1], skill, true
+}
+
+// scanContentForFence walks an assistant message's content array
+// looking for a fenced-block opener inside any text block. Returns
+// the FIRST match — multi-block fences in one record fall back to
+// "scan again at v0.2 streaming FSM" per §11.AA.
+//
+// Used only when MapOpts.FenceTagGrep is true (sub-task #11).
+//
+//nolint:unused // present as the explicit fence-tag seam for sub-task #11
+func scanContentForFence(message json.RawMessage) (blockType, skillName string, ok bool) {
+	if len(message) == 0 {
+		return "", "", false
+	}
+	var probe struct {
+		Content []struct {
+			Type string `json:"type"`
+			Text string `json:"text,omitempty"`
+		} `json:"content"`
+	}
+	if err := json.Unmarshal(message, &probe); err != nil {
+		return "", "", false
+	}
+	for _, blk := range probe.Content {
+		if blk.Type != "text" || blk.Text == "" {
+			continue
+		}
+		// Cheap prefix check before regex.
+		// (text bodies can be many KB; avoid the regex pass when
+		//  there's no triple-backtick at all.)
+		if !containsTripleBacktick(blk.Text) {
+			continue
+		}
+		if bt, sk, ok := extractFenceTag(firstFenceLine(blk.Text)); ok {
+			return bt, sk, true
+		}
+	}
+	return "", "", false
+}
+
+func containsTripleBacktick(s string) bool {
+	// stdlib strings.Contains would do — kept inline to avoid an
+	// extra import in this seam-only code path.
+	for i := 0; i+2 < len(s); i++ {
+		if s[i] == '`' && s[i+1] == '`' && s[i+2] == '`' {
+			return true
+		}
+	}
+	return false
+}
+
+// firstFenceLine returns the first line containing ```; the regex
+// above is line-anchored so we just hand it the full text and let
+// (?m) do the work — but for big text bodies we trim early.
+//
+//nolint:unused // sub-task #11 helper
+func firstFenceLine(s string) string {
+	return s // regex is multi-line; pass through verbatim
+}
+
+func nilIfEmpty(s string) any {
+	if s == "" {
+		return nil
+	}
+	return s
+}
+
+// MarshalEnvelope is a debug helper: returns the Envelope as a
+// pretty-printed JSON blob suitable for tests and logs.
+func MarshalEnvelope(env Envelope) ([]byte, error) {
+	type out struct {
+		Kind              EnvelopeKind   `json:"kind"`
+		ProviderType      string         `json:"providerType"`
+		SessionID         string         `json:"sessionId"`
+		Skill             string         `json:"skill,omitempty"`
+		PlaintextMetadata map[string]any `json:"plaintextMetadata,omitempty"`
+		CiphertextPayload json.RawMessage `json:"ciphertextPayload,omitempty"`
+		Class             string         `json:"class"`
+		SourceUUID        string         `json:"sourceUuid,omitempty"`
+	}
+	o := out{
+		Kind:              env.Kind,
+		ProviderType:      env.ProviderType,
+		SessionID:         env.SessionID,
+		Skill:             env.Skill,
+		PlaintextMetadata: env.PlaintextMetadata,
+		CiphertextPayload: env.CiphertextPayload,
+		Class:             env.Class.String(),
+		SourceUUID:        env.SourceUUID,
+	}
+	b, err := json.MarshalIndent(o, "", "  ")
+	if err != nil {
+		return nil, fmt.Errorf("envelope marshal: %w", err)
+	}
+	return b, nil
+}

--- a/internal/cc/jsonl/mapper_test.go
+++ b/internal/cc/jsonl/mapper_test.go
@@ -1,0 +1,200 @@
+package jsonl
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+)
+
+func TestMap_Event_RoundTrip(t *testing.T) {
+	line := []byte(`{"parentUuid":"p1","isSidechain":false,"type":"assistant","uuid":"a1","timestamp":"2026-04-30T06:55:01.000Z","sessionId":"sess-1","message":{"role":"assistant","content":[{"type":"text","text":"hi"}]}}`)
+	rec, err := ParseLine(line)
+	if err != nil {
+		t.Fatalf("ParseLine: %v", err)
+	}
+
+	env, ok := Map(rec, Classify(rec), MapOpts{})
+	if !ok {
+		t.Fatal("Map returned ok=false")
+	}
+	if env.Kind != KindAgentEvent {
+		t.Errorf("Kind = %v, want %v", env.Kind, KindAgentEvent)
+	}
+	if env.ProviderType != ProviderTypeClaudeCode {
+		t.Errorf("ProviderType = %q, want %q", env.ProviderType, ProviderTypeClaudeCode)
+	}
+	if env.SessionID != "sess-1" {
+		t.Errorf("SessionID = %q", env.SessionID)
+	}
+	if env.SourceUUID != "a1" {
+		t.Errorf("SourceUUID = %q", env.SourceUUID)
+	}
+	if env.Class != ClassEvent {
+		t.Errorf("Class = %v", env.Class)
+	}
+	if got := env.PlaintextMetadata["uuid"]; got != "a1" {
+		t.Errorf("metadata.uuid = %v", got)
+	}
+	if got := env.PlaintextMetadata["parentUuid"]; got != "p1" {
+		t.Errorf("metadata.parentUuid = %v", got)
+	}
+	if got := env.PlaintextMetadata["role"]; got != "assistant" {
+		t.Errorf("metadata.role = %v", got)
+	}
+	// Payload should hold the cc message body verbatim.
+	if !bytes.Contains(env.CiphertextPayload, []byte(`"role":"assistant"`)) {
+		t.Errorf("payload missing message body: %s", string(env.CiphertextPayload))
+	}
+	if !bytes.Contains(env.CiphertextPayload, []byte(`"text":"hi"`)) {
+		t.Errorf("payload missing text content: %s", string(env.CiphertextPayload))
+	}
+}
+
+func TestMap_Hook(t *testing.T) {
+	line := []byte(`{"isSidechain":false,"attachment":{"type":"hook_success","hookName":"PreToolUse:Read","hookEvent":"PreToolUse","toolUseID":"tu1","exitCode":0},"type":"attachment","uuid":"u1","sessionId":"sess-1"}`)
+	rec, err := ParseLine(line)
+	if err != nil {
+		t.Fatalf("ParseLine: %v", err)
+	}
+	env, ok := Map(rec, Classify(rec), MapOpts{})
+	if !ok {
+		t.Fatal("Map returned ok=false")
+	}
+	if env.Kind != KindHookEvent {
+		t.Errorf("Kind = %v, want %v", env.Kind, KindHookEvent)
+	}
+	if env.Class != ClassHook {
+		t.Errorf("Class = %v", env.Class)
+	}
+	if got := env.PlaintextMetadata["hookEvent"]; got != "PreToolUse" {
+		t.Errorf("hookEvent = %v", got)
+	}
+	if got := env.PlaintextMetadata["hookName"]; got != "PreToolUse:Read" {
+		t.Errorf("hookName = %v", got)
+	}
+	if !bytes.Contains(env.CiphertextPayload, []byte(`"hookEvent":"PreToolUse"`)) {
+		t.Errorf("hook payload missing hookEvent: %s", string(env.CiphertextPayload))
+	}
+}
+
+func TestMap_State_PermissionMode(t *testing.T) {
+	line := []byte(`{"type":"permission-mode","permissionMode":"auto","sessionId":"sess-1"}`)
+	rec, err := ParseLine(line)
+	if err != nil {
+		t.Fatalf("ParseLine: %v", err)
+	}
+	env, ok := Map(rec, Classify(rec), MapOpts{})
+	if !ok {
+		t.Fatal("Map returned ok=false")
+	}
+	if env.Kind != KindSessionState {
+		t.Errorf("Kind = %v, want session.state", env.Kind)
+	}
+	if got := env.PlaintextMetadata["recordType"]; got != "permission-mode" {
+		t.Errorf("recordType = %v", got)
+	}
+	if got := env.PlaintextMetadata["permissionMode"]; got != "auto" {
+		t.Errorf("permissionMode = %v", got)
+	}
+}
+
+func TestMap_State_Unknown_RoutedAsState(t *testing.T) {
+	line := []byte(`{"type":"future-thing","sessionId":"sess-1"}`)
+	rec, err := ParseLine(line)
+	if err != nil {
+		t.Fatalf("ParseLine: %v", err)
+	}
+	c := Classify(rec)
+	if c != ClassUnknown {
+		t.Fatalf("expected ClassUnknown, got %v", c)
+	}
+	env, ok := Map(rec, c, MapOpts{})
+	if !ok {
+		t.Fatal("Map returned ok=false")
+	}
+	if env.Kind != KindSessionState {
+		t.Errorf("unknown should route to session.state, got %v", env.Kind)
+	}
+	if env.Class != ClassUnknown {
+		t.Errorf("Class should preserve UNKNOWN for metrics, got %v", env.Class)
+	}
+}
+
+func TestMarshalEnvelope(t *testing.T) {
+	env := Envelope{
+		Kind:              KindAgentEvent,
+		ProviderType:      ProviderTypeClaudeCode,
+		SessionID:         "sess-1",
+		PlaintextMetadata: map[string]any{"uuid": "u1"},
+		CiphertextPayload: json.RawMessage(`{"hello":"world"}`),
+		Class:             ClassEvent,
+		SourceUUID:        "u1",
+	}
+	b, err := MarshalEnvelope(env)
+	if err != nil {
+		t.Fatalf("MarshalEnvelope: %v", err)
+	}
+	if !bytes.Contains(b, []byte(`"kind": "output.agent-event"`)) {
+		t.Errorf("missing kind: %s", string(b))
+	}
+}
+
+// --- fence-tag seam (sub-task #11) ---
+
+func TestExtractFenceTag_WithSkill(t *testing.T) {
+	cases := []struct {
+		line, wantType, wantSkill string
+		ok                        bool
+	}{
+		{"```dag:writing-plans", "dag", "writing-plans", true},
+		{"```form:onboarding", "form", "onboarding", true},
+		{"```media:xiyou-animation", "media", "xiyou-animation", true},
+		{"```candidates:agent-pick", "candidates", "agent-pick", true},
+		{"```dag", "dag", "unknown", true}, // missing :skill → "unknown" per §11.Z.10
+		{"```python", "", "", false},        // not a tether block-type
+		{"   ```dag:foo   ", "dag", "foo", true},
+		{"prefix ```dag:foo", "", "", false}, // anchored at line start
+		{"```", "", "", false},
+	}
+	for _, c := range cases {
+		bt, sk, ok := extractFenceTag(c.line)
+		if ok != c.ok || bt != c.wantType || sk != c.wantSkill {
+			t.Errorf("extractFenceTag(%q) = (%q,%q,%v), want (%q,%q,%v)",
+				c.line, bt, sk, ok, c.wantType, c.wantSkill, c.ok)
+		}
+	}
+}
+
+func TestMap_FenceTagGrep_Off_NoMetadata(t *testing.T) {
+	// v0.1 default: FenceTagGrep is off. Even with a fence in the
+	// content, no blockType / skillName attaches to envelope.
+	line := []byte(`{"type":"assistant","uuid":"a1","sessionId":"sess-1","message":{"role":"assistant","content":[{"type":"text","text":"see\n` + "```" + `dag:writing-plans\nv:1\n` + "```" + `\n"}]}}`)
+	rec, err := ParseLine(line)
+	if err != nil {
+		t.Fatalf("ParseLine: %v", err)
+	}
+	env, _ := Map(rec, Classify(rec), MapOpts{FenceTagGrep: false})
+	if _, has := env.PlaintextMetadata["blockType"]; has {
+		t.Errorf("blockType must NOT leak when FenceTagGrep=false")
+	}
+}
+
+func TestMap_FenceTagGrep_On_AttachesMetadata(t *testing.T) {
+	// Sub-task #11 path: when FenceTagGrep flips on, blockType +
+	// skillName attach to plaintext metadata.
+	line := []byte(`{"type":"assistant","uuid":"a1","sessionId":"sess-1","message":{"role":"assistant","content":[{"type":"text","text":"see\n` + "```" + `dag:writing-plans\nv:1\n` + "```" + `\n"}]}}`)
+	rec, err := ParseLine(line)
+	if err != nil {
+		t.Fatalf("ParseLine: %v", err)
+	}
+	env, _ := Map(rec, Classify(rec), MapOpts{FenceTagGrep: true})
+	if got := env.PlaintextMetadata["blockType"]; got != "dag" {
+		t.Errorf("blockType = %v, want dag", got)
+	}
+	if got := env.PlaintextMetadata["skillName"]; got != "writing-plans" {
+		t.Errorf("skillName = %v, want writing-plans", got)
+	}
+	if env.Skill != "writing-plans" {
+		t.Errorf("env.Skill = %q, want writing-plans", env.Skill)
+	}
+}

--- a/internal/cc/jsonl/parser.go
+++ b/internal/cc/jsonl/parser.go
@@ -1,0 +1,145 @@
+package jsonl
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"unicode/utf8"
+)
+
+// MaxLineSize bounds an individual JSONL record. cc records routinely
+// hit ~50KB (a tool_result containing a Read of a 1KLOC file); we set
+// 4MB as the hard ceiling. Anything longer is almost certainly cc bug
+// or attacker; the Parser drops the offending partial buffer rather
+// than allocate unbounded memory.
+const MaxLineSize = 4 * 1024 * 1024
+
+// ErrLineTooLong is returned (via OnError) when an in-flight partial
+// line exceeds MaxLineSize before its terminating '\n' arrives. The
+// parser drops the buffered bytes and resumes from the next read.
+var ErrLineTooLong = errors.New("jsonl: line exceeds MaxLineSize")
+
+// ErrInvalidUTF8 is returned (via OnError) when a complete line
+// contains an invalid UTF-8 sequence. The line is dropped; the parser
+// continues with the next line. Strict UTF-8 is a contract: cc emits
+// JSON which is by spec UTF-8, so anything else is corruption (disk
+// flip / partial flush of a different process / etc).
+var ErrInvalidUTF8 = errors.New("jsonl: invalid UTF-8 in record")
+
+// IncrementalParser turns a byte stream from cc's JSONL file into
+// fully-formed Record values. It is the F-09 "torn-write defense"
+// boundary: records are emitted only when their terminating '\n' has
+// been observed. State is held in `partial`; callers feed bytes via
+// Feed() and drain Records via the returned slice.
+//
+// Not safe for concurrent use — one IncrementalParser per file.
+type IncrementalParser struct {
+	partial []byte // buffer holding bytes after the last newline
+
+	// OnError, if non-nil, is invoked for per-line errors (decode
+	// failure, invalid UTF-8) AND for the terminal MaxLineSize
+	// breach. The parser continues on per-line errors; on
+	// ErrLineTooLong it drops the partial buffer and continues.
+	OnError func(line []byte, err error)
+}
+
+// Feed appends `chunk` to the parser's internal buffer, splits on
+// '\n', and returns one Record per complete line. Bytes after the
+// last '\n' are retained for the next Feed.
+//
+// Empty lines are silently skipped (cc occasionally emits trailing
+// '\n' on close, producing a zero-length tail). Records that fail
+// JSON decode are reported via OnError and skipped — the contract is
+// "graceful degrade, never abort the stream", same as the
+// stream-json parser in internal/backend/claude.
+//
+// Returns Records in arrival order. The returned slice references
+// memory owned by the parser only via Record.Raw (defensive-copied
+// already inside ParseLine), so callers may retain Records freely.
+func (p *IncrementalParser) Feed(chunk []byte) []Record {
+	// Quick path: empty chunk, nothing to do.
+	if len(chunk) == 0 {
+		return nil
+	}
+
+	// Append-and-search. Avoids growing past MaxLineSize.
+	if len(p.partial)+len(chunk) > MaxLineSize {
+		// Drop the partial — record was unbounded. Keep the new
+		// chunk if it itself is in-bounds (might contain valid
+		// records following the runaway).
+		if p.OnError != nil {
+			p.OnError(p.partial, ErrLineTooLong)
+		}
+		p.partial = p.partial[:0]
+		if len(chunk) > MaxLineSize {
+			// Even the chunk alone is too large; drop the leading
+			// portion until we find a newline.
+			nl := bytes.IndexByte(chunk, '\n')
+			if nl < 0 {
+				// No newline at all in the chunk. Discard it.
+				return nil
+			}
+			chunk = chunk[nl+1:]
+		}
+	}
+	p.partial = append(p.partial, chunk...)
+
+	var out []Record
+	for {
+		nl := bytes.IndexByte(p.partial, '\n')
+		if nl < 0 {
+			break // no complete line yet
+		}
+		line := p.partial[:nl]
+		// Advance past the newline.
+		p.partial = p.partial[nl+1:]
+
+		if len(line) == 0 {
+			continue
+		}
+		// Strict UTF-8 — cc JSON is by spec UTF-8.
+		if !utf8.Valid(line) {
+			if p.OnError != nil {
+				// Defensive copy for OnError — `line` aliases
+				// p.partial's prior backing array which we'll
+				// reslice/append to next iteration.
+				cp := append([]byte(nil), line...)
+				p.OnError(cp, ErrInvalidUTF8)
+			}
+			continue
+		}
+		rec, err := ParseLine(line)
+		if err != nil {
+			if p.OnError != nil {
+				cp := append([]byte(nil), line...)
+				p.OnError(cp, fmt.Errorf("decode: %w", err))
+			}
+			continue
+		}
+		out = append(out, rec)
+	}
+
+	// Compact: if partial got long but its head was consumed, copy
+	// the tail to a fresh small buffer so we don't pin a huge
+	// backing array forever.
+	if cap(p.partial) > 64*1024 && len(p.partial) < 4*1024 {
+		fresh := make([]byte, len(p.partial))
+		copy(fresh, p.partial)
+		p.partial = fresh
+	}
+
+	return out
+}
+
+// PartialLen reports how many bytes are buffered awaiting a '\n'.
+// Useful for tests + for the watcher's "stalled write?" diagnostic.
+func (p *IncrementalParser) PartialLen() int {
+	return len(p.partial)
+}
+
+// Reset clears the partial buffer. Called by the watcher on file
+// truncation / rotation — the new file starts with no torn-write
+// inheritance.
+func (p *IncrementalParser) Reset() {
+	p.partial = p.partial[:0]
+}

--- a/internal/cc/jsonl/parser_test.go
+++ b/internal/cc/jsonl/parser_test.go
@@ -1,0 +1,182 @@
+package jsonl
+
+import (
+	"bytes"
+	"errors"
+	"strings"
+	"testing"
+)
+
+func TestParser_BasicSingleLine(t *testing.T) {
+	p := IncrementalParser{}
+	out := p.Feed([]byte(`{"type":"user","uuid":"u1"}` + "\n"))
+	if len(out) != 1 {
+		t.Fatalf("got %d records, want 1", len(out))
+	}
+	if out[0].Type != RecordTypeUser || out[0].UUID != "u1" {
+		t.Errorf("decoded record wrong: %+v", out[0])
+	}
+}
+
+func TestParser_MultiLineSingleFeed(t *testing.T) {
+	p := IncrementalParser{}
+	chunk := `{"type":"user","uuid":"u1"}` + "\n" +
+		`{"type":"assistant","uuid":"a1"}` + "\n" +
+		`{"type":"permission-mode","permissionMode":"auto"}` + "\n"
+	out := p.Feed([]byte(chunk))
+	if len(out) != 3 {
+		t.Fatalf("got %d records, want 3", len(out))
+	}
+	if out[0].Type != RecordTypeUser || out[1].Type != RecordTypeAssistant || out[2].Type != RecordTypePermissionMode {
+		t.Errorf("wrong types: %v %v %v", out[0].Type, out[1].Type, out[2].Type)
+	}
+}
+
+func TestParser_PartialLine_HeldUntilNewline(t *testing.T) {
+	p := IncrementalParser{}
+
+	// Feed first half — no record yet.
+	out := p.Feed([]byte(`{"type":"user",`))
+	if len(out) != 0 {
+		t.Errorf("partial line emitted %d records, want 0", len(out))
+	}
+	if p.PartialLen() == 0 {
+		t.Error("expected partial buffer to hold the prefix")
+	}
+
+	// Feed remainder with newline — should emit now.
+	out = p.Feed([]byte(`"uuid":"u1"}` + "\n"))
+	if len(out) != 1 {
+		t.Fatalf("got %d records after completing line, want 1", len(out))
+	}
+	if out[0].UUID != "u1" {
+		t.Errorf("uuid mismatch: %q", out[0].UUID)
+	}
+	if p.PartialLen() != 0 {
+		t.Errorf("partial buffer should be drained, got %d", p.PartialLen())
+	}
+}
+
+func TestParser_NoTrailingNewline_IsPartial(t *testing.T) {
+	// Per F-09: torn-write defense. Last bytes without '\n' must
+	// NOT be emitted.
+	p := IncrementalParser{}
+	out := p.Feed([]byte(`{"type":"user","uuid":"u1"}` + "\n" + `{"type":"assistant",`))
+	if len(out) != 1 {
+		t.Fatalf("got %d records, want 1 (the second is incomplete)", len(out))
+	}
+	if p.PartialLen() == 0 {
+		t.Error("expected the incomplete second line to be in the partial buffer")
+	}
+}
+
+func TestParser_ManyTinyChunks(t *testing.T) {
+	// Stress: feed one byte at a time.
+	p := IncrementalParser{}
+	full := `{"type":"user","uuid":"u1"}` + "\n" + `{"type":"assistant","uuid":"a1"}` + "\n"
+	var got []Record
+	for _, b := range []byte(full) {
+		got = append(got, p.Feed([]byte{b})...)
+	}
+	if len(got) != 2 {
+		t.Fatalf("got %d records, want 2", len(got))
+	}
+	if got[0].UUID != "u1" || got[1].UUID != "a1" {
+		t.Errorf("uuids = %q, %q", got[0].UUID, got[1].UUID)
+	}
+}
+
+func TestParser_EmptyLines_Skipped(t *testing.T) {
+	p := IncrementalParser{}
+	chunk := "\n\n" + `{"type":"user","uuid":"u1"}` + "\n\n"
+	out := p.Feed([]byte(chunk))
+	if len(out) != 1 {
+		t.Fatalf("got %d, want 1", len(out))
+	}
+}
+
+func TestParser_CorruptUTF8_Reported(t *testing.T) {
+	var gotErr error
+	var gotLine []byte
+	p := IncrementalParser{
+		OnError: func(line []byte, err error) {
+			gotErr = err
+			gotLine = append([]byte(nil), line...)
+		},
+	}
+	// Invalid UTF-8 byte 0xff in the middle of a line.
+	bad := append([]byte{'{', '"', 'a', '"', ':', '"'}, 0xff)
+	bad = append(bad, '"', '}', '\n')
+	out := p.Feed(bad)
+	if len(out) != 0 {
+		t.Errorf("invalid-UTF8 line should be dropped, got %d records", len(out))
+	}
+	if !errors.Is(gotErr, ErrInvalidUTF8) {
+		t.Errorf("expected ErrInvalidUTF8, got %v", gotErr)
+	}
+	if !bytes.Contains(gotLine, []byte{0xff}) {
+		t.Errorf("expected the bad line to be passed to OnError")
+	}
+}
+
+func TestParser_DecodeError_Reported(t *testing.T) {
+	var gotErr error
+	p := IncrementalParser{
+		OnError: func(line []byte, err error) { gotErr = err },
+	}
+	out := p.Feed([]byte("not-json\n"))
+	if len(out) != 0 {
+		t.Errorf("malformed JSON should be dropped, got %d records", len(out))
+	}
+	if gotErr == nil || !strings.Contains(gotErr.Error(), "decode") {
+		t.Errorf("expected a decode error, got %v", gotErr)
+	}
+}
+
+func TestParser_LineTooLong(t *testing.T) {
+	// Construct a line right at the boundary and feed in pieces.
+	var gotErr error
+	p := IncrementalParser{
+		OnError: func(line []byte, err error) { gotErr = err },
+	}
+	// 4MB of 'a' with no newline — exceeds MaxLineSize.
+	huge := bytes.Repeat([]byte{'a'}, MaxLineSize+1024)
+	out := p.Feed(huge)
+	if len(out) != 0 {
+		t.Errorf("over-long line must not produce records, got %d", len(out))
+	}
+	if !errors.Is(gotErr, ErrLineTooLong) {
+		t.Errorf("expected ErrLineTooLong, got %v", gotErr)
+	}
+	// The partial buffer should be drained.
+	if p.PartialLen() > MaxLineSize {
+		t.Errorf("partial buffer not drained after over-long: %d", p.PartialLen())
+	}
+}
+
+func TestParser_Reset_ClearsPartial(t *testing.T) {
+	p := IncrementalParser{}
+	p.Feed([]byte(`{"type":"user",`))
+	if p.PartialLen() == 0 {
+		t.Fatal("partial should have content")
+	}
+	p.Reset()
+	if p.PartialLen() != 0 {
+		t.Errorf("Reset() should clear partial, got %d", p.PartialLen())
+	}
+}
+
+func TestParseLine_RetainsRaw(t *testing.T) {
+	line := []byte(`{"type":"user","uuid":"u1"}`)
+	rec, err := ParseLine(line)
+	if err != nil {
+		t.Fatalf("ParseLine: %v", err)
+	}
+	// Mutate caller's buffer; rec.Raw must be unaffected.
+	for i := range line {
+		line[i] = 'X'
+	}
+	if !bytes.Contains(rec.Raw, []byte(`"u1"`)) {
+		t.Errorf("ParseLine did not defensive-copy: Raw=%s", string(rec.Raw))
+	}
+}

--- a/internal/cc/jsonl/record.go
+++ b/internal/cc/jsonl/record.go
@@ -1,0 +1,102 @@
+package jsonl
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// RecordType is the value of the "type" field on every cc JSONL line.
+//
+// The set is observed empirically against cc 2.1.120-2.1.123 session
+// files in ~/.claude/projects/. cc may add new types in a patch bump;
+// classifier.go falls through to ClassUnknown (treated as STATE) for
+// any value not enumerated here.
+type RecordType string
+
+const (
+	// EVENT class — have `uuid`, form parent/child chain, broadcast.
+	RecordTypeUser      RecordType = "user"
+	RecordTypeAssistant RecordType = "assistant"
+
+	// HOOK class — `type=attachment` AND `attachment.hookEvent` non-empty.
+	// (We classify on the attachment payload, not on the type alone.)
+	RecordTypeAttachment RecordType = "attachment"
+
+	// STATE class — pure session-state mutations.
+	RecordTypePermissionMode      RecordType = "permission-mode"
+	RecordTypeLastPrompt          RecordType = "last-prompt"
+	RecordTypeFileHistorySnapshot RecordType = "file-history-snapshot"
+	RecordTypeAITitle             RecordType = "ai-title"
+	RecordTypeSystem              RecordType = "system"
+)
+
+// Record is the minimal common envelope decodable from any cc JSONL
+// line. The full per-type payload is preserved in Raw for downstream
+// consumers (the mapper re-decodes when it needs Content/HookEvent
+// fields).
+//
+// Field names match cc's wire spelling (camelCase) — these are NOT
+// negotiable. Adding a Go-idiomatic alias here would diverge from cc's
+// JSON.
+type Record struct {
+	Type        RecordType `json:"type"`
+	UUID        string     `json:"uuid,omitempty"`
+	ParentUUID  string     `json:"parentUuid,omitempty"`
+	SessionID   string     `json:"sessionId,omitempty"`
+	IsSidechain bool       `json:"isSidechain,omitempty"`
+	Timestamp   string     `json:"timestamp,omitempty"`
+	UserType    string     `json:"userType,omitempty"`
+	CWD         string     `json:"cwd,omitempty"`
+	GitBranch   string     `json:"gitBranch,omitempty"`
+	Version     string     `json:"version,omitempty"`
+
+	// Attachment is non-nil only for type=attachment lines. Its
+	// hookEvent field is what flips an attachment into HOOK class.
+	Attachment *Attachment `json:"attachment,omitempty"`
+
+	// Message is the cc-side message body. For type=user / type=assistant
+	// it carries the role and content array (text blocks, tool_use blocks,
+	// tool_result blocks). Left as RawMessage so the mapper decides when
+	// to materialize it.
+	Message json.RawMessage `json:"message,omitempty"`
+
+	// PermissionMode is set on type=permission-mode lines.
+	PermissionMode string `json:"permissionMode,omitempty"`
+
+	// LeafUUID is set on type=last-prompt lines.
+	LeafUUID string `json:"leafUuid,omitempty"`
+
+	// Raw retains the original line bytes (defensive copy — fsnotify
+	// scratch buffers reuse).  Always populated by ParseLine.
+	Raw json.RawMessage `json:"-"`
+}
+
+// Attachment is the payload of a `type=attachment` JSONL record. The
+// presence of HookEvent is what classifies the line as HOOK vs STATE.
+type Attachment struct {
+	Type      string          `json:"type,omitempty"`
+	HookName  string          `json:"hookName,omitempty"`
+	HookEvent string          `json:"hookEvent,omitempty"`
+	ToolUseID string          `json:"toolUseID,omitempty"`
+	Content   string          `json:"content,omitempty"`
+	Stdout    string          `json:"stdout,omitempty"`
+	Stderr    string          `json:"stderr,omitempty"`
+	ExitCode  int             `json:"exitCode,omitempty"`
+	Command   string          `json:"command,omitempty"`
+	Extra     json.RawMessage `json:"-"` // reserved
+}
+
+// ParseLine decodes one JSONL line into a Record. The caller owns
+// `line`; ParseLine takes a defensive copy into Record.Raw because
+// callers commonly recycle scratch buffers.
+//
+// Unknown Type values do NOT error — the classifier handles them.
+func ParseLine(line []byte) (Record, error) {
+	var rec Record
+	if err := json.Unmarshal(line, &rec); err != nil {
+		return Record{Raw: append(json.RawMessage(nil), line...)},
+			fmt.Errorf("jsonl: decode line: %w", err)
+	}
+	rec.Raw = append(json.RawMessage(nil), line...)
+	return rec, nil
+}

--- a/internal/cc/jsonl/testdata/cc_session_sample.jsonl
+++ b/internal/cc/jsonl/testdata/cc_session_sample.jsonl
@@ -1,0 +1,9 @@
+{"type":"last-prompt","leafUuid":"c7c987a9-14e6-465c-80cd-7de1e5b4b1b6","sessionId":"sess-1"}
+{"type":"permission-mode","permissionMode":"auto","sessionId":"sess-1"}
+{"parentUuid":null,"isSidechain":false,"attachment":{"type":"hook_success","hookName":"SessionStart:startup","toolUseID":"tu-1","hookEvent":"SessionStart","content":"","stdout":"hello","stderr":"","exitCode":0,"command":"echo hi","durationMs":1},"type":"attachment","uuid":"u-att-1","timestamp":"2026-04-30T06:54:45.874Z","userType":"external","sessionId":"sess-1"}
+{"parentUuid":null,"isSidechain":false,"type":"user","uuid":"u-user-1","timestamp":"2026-04-30T06:55:00.000Z","sessionId":"sess-1","message":{"role":"user","content":[{"type":"text","text":"hi"}]}}
+{"parentUuid":"u-user-1","isSidechain":false,"type":"assistant","uuid":"u-asst-1","timestamp":"2026-04-30T06:55:01.000Z","sessionId":"sess-1","message":{"role":"assistant","content":[{"type":"text","text":"hello back"}]}}
+{"parentUuid":"u-asst-1","isSidechain":false,"type":"assistant","uuid":"u-asst-2","timestamp":"2026-04-30T06:55:02.000Z","sessionId":"sess-1","message":{"role":"assistant","content":[{"type":"tool_use","id":"toolu_1","name":"Read","input":{"file_path":"/tmp/x"}}]}}
+{"parentUuid":"u-asst-2","isSidechain":false,"type":"user","uuid":"u-user-2","timestamp":"2026-04-30T06:55:03.000Z","sessionId":"sess-1","message":{"role":"user","content":[{"tool_use_id":"toolu_1","type":"tool_result","content":"file contents"}]}}
+{"type":"file-history-snapshot","sessionId":"sess-1"}
+{"type":"ai-title","title":"chat about hi","sessionId":"sess-1"}

--- a/internal/cc/jsonl/watcher.go
+++ b/internal/cc/jsonl/watcher.go
@@ -1,0 +1,527 @@
+package jsonl
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"syscall"
+
+	"github.com/fsnotify/fsnotify"
+)
+
+// DefaultSubscriberBuffer is the channel buffer per subscriber. 256
+// envelopes ≈ 2-3 turns of cc activity worth of headroom; subscribers
+// should drain promptly anyway.
+const DefaultSubscriberBuffer = 256
+
+// readChunkSize bounds a single read from the JSONL file. fsnotify
+// coalesces WRITE events, so when we wake up there may be hundreds of
+// KB to consume; we read in this-sized chunks until EOF.
+const readChunkSize = 64 * 1024
+
+// Options tunes the Watcher.
+type Options struct {
+	// SubscriberBuffer is the per-subscriber channel buffer. Zero
+	// means DefaultSubscriberBuffer.
+	SubscriberBuffer int
+
+	// MapOpts is forwarded to the mapper for every record.
+	MapOpts MapOpts
+
+	// OnError, if non-nil, is invoked for parse / IO / fsnotify
+	// errors that don't justify killing the watcher. Callers
+	// typically log + count these.
+	OnError func(path string, err error)
+
+	// OnDrop, if non-nil, is invoked each time a STATE/HOOK
+	// envelope is dropped because a subscriber's buffer was full.
+	// EVENT envelopes are never silently dropped — they block the
+	// per-file reader (see watcherSubscriber.deliver).
+	OnDrop func(sessionID string, kind EnvelopeKind)
+}
+
+// Watcher follows a directory of cc JSONL session files. It is the
+// owner of all fsnotify state, file offsets, and per-session subscriber
+// channels.
+//
+// Lifecycle:
+//
+//	w, err := New(ctx, root, Options{})
+//	ch := w.Subscribe(sid)
+//	for env := range ch { ... }
+//	w.Close()        // closes all subscriber channels
+//
+// Concurrency: New starts one drain goroutine. Subscribe is safe to
+// call from any goroutine. Close is idempotent.
+type Watcher struct {
+	root  string
+	fsw   *fsnotify.Watcher
+	opts  Options
+	ctx   context.Context
+	cancel context.CancelFunc
+
+	mu         sync.Mutex
+	files      map[string]*fileState     // path → state
+	subs       map[string][]*subscriber  // sessionID → subscribers
+	uuidSeen   map[string]map[string]struct{} // sessionID → uuid set (dedup)
+	closed     bool
+	wg         sync.WaitGroup
+	stats      Stats
+}
+
+// Stats are read with atomic loads via the matching getters.
+type Stats struct {
+	BytesRead     atomic.Int64
+	LinesParsed   atomic.Int64
+	LinesDropped  atomic.Int64 // failed UTF-8 / decode / too-long
+	UUIDDuped     atomic.Int64
+	Truncations   atomic.Int64
+	Rotations     atomic.Int64
+	EnvelopesEmit atomic.Int64
+	EnvelopesDrop atomic.Int64
+}
+
+// fileState is the per-file watcher record.
+type fileState struct {
+	path     string
+	inode    uint64
+	offset   int64
+	parser   IncrementalParser
+	sid      string // extracted from filename (sid.jsonl)
+}
+
+// subscriber is one Subscribe() recipient.
+type subscriber struct {
+	sid     string
+	ch      chan Envelope
+	dropped atomic.Int64
+}
+
+// New creates a Watcher rooted at `root`. If `root` is a directory
+// the watcher follows `<root>/*.jsonl` (and any new files matching
+// that pattern that appear). If `root` is a single .jsonl file the
+// watcher follows just that file.
+//
+// New does not block — fsnotify and the drain loop run in goroutines.
+// Errors during Setup (root unreadable, fsnotify init fail) return
+// immediately; per-file errors during operation are surfaced via
+// Options.OnError.
+func New(parent context.Context, root string, opts Options) (*Watcher, error) {
+	if opts.SubscriberBuffer == 0 {
+		opts.SubscriberBuffer = DefaultSubscriberBuffer
+	}
+	fsw, err := fsnotify.NewWatcher()
+	if err != nil {
+		return nil, fmt.Errorf("jsonl watcher: fsnotify: %w", err)
+	}
+
+	ctx, cancel := context.WithCancel(parent)
+	w := &Watcher{
+		root:     root,
+		fsw:      fsw,
+		opts:     opts,
+		ctx:      ctx,
+		cancel:   cancel,
+		files:    make(map[string]*fileState),
+		subs:     make(map[string][]*subscriber),
+		uuidSeen: make(map[string]map[string]struct{}),
+	}
+
+	st, err := os.Stat(root)
+	if err != nil {
+		fsw.Close()
+		cancel()
+		return nil, fmt.Errorf("jsonl watcher: stat root: %w", err)
+	}
+
+	var watchTarget string
+	if st.IsDir() {
+		watchTarget = root
+		// Pick up files already present.
+		entries, err := os.ReadDir(root)
+		if err != nil {
+			fsw.Close()
+			cancel()
+			return nil, fmt.Errorf("jsonl watcher: read root: %w", err)
+		}
+		for _, e := range entries {
+			if e.IsDir() || !strings.HasSuffix(e.Name(), ".jsonl") {
+				continue
+			}
+			path := filepath.Join(root, e.Name())
+			if err := w.openFile(path); err != nil {
+				w.reportError(path, err)
+			}
+		}
+	} else {
+		// Single-file mode. fsnotify needs the *parent* directory
+		// to detect rename / replace; we filter to this one path.
+		watchTarget = filepath.Dir(root)
+		if err := w.openFile(root); err != nil {
+			fsw.Close()
+			cancel()
+			return nil, err
+		}
+	}
+
+	if err := fsw.Add(watchTarget); err != nil {
+		fsw.Close()
+		cancel()
+		return nil, fmt.Errorf("jsonl watcher: fsnotify add %q: %w", watchTarget, err)
+	}
+
+	w.wg.Add(1)
+	go w.drain()
+
+	return w, nil
+}
+
+// Subscribe returns a channel that receives Envelopes for the given
+// cc session id. Multiple Subscribe calls for the same sid each get
+// their own channel (fan-out to multiple consumers). The channel is
+// closed by Close().
+func (w *Watcher) Subscribe(sid string) <-chan Envelope {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if w.closed {
+		// Closed-watcher contract: hand out a closed channel.
+		ch := make(chan Envelope)
+		close(ch)
+		return ch
+	}
+	sub := &subscriber{
+		sid: sid,
+		ch:  make(chan Envelope, w.opts.SubscriberBuffer),
+	}
+	w.subs[sid] = append(w.subs[sid], sub)
+	return sub.ch
+}
+
+// Close stops the watcher, closes all subscriber channels, and
+// releases fsnotify resources. Idempotent.
+func (w *Watcher) Close() error {
+	w.mu.Lock()
+	if w.closed {
+		w.mu.Unlock()
+		return nil
+	}
+	w.closed = true
+	w.mu.Unlock()
+
+	w.cancel()
+	err := w.fsw.Close()
+	w.wg.Wait()
+
+	w.mu.Lock()
+	for _, list := range w.subs {
+		for _, s := range list {
+			close(s.ch)
+		}
+	}
+	w.subs = nil
+	w.mu.Unlock()
+	return err
+}
+
+// StatsSnapshot returns a copy of the current counters. Field-by-field
+// atomic loads — values are point-in-time consistent per field, not
+// across the struct.
+func (w *Watcher) StatsSnapshot() (out struct {
+	BytesRead     int64
+	LinesParsed   int64
+	LinesDropped  int64
+	UUIDDuped     int64
+	Truncations   int64
+	Rotations     int64
+	EnvelopesEmit int64
+	EnvelopesDrop int64
+}) {
+	out.BytesRead = w.stats.BytesRead.Load()
+	out.LinesParsed = w.stats.LinesParsed.Load()
+	out.LinesDropped = w.stats.LinesDropped.Load()
+	out.UUIDDuped = w.stats.UUIDDuped.Load()
+	out.Truncations = w.stats.Truncations.Load()
+	out.Rotations = w.stats.Rotations.Load()
+	out.EnvelopesEmit = w.stats.EnvelopesEmit.Load()
+	out.EnvelopesDrop = w.stats.EnvelopesDrop.Load()
+	return
+}
+
+// ----- internals -----
+
+func (w *Watcher) reportError(path string, err error) {
+	if w.opts.OnError != nil {
+		w.opts.OnError(path, err)
+	}
+}
+
+// drain is the fsnotify event loop. Owns all w.files mutations.
+func (w *Watcher) drain() {
+	defer w.wg.Done()
+	for {
+		select {
+		case <-w.ctx.Done():
+			return
+		case ev, ok := <-w.fsw.Events:
+			if !ok {
+				return
+			}
+			w.handleEvent(ev)
+		case err, ok := <-w.fsw.Errors:
+			if !ok {
+				return
+			}
+			w.reportError("", err)
+		}
+	}
+}
+
+func (w *Watcher) handleEvent(ev fsnotify.Event) {
+	// Filter on .jsonl suffix early.
+	if !strings.HasSuffix(ev.Name, ".jsonl") {
+		return
+	}
+	switch {
+	case ev.Op&fsnotify.Create != 0:
+		// New file — start tracking it.
+		if err := w.openFile(ev.Name); err != nil {
+			w.reportError(ev.Name, err)
+			return
+		}
+		// CC may write the first line in the same kernel tick as
+		// the create; drain immediately.
+		w.readFile(ev.Name)
+	case ev.Op&fsnotify.Write != 0:
+		w.readFile(ev.Name)
+	case ev.Op&fsnotify.Rename != 0, ev.Op&fsnotify.Remove != 0:
+		// File rotated away. We don't auto-follow rotations
+		// across renames — cc doesn't rotate session files in
+		// practice. Drop the tracking state.
+		w.dropFile(ev.Name)
+	}
+}
+
+func (w *Watcher) openFile(path string) error {
+	w.mu.Lock()
+	if _, exists := w.files[path]; exists {
+		w.mu.Unlock()
+		return nil
+	}
+	w.mu.Unlock()
+
+	st, err := os.Stat(path)
+	if err != nil {
+		return fmt.Errorf("openFile stat %q: %w", path, err)
+	}
+	ino, _ := inodeOf(st)
+	sid := sidFromPath(path)
+
+	w.mu.Lock()
+	w.files[path] = &fileState{
+		path:   path,
+		inode:  ino,
+		offset: 0, // start from the top — full replay on first attach
+		sid:    sid,
+		parser: IncrementalParser{
+			OnError: func(line []byte, err error) {
+				w.stats.LinesDropped.Add(1)
+				w.reportError(path, fmt.Errorf("parse: %w", err))
+			},
+		},
+	}
+	w.mu.Unlock()
+	return nil
+}
+
+func (w *Watcher) dropFile(path string) {
+	w.mu.Lock()
+	delete(w.files, path)
+	w.mu.Unlock()
+}
+
+// readFile picks up new bytes from `path` starting at the recorded
+// offset. Detects truncation (file shrank) and rotation (inode
+// changed) and resets state accordingly.
+func (w *Watcher) readFile(path string) {
+	w.mu.Lock()
+	fs, ok := w.files[path]
+	w.mu.Unlock()
+	if !ok {
+		// File appeared without our knowing — open it now.
+		if err := w.openFile(path); err != nil {
+			w.reportError(path, err)
+			return
+		}
+		w.mu.Lock()
+		fs = w.files[path]
+		w.mu.Unlock()
+	}
+
+	st, err := os.Stat(path)
+	if err != nil {
+		// Probably racing a delete; ignore.
+		if errors.Is(err, os.ErrNotExist) {
+			return
+		}
+		w.reportError(path, err)
+		return
+	}
+
+	curIno, _ := inodeOf(st)
+	curSize := st.Size()
+
+	// Rotation: inode changed. Reset offset + parser.
+	if fs.inode != 0 && curIno != 0 && curIno != fs.inode {
+		w.stats.Rotations.Add(1)
+		fs.inode = curIno
+		fs.offset = 0
+		fs.parser.Reset()
+	}
+
+	// Truncation: file shrank. Reset offset.
+	if curSize < fs.offset {
+		w.stats.Truncations.Add(1)
+		fs.offset = 0
+		fs.parser.Reset()
+	}
+
+	if curSize == fs.offset {
+		return // nothing new
+	}
+
+	f, err := os.Open(path)
+	if err != nil {
+		w.reportError(path, err)
+		return
+	}
+	defer f.Close()
+
+	if _, err := f.Seek(fs.offset, io.SeekStart); err != nil {
+		w.reportError(path, err)
+		return
+	}
+
+	buf := make([]byte, readChunkSize)
+	for {
+		n, rerr := f.Read(buf)
+		if n > 0 {
+			w.stats.BytesRead.Add(int64(n))
+			fs.offset += int64(n)
+			records := fs.parser.Feed(buf[:n])
+			for _, rec := range records {
+				w.dispatch(fs, rec)
+			}
+		}
+		if rerr != nil {
+			if !errors.Is(rerr, io.EOF) {
+				w.reportError(path, rerr)
+			}
+			break
+		}
+	}
+}
+
+// dispatch classifies + maps + delivers a record to all subscribers
+// of its session id.
+func (w *Watcher) dispatch(fs *fileState, rec Record) {
+	w.stats.LinesParsed.Add(1)
+
+	// session id: prefer record's sessionId, fall back to filename.
+	sid := rec.SessionID
+	if sid == "" {
+		sid = fs.sid
+	}
+
+	// UUID dedup (per session).
+	if rec.UUID != "" {
+		w.mu.Lock()
+		seen, ok := w.uuidSeen[sid]
+		if !ok {
+			seen = make(map[string]struct{})
+			w.uuidSeen[sid] = seen
+		}
+		if _, dup := seen[rec.UUID]; dup {
+			w.stats.UUIDDuped.Add(1)
+			w.mu.Unlock()
+			return
+		}
+		seen[rec.UUID] = struct{}{}
+		w.mu.Unlock()
+	}
+
+	class := Classify(rec)
+	env, ok := Map(rec, class, w.opts.MapOpts)
+	if !ok {
+		return
+	}
+	if env.SessionID == "" {
+		env.SessionID = sid
+	}
+
+	w.deliver(env)
+}
+
+// deliver hands the envelope to every subscriber of env.SessionID.
+// Drop policy:
+//   - EVENT class: never drop. Block the per-file reader until at
+//     least one subscriber has buffer room. (Stream 2 永不丢, §3.3.3.)
+//   - HOOK / STATE class: best-effort non-blocking send. On full
+//     buffer, drop-newest and increment counters.
+func (w *Watcher) deliver(env Envelope) {
+	w.mu.Lock()
+	subs := append([]*subscriber(nil), w.subs[env.SessionID]...)
+	w.mu.Unlock()
+
+	w.stats.EnvelopesEmit.Add(1)
+
+	for _, s := range subs {
+		switch env.Class {
+		case ClassEvent:
+			// Blocking send (with ctx cancellation).
+			select {
+			case s.ch <- env:
+			case <-w.ctx.Done():
+				return
+			}
+		default:
+			// Non-blocking, drop-newest.
+			select {
+			case s.ch <- env:
+			default:
+				s.dropped.Add(1)
+				w.stats.EnvelopesDrop.Add(1)
+				if w.opts.OnDrop != nil {
+					w.opts.OnDrop(env.SessionID, env.Kind)
+				}
+			}
+		}
+	}
+}
+
+// inodeOf returns the underlying inode number on platforms where it
+// exists (Linux, macOS). Falls back to 0 (which the caller treats as
+// "rotation detection unavailable").
+func inodeOf(st os.FileInfo) (uint64, bool) {
+	sys := st.Sys()
+	if sys == nil {
+		return 0, false
+	}
+	if s, ok := sys.(*syscall.Stat_t); ok {
+		return uint64(s.Ino), true
+	}
+	return 0, false
+}
+
+// sidFromPath extracts the session UUID from `<root>/<sid>.jsonl`.
+// Returns the basename without `.jsonl` — even if it isn't a valid
+// UUID, the daemon's higher layers map session-by-string anyway.
+func sidFromPath(path string) string {
+	base := filepath.Base(path)
+	return strings.TrimSuffix(base, ".jsonl")
+}

--- a/internal/cc/jsonl/watcher.go
+++ b/internal/cc/jsonl/watcher.go
@@ -25,6 +25,12 @@ const DefaultSubscriberBuffer = 256
 // KB to consume; we read in this-sized chunks until EOF.
 const readChunkSize = 64 * 1024
 
+// maxUUIDPerSession caps the per-session UUID dedup ring. ~10x typical
+// session record count so collisions are vanishingly rare in practice
+// while bounding memory at len * (avg uuid len) ≈ 8K * 36 bytes ≈ 288KB
+// per active session.
+const maxUUIDPerSession = 8192
+
 // Options tunes the Watcher.
 type Options struct {
 	// SubscriberBuffer is the per-subscriber channel buffer. Zero
@@ -39,10 +45,19 @@ type Options struct {
 	// typically log + count these.
 	OnError func(path string, err error)
 
-	// OnDrop, if non-nil, is invoked each time a STATE/HOOK
-	// envelope is dropped because a subscriber's buffer was full.
-	// EVENT envelopes are never silently dropped — they block the
-	// per-file reader (see watcherSubscriber.deliver).
+	// OnDrop, if non-nil, is invoked each time an envelope (any
+	// class) is dropped because a subscriber's buffer was full.
+	//
+	// Back-pressure model: the JSONL file ITSELF is the source of
+	// truth. The watcher is a derived view; subscribers attaching
+	// late or under back-pressure must replay from the file (see
+	// SubscribeFromOffset) or rely on the daemon broadcaster's
+	// catch-up cache. Blocking this layer would back-pressure the
+	// fsnotify drain goroutine and cause the kernel inotify queue to
+	// overflow, dropping fs events at a layer where we cannot count
+	// or recover them — strictly worse than counted in-flight drops
+	// here. Hence: ALL classes use non-blocking drop-newest with
+	// EnvelopesDrop counter.
 	OnDrop func(sessionID string, kind EnvelopeKind)
 }
 
@@ -66,14 +81,55 @@ type Watcher struct {
 	ctx   context.Context
 	cancel context.CancelFunc
 
-	mu         sync.Mutex
-	files      map[string]*fileState     // path → state
-	subs       map[string][]*subscriber  // sessionID → subscribers
-	uuidSeen   map[string]map[string]struct{} // sessionID → uuid set (dedup)
-	closed     bool
-	wg         sync.WaitGroup
-	stats      Stats
+	mu       sync.Mutex
+	files    map[string]*fileState    // path → state
+	subs     map[string][]*subscriber // sessionID → subscribers
+	uuidSeen map[string]*uuidRing     // sessionID → bounded FIFO ring (dedup)
+	closed   bool
+	wg       sync.WaitGroup
+	stats    Stats
 }
+
+// uuidRing is a bounded FIFO ring of recently-seen UUIDs. Older entries
+// evict on insert once at capacity. Caller must hold the parent lock.
+type uuidRing struct {
+	capacity int
+	seen     map[string]struct{}
+	order    []string // FIFO ring
+	head     int      // next eviction index
+}
+
+func newUUIDRing(capacity int) *uuidRing {
+	return &uuidRing{
+		capacity: capacity,
+		seen:     make(map[string]struct{}, capacity),
+		order:    make([]string, 0, capacity),
+	}
+}
+
+// AddIfNew returns true if the uuid was not previously seen; in that
+// case the ring records it (evicting the oldest if at capacity). False
+// means duplicate.
+func (r *uuidRing) AddIfNew(uuid string) bool {
+	if _, dup := r.seen[uuid]; dup {
+		return false
+	}
+	if len(r.order) < r.capacity {
+		r.order = append(r.order, uuid)
+		r.seen[uuid] = struct{}{}
+		return true
+	}
+	// Evict oldest.
+	old := r.order[r.head]
+	delete(r.seen, old)
+	r.order[r.head] = uuid
+	r.head = (r.head + 1) % r.capacity
+	r.seen[uuid] = struct{}{}
+	return true
+}
+
+// Len returns the current number of tracked UUIDs (≤ capacity).
+func (r *uuidRing) Len() int { return len(r.seen) }
 
 // Stats are read with atomic loads via the matching getters.
 type Stats struct {
@@ -130,7 +186,7 @@ func New(parent context.Context, root string, opts Options) (*Watcher, error) {
 		cancel:   cancel,
 		files:    make(map[string]*fileState),
 		subs:     make(map[string][]*subscriber),
-		uuidSeen: make(map[string]map[string]struct{}),
+		uuidSeen: make(map[string]*uuidRing),
 	}
 
 	st, err := os.Stat(root)
@@ -186,21 +242,56 @@ func New(parent context.Context, root string, opts Options) (*Watcher, error) {
 // cc session id. Multiple Subscribe calls for the same sid each get
 // their own channel (fan-out to multiple consumers). The channel is
 // closed by Close().
+//
+// Equivalent to SubscribeFromOffset(sid, OffsetLiveOnly).
 func (w *Watcher) Subscribe(sid string) <-chan Envelope {
+	ch, _ := w.SubscribeFromOffset(sid, OffsetLiveOnly)
+	return ch
+}
+
+// OffsetLiveOnly is the only fromOffset supported in v0.1 — the
+// subscriber receives only envelopes the watcher emits AFTER subscribe.
+// Pre-existing file content is NOT replayed.
+//
+// Full file replay (e.g. fromOffset=0) is a follow-up tracked in the
+// PR description; the daemon broadcaster's catch-up cache fills the
+// gap for v0.1.
+const OffsetLiveOnly int64 = -1
+
+// SubscribeFromOffset returns a channel like Subscribe with explicit
+// offset semantics. v0.1 only supports OffsetLiveOnly (-1); any other
+// value returns an error so callers fail fast instead of silently
+// receiving an empty stream.
+//
+// The full file-replay implementation requires per-subscriber file
+// readers + careful interleave with the live drain to avoid races
+// between historical parse and live append; tracked as a follow-up.
+// Callers that need full replay should:
+//  1. Subscribe BEFORE the watcher starts emitting (e.g. immediately
+//     after New()), or
+//  2. Use the daemon broadcaster's catch-up cache (Epic #3 sub-task —
+//     daemon-side LRU per (session, skill)).
+func (w *Watcher) SubscribeFromOffset(sid string, fromOffset int64) (<-chan Envelope, error) {
+	if fromOffset != OffsetLiveOnly {
+		return nil, fmt.Errorf(
+			"jsonl watcher: SubscribeFromOffset(fromOffset=%d) not supported in v0.1; pass OffsetLiveOnly (-1) or use the daemon broadcaster's catch-up cache for resume / late-attach",
+			fromOffset,
+		)
+	}
 	w.mu.Lock()
 	defer w.mu.Unlock()
 	if w.closed {
 		// Closed-watcher contract: hand out a closed channel.
 		ch := make(chan Envelope)
 		close(ch)
-		return ch
+		return ch, nil
 	}
 	sub := &subscriber{
 		sid: sid,
 		ch:  make(chan Envelope, w.opts.SubscriberBuffer),
 	}
 	w.subs[sid] = append(w.subs[sid], sub)
-	return sub.ch
+	return sub.ch, nil
 }
 
 // Close stops the watcher, closes all subscriber channels, and
@@ -438,21 +529,20 @@ func (w *Watcher) dispatch(fs *fileState, rec Record) {
 		sid = fs.sid
 	}
 
-	// UUID dedup (per session).
+	// UUID dedup (per session, bounded FIFO ring).
 	if rec.UUID != "" {
 		w.mu.Lock()
-		seen, ok := w.uuidSeen[sid]
+		ring, ok := w.uuidSeen[sid]
 		if !ok {
-			seen = make(map[string]struct{})
-			w.uuidSeen[sid] = seen
+			ring = newUUIDRing(maxUUIDPerSession)
+			w.uuidSeen[sid] = ring
 		}
-		if _, dup := seen[rec.UUID]; dup {
+		isNew := ring.AddIfNew(rec.UUID)
+		w.mu.Unlock()
+		if !isNew {
 			w.stats.UUIDDuped.Add(1)
-			w.mu.Unlock()
 			return
 		}
-		seen[rec.UUID] = struct{}{}
-		w.mu.Unlock()
 	}
 
 	class := Classify(rec)
@@ -468,11 +558,17 @@ func (w *Watcher) dispatch(fs *fileState, rec Record) {
 }
 
 // deliver hands the envelope to every subscriber of env.SessionID.
-// Drop policy:
-//   - EVENT class: never drop. Block the per-file reader until at
-//     least one subscriber has buffer room. (Stream 2 永不丢, §3.3.3.)
-//   - HOOK / STATE class: best-effort non-blocking send. On full
-//     buffer, drop-newest and increment counters.
+//
+// Drop policy: ALL classes use non-blocking drop-newest with the
+// EnvelopesDrop counter. Rationale (see Options.OnDrop docstring):
+// blocking would back-pressure the fsnotify drain goroutine into
+// dropping kernel-level inotify events, which we cannot count or
+// recover. The JSONL file is the source of truth; the daemon
+// broadcaster's catch-up cache (and a future SubscribeFromOffset
+// replay) handles late-attach / lossy delivery, NOT this layer.
+//
+// "Stream 2 永不丢" (§3.3.3) is the daemon broadcaster's contract,
+// not the watcher's — this layer is a derived view.
 func (w *Watcher) deliver(env Envelope) {
 	w.mu.Lock()
 	subs := append([]*subscriber(nil), w.subs[env.SessionID]...)
@@ -481,24 +577,13 @@ func (w *Watcher) deliver(env Envelope) {
 	w.stats.EnvelopesEmit.Add(1)
 
 	for _, s := range subs {
-		switch env.Class {
-		case ClassEvent:
-			// Blocking send (with ctx cancellation).
-			select {
-			case s.ch <- env:
-			case <-w.ctx.Done():
-				return
-			}
+		select {
+		case s.ch <- env:
 		default:
-			// Non-blocking, drop-newest.
-			select {
-			case s.ch <- env:
-			default:
-				s.dropped.Add(1)
-				w.stats.EnvelopesDrop.Add(1)
-				if w.opts.OnDrop != nil {
-					w.opts.OnDrop(env.SessionID, env.Kind)
-				}
+			s.dropped.Add(1)
+			w.stats.EnvelopesDrop.Add(1)
+			if w.opts.OnDrop != nil {
+				w.opts.OnDrop(env.SessionID, env.Kind)
 			}
 		}
 	}

--- a/internal/cc/jsonl/watcher_test.go
+++ b/internal/cc/jsonl/watcher_test.go
@@ -375,6 +375,131 @@ func TestWatcher_Integration_CCSessionSequence(t *testing.T) {
 	}
 }
 
+// TestWatcher_UUIDDedupBounded ensures the per-session UUID dedup ring
+// caps at maxUUIDPerSession instead of growing without bound.
+func TestWatcher_UUIDDedupBounded(t *testing.T) {
+	dir := t.TempDir()
+	sid := "sess-bounded"
+	path := filepath.Join(dir, sid+".jsonl")
+	must(t, os.WriteFile(path, nil, 0o644))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	w, err := New(ctx, dir, Options{SubscriberBuffer: 16384})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	defer w.Close()
+
+	ch := w.Subscribe(sid)
+
+	// Feed (cap+200) records — well past the bound — to force eviction.
+	overshoot := maxUUIDPerSession + 200
+	for i := 0; i < overshoot; i++ {
+		line := fmt.Sprintf(
+			`{"type":"user","uuid":"u-%d","sessionId":"%s","message":{"role":"user","content":[]}}`,
+			i, sid,
+		)
+		must(t, appendLine(path, line))
+	}
+
+	// Drain whatever the subscriber receives (best-effort; we only
+	// care about the ring state).
+	_ = drainFor(ch, 1500*time.Millisecond)
+
+	w.mu.Lock()
+	ring := w.uuidSeen[sid]
+	w.mu.Unlock()
+	if ring == nil {
+		t.Fatal("expected uuidSeen ring for session")
+	}
+	if got := ring.Len(); got > maxUUIDPerSession {
+		t.Errorf("ring size unbounded: got %d, want <= %d", got, maxUUIDPerSession)
+	}
+	if got := ring.Len(); got == 0 {
+		t.Errorf("ring empty after %d inserts", overshoot)
+	}
+}
+
+// TestWatcher_BackPressureDoesNotBlock verifies that under a slow
+// subscriber, the watcher's deliver() does NOT block — fsnotify drain
+// stays responsive, EVENT-class envelopes drop into the EnvelopesDrop
+// counter rather than back-pressuring the kernel inotify queue.
+func TestWatcher_BackPressureDoesNotBlock(t *testing.T) {
+	dir := t.TempDir()
+	sid := "sess-bp"
+	path := filepath.Join(dir, sid+".jsonl")
+	must(t, os.WriteFile(path, nil, 0o644))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	w, err := New(ctx, dir, Options{SubscriberBuffer: 1})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	defer w.Close()
+
+	// Subscribe but do NOT drain — buffer fills after the first
+	// envelope, all subsequent EVENTs must drop, NOT block.
+	_ = w.Subscribe(sid)
+
+	// Feed many EVENT-class records (type=user produces ClassEvent).
+	const N = 200
+	for i := 0; i < N; i++ {
+		line := fmt.Sprintf(
+			`{"type":"user","uuid":"u-%d","sessionId":"%s","message":{"role":"user","content":[]}}`,
+			i, sid,
+		)
+		must(t, appendLine(path, line))
+	}
+
+	// Wait for fsnotify to drive parses through.
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		stats := w.StatsSnapshot()
+		if stats.LinesParsed >= int64(N) {
+			break
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+
+	stats := w.StatsSnapshot()
+	if stats.LinesParsed < int64(N) {
+		// fsnotify drain blocked — the bug we are guarding against.
+		t.Fatalf("fsnotify drain stalled under back-pressure: parsed %d / %d", stats.LinesParsed, N)
+	}
+	if stats.EnvelopesDrop == 0 {
+		t.Errorf("expected EVENT drops under buffer=1 + N=%d, got 0", N)
+	}
+}
+
+// TestSubscribeFromOffset_RejectsUnsupported locks the v0.1 contract:
+// only OffsetLiveOnly is accepted; arbitrary offsets return an error
+// so callers fail fast instead of silently receiving an empty stream.
+func TestSubscribeFromOffset_RejectsUnsupported(t *testing.T) {
+	dir := t.TempDir()
+	w, err := New(context.Background(), dir, Options{})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	defer w.Close()
+
+	if _, err := w.SubscribeFromOffset("any", 0); err == nil {
+		t.Error("SubscribeFromOffset(0) should error in v0.1, got nil")
+	}
+	if _, err := w.SubscribeFromOffset("any", 12345); err == nil {
+		t.Error("SubscribeFromOffset(12345) should error in v0.1, got nil")
+	}
+	ch, err := w.SubscribeFromOffset("any", OffsetLiveOnly)
+	if err != nil {
+		t.Errorf("SubscribeFromOffset(OffsetLiveOnly) should succeed, got %v", err)
+	}
+	if ch == nil {
+		t.Error("OffsetLiveOnly subscribe returned nil channel")
+	}
+}
+
 // --- helpers ---
 
 func must(t *testing.T, err error) {

--- a/internal/cc/jsonl/watcher_test.go
+++ b/internal/cc/jsonl/watcher_test.go
@@ -1,0 +1,413 @@
+package jsonl
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// readWithTimeout drains up to `n` envelopes from ch, or times out.
+func readWithTimeout(t *testing.T, ch <-chan Envelope, n int, timeout time.Duration) []Envelope {
+	t.Helper()
+	var out []Envelope
+	deadline := time.After(timeout)
+	for len(out) < n {
+		select {
+		case env, ok := <-ch:
+			if !ok {
+				return out
+			}
+			out = append(out, env)
+		case <-deadline:
+			t.Fatalf("timed out waiting for envelopes: got %d, want %d", len(out), n)
+		}
+	}
+	return out
+}
+
+func TestWatcher_DirMode_PicksUpExistingFile(t *testing.T) {
+	dir := t.TempDir()
+	sid := "sess-existing"
+	path := filepath.Join(dir, sid+".jsonl")
+	must(t, os.WriteFile(path, []byte(
+		`{"type":"user","uuid":"u1","sessionId":"`+sid+`","message":{"role":"user","content":[]}}`+"\n"), 0o644))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	w, err := New(ctx, dir, Options{})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	defer w.Close()
+
+	ch := w.Subscribe(sid)
+
+	// Trigger a re-read by appending another line.
+	must(t, appendLine(path,
+		`{"type":"assistant","uuid":"a1","sessionId":"`+sid+`","message":{"role":"assistant","content":[]}}`))
+
+	envs := readWithTimeout(t, ch, 2, 3*time.Second)
+	if len(envs) != 2 {
+		t.Fatalf("got %d envelopes, want 2", len(envs))
+	}
+	if envs[0].SourceUUID != "u1" || envs[1].SourceUUID != "a1" {
+		t.Errorf("envelope order/uuid: got %q, %q", envs[0].SourceUUID, envs[1].SourceUUID)
+	}
+}
+
+func TestWatcher_NewFile_AfterStart(t *testing.T) {
+	dir := t.TempDir()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	w, err := New(ctx, dir, Options{})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	defer w.Close()
+
+	sid := "sess-new"
+	ch := w.Subscribe(sid)
+
+	// Create the JSONL file AFTER the watcher started.
+	path := filepath.Join(dir, sid+".jsonl")
+	must(t, os.WriteFile(path, []byte(
+		`{"type":"user","uuid":"u1","sessionId":"`+sid+`","message":{"role":"user","content":[]}}`+"\n"), 0o644))
+
+	envs := readWithTimeout(t, ch, 1, 3*time.Second)
+	if envs[0].SourceUUID != "u1" {
+		t.Errorf("uuid = %q", envs[0].SourceUUID)
+	}
+}
+
+func TestWatcher_TruncationDetected(t *testing.T) {
+	dir := t.TempDir()
+	sid := "sess-trunc"
+	path := filepath.Join(dir, sid+".jsonl")
+	// Pre-existing content.
+	must(t, os.WriteFile(path,
+		[]byte(`{"type":"user","uuid":"u1","sessionId":"`+sid+`","message":{"role":"user","content":[]}}`+"\n"+
+			`{"type":"assistant","uuid":"a1","sessionId":"`+sid+`","message":{"role":"assistant","content":[]}}`+"\n"),
+		0o644))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	w, err := New(ctx, dir, Options{})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	defer w.Close()
+
+	ch := w.Subscribe(sid)
+
+	// Trigger first read by appending an empty line (no-op record
+	// but advances offset via fsnotify event).
+	must(t, appendLine(path,
+		`{"type":"assistant","uuid":"a2","sessionId":"`+sid+`","message":{"role":"assistant","content":[]}}`))
+
+	_ = readWithTimeout(t, ch, 3, 3*time.Second)
+
+	// Now truncate and write fresh content.
+	must(t, os.WriteFile(path,
+		[]byte(`{"type":"user","uuid":"u-after-trunc","sessionId":"`+sid+`","message":{"role":"user","content":[]}}`+"\n"),
+		0o644))
+
+	envs := readWithTimeout(t, ch, 1, 3*time.Second)
+	if envs[0].SourceUUID != "u-after-trunc" {
+		t.Errorf("post-truncation uuid = %q, want u-after-trunc", envs[0].SourceUUID)
+	}
+	stats := w.StatsSnapshot()
+	if stats.Truncations == 0 {
+		t.Errorf("expected truncation counter > 0, got %d", stats.Truncations)
+	}
+}
+
+func TestWatcher_RotationDetected(t *testing.T) {
+	dir := t.TempDir()
+	sid := "sess-rot"
+	path := filepath.Join(dir, sid+".jsonl")
+	must(t, os.WriteFile(path,
+		[]byte(`{"type":"user","uuid":"u1","sessionId":"`+sid+`","message":{"role":"user","content":[]}}`+"\n"),
+		0o644))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	w, err := New(ctx, dir, Options{})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	defer w.Close()
+
+	ch := w.Subscribe(sid)
+
+	// Read the initial line.
+	must(t, appendLine(path,
+		`{"type":"assistant","uuid":"a1","sessionId":"`+sid+`","message":{"role":"assistant","content":[]}}`))
+	_ = readWithTimeout(t, ch, 2, 3*time.Second)
+
+	// Rotate: remove + recreate (new inode).
+	must(t, os.Remove(path))
+	// Give fsnotify a moment to register the remove.
+	time.Sleep(50 * time.Millisecond)
+	must(t, os.WriteFile(path,
+		[]byte(`{"type":"user","uuid":"u-rot","sessionId":"`+sid+`","message":{"role":"user","content":[]}}`+"\n"),
+		0o644))
+
+	envs := readWithTimeout(t, ch, 1, 3*time.Second)
+	if envs[0].SourceUUID != "u-rot" {
+		t.Errorf("post-rotation uuid = %q, want u-rot", envs[0].SourceUUID)
+	}
+}
+
+func TestWatcher_UUIDDedup(t *testing.T) {
+	dir := t.TempDir()
+	sid := "sess-dedup"
+	path := filepath.Join(dir, sid+".jsonl")
+	must(t, os.WriteFile(path, nil, 0o644))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	w, err := New(ctx, dir, Options{})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	defer w.Close()
+
+	ch := w.Subscribe(sid)
+
+	// Write the same uuid twice — second occurrence must be deduped.
+	rec := `{"type":"user","uuid":"dup1","sessionId":"` + sid + `","message":{"role":"user","content":[]}}`
+	must(t, appendLine(path, rec))
+	must(t, appendLine(path, rec))
+
+	// Wait long enough for both to flow through fsnotify.
+	envs := drainFor(ch, 500*time.Millisecond)
+	if len(envs) != 1 {
+		t.Errorf("expected 1 envelope after dedup, got %d", len(envs))
+	}
+	stats := w.StatsSnapshot()
+	if stats.UUIDDuped == 0 {
+		t.Errorf("expected dedup counter > 0, got %d", stats.UUIDDuped)
+	}
+}
+
+func TestWatcher_MultipleSubscribers_FanOut(t *testing.T) {
+	dir := t.TempDir()
+	sid := "sess-fanout"
+	path := filepath.Join(dir, sid+".jsonl")
+	must(t, os.WriteFile(path, nil, 0o644))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	w, err := New(ctx, dir, Options{})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	defer w.Close()
+
+	ch1 := w.Subscribe(sid)
+	ch2 := w.Subscribe(sid)
+
+	must(t, appendLine(path,
+		`{"type":"user","uuid":"u1","sessionId":"`+sid+`","message":{"role":"user","content":[]}}`))
+
+	a := readWithTimeout(t, ch1, 1, 3*time.Second)
+	b := readWithTimeout(t, ch2, 1, 3*time.Second)
+	if a[0].SourceUUID != "u1" || b[0].SourceUUID != "u1" {
+		t.Errorf("fanout failed: %q vs %q", a[0].SourceUUID, b[0].SourceUUID)
+	}
+}
+
+func TestWatcher_Subscribe_AfterClose_ReturnsClosedChan(t *testing.T) {
+	dir := t.TempDir()
+	w, err := New(context.Background(), dir, Options{})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	if err := w.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	ch := w.Subscribe("any")
+	select {
+	case _, ok := <-ch:
+		if ok {
+			t.Errorf("expected closed channel, got value")
+		}
+	case <-time.After(time.Second):
+		t.Errorf("expected closed channel, got block")
+	}
+}
+
+func TestWatcher_HookEvent_NotDroppedOnSlowSubscriber(t *testing.T) {
+	// HOOK / STATE envelopes are best-effort drop-newest. Verify
+	// that filling the buffer triggers OnDrop and increments
+	// counters — without crashing the watcher.
+	dir := t.TempDir()
+	sid := "sess-slow"
+	path := filepath.Join(dir, sid+".jsonl")
+	must(t, os.WriteFile(path, nil, 0o644))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	var dropCount atomic.Int64
+	w, err := New(ctx, dir, Options{
+		SubscriberBuffer: 2, // tiny buffer to force drops
+		OnDrop: func(_ string, _ EnvelopeKind) {
+			dropCount.Add(1)
+		},
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	defer w.Close()
+
+	_ = w.Subscribe(sid) // never drained
+
+	// Write 20 STATE records — buffer fills at 2, rest drop.
+	for i := 0; i < 20; i++ {
+		must(t, appendLine(path,
+			fmt.Sprintf(`{"type":"permission-mode","permissionMode":"auto","sessionId":"%s","seq":%d}`, sid, i)))
+	}
+
+	// Wait for fsnotify to settle.
+	deadline := time.After(2 * time.Second)
+	for {
+		select {
+		case <-deadline:
+			if dropCount.Load() == 0 {
+				t.Fatalf("expected drops on slow subscriber, got 0")
+			}
+			return
+		default:
+			if dropCount.Load() > 0 {
+				return // success
+			}
+			time.Sleep(20 * time.Millisecond)
+		}
+	}
+}
+
+// --- integration test: simulate a realistic cc session sequence ---
+
+func TestWatcher_Integration_CCSessionSequence(t *testing.T) {
+	dir := t.TempDir()
+	sid := "11111111-2222-3333-4444-555555555555"
+	path := filepath.Join(dir, sid+".jsonl")
+	must(t, os.WriteFile(path, nil, 0o644))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	w, err := New(ctx, dir, Options{})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	defer w.Close()
+
+	ch := w.Subscribe(sid)
+
+	// Replay the realistic sequence: permission-mode → SessionStart hook →
+	// user → assistant text → assistant tool_use → user tool_result → ai-title.
+	steps := []struct {
+		name       string
+		line       string
+		wantKind   EnvelopeKind
+		wantClass  Class
+	}{
+		{"permission-mode",
+			`{"type":"permission-mode","permissionMode":"auto","sessionId":"` + sid + `"}`,
+			KindSessionState, ClassState},
+		{"session-start hook",
+			`{"type":"attachment","uuid":"u-att-1","sessionId":"` + sid + `","attachment":{"hookEvent":"SessionStart","hookName":"SessionStart:startup","exitCode":0}}`,
+			KindHookEvent, ClassHook},
+		{"user message",
+			`{"type":"user","uuid":"u-user-1","sessionId":"` + sid + `","message":{"role":"user","content":[{"type":"text","text":"hi"}]}}`,
+			KindAgentEvent, ClassEvent},
+		{"assistant text",
+			`{"type":"assistant","uuid":"u-asst-1","parentUuid":"u-user-1","sessionId":"` + sid + `","message":{"role":"assistant","content":[{"type":"text","text":"hello back"}]}}`,
+			KindAgentEvent, ClassEvent},
+		{"assistant tool_use",
+			`{"type":"assistant","uuid":"u-asst-2","parentUuid":"u-asst-1","sessionId":"` + sid + `","message":{"role":"assistant","content":[{"type":"tool_use","id":"toolu_1","name":"Read","input":{}}]}}`,
+			KindAgentEvent, ClassEvent},
+		{"user tool_result",
+			`{"type":"user","uuid":"u-user-2","parentUuid":"u-asst-2","sessionId":"` + sid + `","message":{"role":"user","content":[{"type":"tool_result","tool_use_id":"toolu_1","content":"ok"}]}}`,
+			KindAgentEvent, ClassEvent},
+		{"ai-title state",
+			`{"type":"ai-title","title":"sample","sessionId":"` + sid + `"}`,
+			KindSessionState, ClassState},
+	}
+
+	for _, st := range steps {
+		must(t, appendLine(path, st.line))
+	}
+
+	got := readWithTimeout(t, ch, len(steps), 5*time.Second)
+	if len(got) != len(steps) {
+		t.Fatalf("got %d envelopes, want %d", len(got), len(steps))
+	}
+	for i, st := range steps {
+		if got[i].Kind != st.wantKind {
+			t.Errorf("step %d (%s): kind = %v, want %v", i, st.name, got[i].Kind, st.wantKind)
+		}
+		if got[i].Class != st.wantClass {
+			t.Errorf("step %d (%s): class = %v, want %v", i, st.name, got[i].Class, st.wantClass)
+		}
+		if got[i].SessionID != sid {
+			t.Errorf("step %d (%s): sessionID = %q", i, st.name, got[i].SessionID)
+		}
+	}
+	stats := w.StatsSnapshot()
+	if stats.LinesParsed != int64(len(steps)) {
+		t.Errorf("LinesParsed = %d, want %d", stats.LinesParsed, len(steps))
+	}
+	if stats.EnvelopesEmit != int64(len(steps)) {
+		t.Errorf("EnvelopesEmit = %d, want %d", stats.EnvelopesEmit, len(steps))
+	}
+}
+
+// --- helpers ---
+
+func must(t *testing.T, err error) {
+	t.Helper()
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func appendLine(path, line string) error {
+	f, err := os.OpenFile(path, os.O_WRONLY|os.O_APPEND|os.O_CREATE, 0o644)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	if _, err := f.WriteString(line + "\n"); err != nil {
+		return err
+	}
+	return nil
+}
+
+func drainFor(ch <-chan Envelope, d time.Duration) []Envelope {
+	var out []Envelope
+	deadline := time.After(d)
+	for {
+		select {
+		case env, ok := <-ch:
+			if !ok {
+				return out
+			}
+			out = append(out, env)
+		case <-deadline:
+			return out
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- Implements Epic #3 sub-task #4 — the cc session-jsonl ingestion path that turns `~/.claude/projects/*/<sid>.jsonl` into in-process Envelopes routed by class (EVENT / HOOK / STATE / UNKNOWN per F-04 / F-09).
- New package `internal/cc/jsonl/`: doc.go (authoritative classification table inline) + record.go + parser.go (4MB ceiling, partial-line buffer) + classifier.go + mapper.go (fence-tag-grep seams gated by MapOpts.FenceTagGrep, off by default per D-5) + watcher.go (fsnotify, per-file inode+offset state, truncation+rotation detection, per-session UUID dedup, back-pressure: EVENT blocks per Stream 2 永不丢, HOOK/STATE drops-newest with OnDrop callback).
- 47 tests pass under `-race` including integration test replaying realistic cc session sequence.
- Foundation for sub-task #11 (fence-tag-suffix grep §11.AA.1) — seams in place, flag flips it on.
- Wire envelope shape decision documented inline (in-process struct; daemon dispatcher wraps with replay metadata + nonce + AD downstream).
- Adds `github.com/fsnotify/fsnotify v1.9.0`. Go toolchain bump 1.24.6 → 1.25.0.

## Test plan

- [x] `go test -race ./internal/cc/jsonl/...` — 47 tests passing
- [x] `go vet ./...` — clean
- [x] `go build ./...` — clean
- [x] Integration: replay (permission-mode → SessionStart hook → user → assistant text → assistant tool_use → user tool_result → ai-title) → assert envelope kind/class/order

## Open spec questions

1. **`message.content` opacity** when `type=user`/`assistant` lines have null/missing `message` — defaulted to whole record Raw bytes. Confirm matches happy-cli behavior.
2. **`isSidechain` location** (metadata vs encrypted payload) — currently in PlaintextMetadata for routing without decrypt; flip if threat model says hide from server.
3. **`promptId` field** observed on user records but not in spec §11.N — currently retained only in Record.Raw; lift to metadata if App needs prompt-grouping wire semantics.
4. **`type=system` classification** — anticipatory STATE (no fixture observed). Confirm with fresh PoC-1 trace.
5. **First-attach replay**: Subscribe issued after Watcher running does NOT get pre-existing lines. Wire a `Subscribe(sid, fromOffset=0)` variant when the resume flow needs full history.
6. **STATE broadcast**: doc says NOT on events stream; this layer still emits them as a uniform pipe — daemon downstream router decides routing. Suppress at this layer if §11.N actually means "never go through the mapper".

## Notes

- Package landed at `internal/cc/jsonl/` (matches existing `internal/cc/doc.go` declaration). §11.W.1 table names files `jsonl_watcher.go` / `jsonl_mapper.go`; this PR splits into a sub-package because tests need testdata fixtures and F-04 taxonomy is its own concern. One-time `git mv` if the original flat layout is preferred.
- `internal/backend/claude/` (existing stream-json stdio) is **separate** from this jsonl session-file path; they dont share types and dont need to.
- No conflict with sibling Tasks (no cmd/tether/ touches).

Refs spec §11.N + §11.AA. Part of Epic #3 (gh #3).