### PR TITLE
tether resume <sid>: cwd-policy strategy (c) CLI wrapper

### DIFF
--- a/cmd/tether/blob.go
+++ b/cmd/tether/blob.go
@@ -1,0 +1,19 @@
+package main
+
+import (
+	"fmt"
+	"os"
+)
+
+// blobRegisterCmd is the v0.1 forward-compat stub for D-18 #3
+// (`/blob/<sha256>` proxy). Spec §11.AA: v0.1 reserves the path/CLI shape
+// so future skill code can target it stably; v0.2 lands the real
+// blob-proxy + DAG skill that uses it.
+func blobRegisterCmd(args []string) int {
+	if len(args) != 1 {
+		fmt.Fprintln(os.Stderr, "usage: tether tether-blob-register <path>")
+		return 2
+	}
+	fmt.Fprintln(os.Stderr, "tether-blob-register: not implemented in v0.1 (reserved for v0.2 blob proxy)")
+	return 1
+}

--- a/cmd/tether/main.go
+++ b/cmd/tether/main.go
@@ -1,11 +1,39 @@
-// Command tether is the v0.1 user-facing CLI. Today it only exposes the
-// skill subsystem (Epic #8) and a `tether-blob-register` forward-compat
-// stub (D-18 #3); daemon/spawn surfaces land in later epics.
+// Command tether is the v0.1 single-binary CLI (spec D-01). v0.1 ships
+// these user-visible subcommands, all routed through the dispatcher below:
+//
+//	tether daemon                  start the supervised daemon (main goroutine
+//	                               = watchdog over daemon + client subsystems,
+//	                               per spec §4.1 / D-11).
+//	tether skill {install|list|remove|info}   manage the global skill pool
+//	                                          (Epic #8, spec §11.Z).
+//	tether tether-blob-register <path>   D-18 #3 forward-compat stub
+//	                                     (returns "not implemented in v0.1";
+//	                                     reserved for the v0.2 blob proxy).
+//
+// Other subcommands (attach, spawn, resume, doctor, …) land in later
+// slices and plug into the same dispatch table.
+//
+// Exit codes (spec §6 / §4.1):
+//
+//	0   clean shutdown / success
+//	1   daemon failed to bootstrap (config / I/O error before watchdog
+//	    started), or subcommand reported a runtime error
+//	2   misuse (unknown subcommand, bad flags)
+//
+// Anything stronger (panic that escapes the supervisor — should never
+// happen because every supervised goroutine routes through safeRun) is
+// the Go runtime's default "exit 2 with a stack trace" path.
 package main
 
 import (
+	"context"
+	"flag"
 	"fmt"
 	"os"
+	"os/signal"
+	"syscall"
+
+	"github.com/piaobeizu/tether/internal/daemon"
 )
 
 func main() {
@@ -14,6 +42,8 @@ func main() {
 		os.Exit(2)
 	}
 	switch os.Args[1] {
+	case "daemon":
+		os.Exit(runDaemon(os.Args[2:]))
 	case "skill":
 		os.Exit(skillCmd(os.Args[2:]))
 	case "tether-blob-register":
@@ -28,13 +58,47 @@ func main() {
 	}
 }
 
+func runDaemon(args []string) int {
+	fs := flag.NewFlagSet("tether daemon", flag.ContinueOnError)
+	fs.SetOutput(os.Stderr)
+	verbose := fs.Bool("v", false, "verbose supervisor logging")
+	if err := fs.Parse(args); err != nil {
+		return 2
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// Translate SIGINT / SIGTERM into a ctx cancel — the watchdog's
+	// Run will then drain its supervised goroutines and return.
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
+	go func() {
+		s := <-sigCh
+		fmt.Fprintf(os.Stderr, "tether daemon: signal %v received, shutting down\n", s)
+		cancel()
+	}()
+
+	cfg := daemon.Config{
+		Verbose: *verbose,
+		Stderr:  os.Stderr,
+	}
+	if err := daemon.Run(ctx, cfg); err != nil {
+		fmt.Fprintf(os.Stderr, "tether daemon: %v\n", err)
+		return 1
+	}
+	return 0
+}
+
 func usage(w *os.File) {
-	fmt.Fprintln(w, "usage: tether <command> [args...]")
+	fmt.Fprintln(w, "usage: tether <subcommand> [flags]")
 	fmt.Fprintln(w, "")
-	fmt.Fprintln(w, "commands:")
+	fmt.Fprintln(w, "Subcommands:")
+	fmt.Fprintln(w, "  daemon                         start the supervised daemon (watchdog + daemon + client)")
 	fmt.Fprintln(w, "  skill install <name|git-url>   install a skill into the global pool")
 	fmt.Fprintln(w, "  skill list                     list installed skills")
 	fmt.Fprintln(w, "  skill remove <name>            uninstall a skill")
 	fmt.Fprintln(w, "  skill info <name>              print manifest details for an installed skill")
 	fmt.Fprintln(w, "  tether-blob-register <path>    (v0.1 stub) reserve blob URL for a workspace path")
+	fmt.Fprintln(w, "  help                           show this message")
 }

--- a/cmd/tether/main.go
+++ b/cmd/tether/main.go
@@ -6,12 +6,14 @@
 //	                               per spec §4.1 / D-11).
 //	tether skill {install|list|remove|info}   manage the global skill pool
 //	                                          (Epic #8, spec §11.Z).
+//	tether resume <sid>            cwd-aware wrapper around `claude --resume`
+//	                               (spec §10.4 strategy c).
 //	tether tether-blob-register <path>   D-18 #3 forward-compat stub
 //	                                     (returns "not implemented in v0.1";
 //	                                     reserved for the v0.2 blob proxy).
 //
-// Other subcommands (attach, spawn, resume, doctor, …) land in later
-// slices and plug into the same dispatch table.
+// Other subcommands (attach, spawn, doctor, …) land in later slices and
+// plug into the same dispatch table.
 //
 // Exit codes (spec §6 / §4.1):
 //
@@ -19,10 +21,6 @@
 //	1   daemon failed to bootstrap (config / I/O error before watchdog
 //	    started), or subcommand reported a runtime error
 //	2   misuse (unknown subcommand, bad flags)
-//
-// Anything stronger (panic that escapes the supervisor — should never
-// happen because every supervised goroutine routes through safeRun) is
-// the Go runtime's default "exit 2 with a stack trace" path.
 package main
 
 import (
@@ -46,6 +44,8 @@ func main() {
 		os.Exit(runDaemon(os.Args[2:]))
 	case "skill":
 		os.Exit(skillCmd(os.Args[2:]))
+	case "resume":
+		os.Exit(runResume(os.Args[2:]))
 	case "tether-blob-register":
 		os.Exit(blobRegisterCmd(os.Args[2:]))
 	case "-h", "--help", "help":
@@ -90,6 +90,61 @@ func runDaemon(args []string) int {
 	return 0
 }
 
+// runResume parses flags + dispatches to the resume wrapper. Returns an
+// exit code.
+func runResume(argv []string) int {
+	fs := flag.NewFlagSet("resume", flag.ContinueOnError)
+	fs.SetOutput(os.Stderr)
+	bucket := fs.String("bucket", "", "disambiguate when sid is found in multiple buckets")
+	dryRun := fs.Bool("dry-run", false, "print resolved cwd + argv, do not exec claude")
+	binary := fs.String("binary", "claude", "path/name of the claude binary to exec")
+	projectsDir := fs.String("projects-dir", "", "override ~/.claude/projects (for tests)")
+
+	fs.Usage = func() {
+		fmt.Fprintln(os.Stderr, "usage: tether resume <sid> [--bucket B] [--dry-run] [--binary PATH]")
+		fmt.Fprintln(os.Stderr, "")
+		fs.PrintDefaults()
+	}
+
+	if err := fs.Parse(argv); err != nil {
+		return 2
+	}
+	if fs.NArg() != 1 {
+		fs.Usage()
+		return 2
+	}
+	sid := fs.Arg(0)
+
+	root := *projectsDir
+	if root == "" {
+		var err error
+		root, err = defaultProjectsDir()
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "tether resume: %v\n", err)
+			return 1
+		}
+	}
+
+	res, err := ResolveSession(root, sid, *bucket)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "tether resume: %v\n", err)
+		return 1
+	}
+
+	if *dryRun {
+		fmt.Printf("cwd:    %s\n", res.Cwd)
+		fmt.Printf("bucket: %s\n", res.Bucket)
+		fmt.Printf("exec:   %s --resume %s\n", *binary, sid)
+		return 0
+	}
+
+	if err := ExecClaude(*binary, res.Cwd, sid); err != nil {
+		fmt.Fprintf(os.Stderr, "tether resume: %v\n", err)
+		return 1
+	}
+	return 0 // unreachable when ExecClaude succeeds (it execve's)
+}
+
 func usage(w *os.File) {
 	fmt.Fprintln(w, "usage: tether <subcommand> [flags]")
 	fmt.Fprintln(w, "")
@@ -99,6 +154,9 @@ func usage(w *os.File) {
 	fmt.Fprintln(w, "  skill list                     list installed skills")
 	fmt.Fprintln(w, "  skill remove <name>            uninstall a skill")
 	fmt.Fprintln(w, "  skill info <name>              print manifest details for an installed skill")
+	fmt.Fprintln(w, "  resume <sid>                   resume a claude session by id (spec §10.4 strategy c)")
 	fmt.Fprintln(w, "  tether-blob-register <path>    (v0.1 stub) reserve blob URL for a workspace path")
 	fmt.Fprintln(w, "  help                           show this message")
+	fmt.Fprintln(w, "")
+	fmt.Fprintln(w, "Run `tether <subcommand> -h` for subcommand-specific flags.")
 }

--- a/cmd/tether/main.go
+++ b/cmd/tether/main.go
@@ -1,0 +1,40 @@
+// Command tether is the v0.1 user-facing CLI. Today it only exposes the
+// skill subsystem (Epic #8) and a `tether-blob-register` forward-compat
+// stub (D-18 #3); daemon/spawn surfaces land in later epics.
+package main
+
+import (
+	"fmt"
+	"os"
+)
+
+func main() {
+	if len(os.Args) < 2 {
+		usage(os.Stderr)
+		os.Exit(2)
+	}
+	switch os.Args[1] {
+	case "skill":
+		os.Exit(skillCmd(os.Args[2:]))
+	case "tether-blob-register":
+		os.Exit(blobRegisterCmd(os.Args[2:]))
+	case "-h", "--help", "help":
+		usage(os.Stdout)
+		os.Exit(0)
+	default:
+		fmt.Fprintf(os.Stderr, "tether: unknown subcommand %q\n\n", os.Args[1])
+		usage(os.Stderr)
+		os.Exit(2)
+	}
+}
+
+func usage(w *os.File) {
+	fmt.Fprintln(w, "usage: tether <command> [args...]")
+	fmt.Fprintln(w, "")
+	fmt.Fprintln(w, "commands:")
+	fmt.Fprintln(w, "  skill install <name|git-url>   install a skill into the global pool")
+	fmt.Fprintln(w, "  skill list                     list installed skills")
+	fmt.Fprintln(w, "  skill remove <name>            uninstall a skill")
+	fmt.Fprintln(w, "  skill info <name>              print manifest details for an installed skill")
+	fmt.Fprintln(w, "  tether-blob-register <path>    (v0.1 stub) reserve blob URL for a workspace path")
+}

--- a/cmd/tether/main.go
+++ b/cmd/tether/main.go
@@ -96,12 +96,13 @@ func runResume(argv []string) int {
 	fs := flag.NewFlagSet("resume", flag.ContinueOnError)
 	fs.SetOutput(os.Stderr)
 	bucket := fs.String("bucket", "", "disambiguate when sid is found in multiple buckets")
+	cwd := fs.String("cwd", "", "manually specify the cwd (skips bucket-name decoding; required when the bucket decodes to multiple existing paths)")
 	dryRun := fs.Bool("dry-run", false, "print resolved cwd + argv, do not exec claude")
 	binary := fs.String("binary", "claude", "path/name of the claude binary to exec")
 	projectsDir := fs.String("projects-dir", "", "override ~/.claude/projects (for tests)")
 
 	fs.Usage = func() {
-		fmt.Fprintln(os.Stderr, "usage: tether resume <sid> [--bucket B] [--dry-run] [--binary PATH]")
+		fmt.Fprintln(os.Stderr, "usage: tether resume <sid> [--bucket B] [--cwd PATH] [--dry-run] [--binary PATH]")
 		fmt.Fprintln(os.Stderr, "")
 		fs.PrintDefaults()
 	}
@@ -125,7 +126,15 @@ func runResume(argv []string) int {
 		}
 	}
 
-	res, err := ResolveSession(root, sid, *bucket)
+	var res *ResolveResult
+	var err error
+	if *cwd != "" {
+		// Manual disambiguation path: caller has already chosen the cwd, we
+		// just verify the jsonl exists under EncodeBucket(cwd).
+		res, err = ResolveSessionWithCwd(root, sid, *cwd)
+	} else {
+		res, err = ResolveSession(root, sid, *bucket)
+	}
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "tether resume: %v\n", err)
 		return 1

--- a/cmd/tether/resume.go
+++ b/cmd/tether/resume.go
@@ -1,0 +1,234 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sort"
+	"strings"
+	"syscall"
+)
+
+// ErrSidNotFound is returned when the session id has no matching jsonl in
+// any project bucket.
+var ErrSidNotFound = errors.New("session id not found in any ~/.claude/projects bucket")
+
+// ResolveResult carries everything the caller needs to exec claude.
+type ResolveResult struct {
+	// Bucket is the directory name under projectsRoot containing <sid>.jsonl.
+	Bucket string
+	// JsonlPath is the absolute path to <bucket>/<sid>.jsonl.
+	JsonlPath string
+	// Cwd is the original spawn-time cwd reconstructed from Bucket. cc's
+	// encoding (`/` → `-`, leading `-`) is lossy, so this is the
+	// "best-effort plausible decoding" — the existing path on disk that
+	// matches when there's exactly one. See decodeBucket.
+	Cwd string
+}
+
+// defaultProjectsDir returns ~/.claude/projects.
+func defaultProjectsDir() (string, error) {
+	home := os.Getenv("HOME")
+	if home == "" {
+		return "", errors.New("$HOME unset; cannot locate ~/.claude/projects")
+	}
+	return filepath.Join(home, ".claude", "projects"), nil
+}
+
+// ResolveSession scans projectsRoot for any bucket containing <sid>.jsonl and
+// returns the resolved cwd. If `forceBucket` is non-empty it short-circuits
+// the search and uses that bucket directly (still requires the jsonl to exist).
+//
+// On a multi-bucket collision the error message lists all candidates and
+// instructs the user to re-run with --bucket.
+func ResolveSession(projectsRoot, sid, forceBucket string) (*ResolveResult, error) {
+	if sid == "" {
+		return nil, errors.New("session id is empty")
+	}
+
+	if forceBucket != "" {
+		jsonl := filepath.Join(projectsRoot, forceBucket, sid+".jsonl")
+		if _, err := os.Stat(jsonl); err != nil {
+			return nil, fmt.Errorf("--bucket %q has no %s.jsonl: %w", forceBucket, sid, err)
+		}
+		return &ResolveResult{
+			Bucket:    forceBucket,
+			JsonlPath: jsonl,
+			Cwd:       decodeBucket(forceBucket),
+		}, nil
+	}
+
+	matches, err := findSidBuckets(projectsRoot, sid)
+	if err != nil {
+		return nil, err
+	}
+	switch len(matches) {
+	case 0:
+		return nil, fmt.Errorf("%w: sid=%s root=%s", ErrSidNotFound, sid, projectsRoot)
+	case 1:
+		b := matches[0]
+		return &ResolveResult{
+			Bucket:    b,
+			JsonlPath: filepath.Join(projectsRoot, b, sid+".jsonl"),
+			Cwd:       decodeBucket(b),
+		}, nil
+	default:
+		var lines []string
+		for _, b := range matches {
+			lines = append(lines, fmt.Sprintf("  --bucket %s   (cwd: %s)", b, decodeBucket(b)))
+		}
+		return nil, fmt.Errorf("session %s found in %d buckets; pick one:\n%s",
+			sid, len(matches), strings.Join(lines, "\n"))
+	}
+}
+
+// findSidBuckets returns bucket names (relative to projectsRoot) that contain
+// <sid>.jsonl, sorted by the jsonl's modtime descending (most recent first)
+// so that single-result callers get the freshest copy and multi-result
+// callers see the most-likely-intended candidate at the top.
+func findSidBuckets(projectsRoot, sid string) ([]string, error) {
+	entries, err := os.ReadDir(projectsRoot)
+	if err != nil {
+		return nil, fmt.Errorf("read %s: %w", projectsRoot, err)
+	}
+
+	type hit struct {
+		name string
+		mod  int64
+	}
+	var hits []hit
+	for _, e := range entries {
+		if !e.IsDir() {
+			continue
+		}
+		jsonl := filepath.Join(projectsRoot, e.Name(), sid+".jsonl")
+		st, err := os.Stat(jsonl)
+		if err != nil {
+			continue
+		}
+		hits = append(hits, hit{name: e.Name(), mod: st.ModTime().UnixNano()})
+	}
+	sort.Slice(hits, func(i, j int) bool { return hits[i].mod > hits[j].mod })
+
+	out := make([]string, len(hits))
+	for i, h := range hits {
+		out[i] = h.name
+	}
+	return out, nil
+}
+
+// decodeBucket reverses cc's `/` → `-` encoding to a plausible filesystem
+// path, picking the longest existing prefix-match on disk to disambiguate
+// the lossy mapping.
+//
+// Lossiness: `/foo/bar` and `/foo-bar` both encode to `-foo-bar`. Decoder
+// strategy: walk left-to-right deciding for each `-` boundary whether it's
+// a path separator or a literal hyphen. We only commit a `/` boundary when
+// the path *up to that boundary* exists on disk; ties break in favor of
+// the interpretation whose final assembled path actually exists.
+//
+// This is best-effort — if no path on disk matches, we fall back to the
+// naive `/`-everywhere substitution. Callers should treat the result as
+// "the cwd to pass to claude --resume" and accept that for buckets whose
+// original path no longer exists the wrapper may pick a sibling location.
+func decodeBucket(bucket string) string {
+	if bucket == "" {
+		return ""
+	}
+	// cc encoding always prefixes with `-` (the leading `/` of an absolute
+	// path). Strip the prefix; what remains is `-`-separated segments.
+	rest := strings.TrimPrefix(bucket, "-")
+	tokens := strings.Split(rest, "-")
+
+	// Try existence-aware decode first.
+	if best := bestExistingDecode("/", tokens, 0); best != "" {
+		return best
+	}
+	// Fallback: naive — every `-` becomes `/`.
+	return "/" + strings.Join(tokens, "/")
+}
+
+// bestExistingDecode picks the longest assembled path that exists on disk by
+// branching at each token boundary on "is this a path separator or literal
+// hyphen". Returns "" when no full assembly exists.
+//
+// We only prune (gate recursion on `pathExists`) when the accumulated
+// prefix ends at a segment boundary (`/`). Mid-segment prefixes are never
+// directories, so checking them would prune valid branches like
+// `/foo` → `/foo-bar` where only the merged form exists.
+func bestExistingDecode(prefix string, tokens []string, i int) string {
+	if i == len(tokens) {
+		// Leaf: accept iff the assembled path exists.
+		if pathExists(prefix) {
+			return prefix
+		}
+		return ""
+	}
+
+	atBoundary := strings.HasSuffix(prefix, "/")
+	if atBoundary && !pathExists(prefix) {
+		// Pruning is safe at boundaries: if `/a/b/` doesn't exist, no
+		// extension of it can.
+		return ""
+	}
+
+	// Branch A: treat the next `-` as a path separator → start a new
+	// segment with this token.
+	sep := "/"
+	if atBoundary {
+		sep = ""
+	}
+	branchA := bestExistingDecode(prefix+sep+tokens[i], tokens, i+1)
+
+	// Branch B: treat the next `-` as a literal hyphen → glue token onto
+	// the current segment. Only meaningful mid-segment (not right after `/`).
+	var branchB string
+	if !atBoundary {
+		branchB = bestExistingDecode(prefix+"-"+tokens[i], tokens, i+1)
+	}
+
+	// Prefer the branch with the longer assembled path. Both being non-empty
+	// means both fully exist; tie-break by length (deeper paths preferred).
+	if len(branchA) >= len(branchB) {
+		return branchA
+	}
+	return branchB
+}
+
+func pathExists(p string) bool {
+	_, err := os.Stat(p)
+	return err == nil
+}
+
+// EncodeBucket is the forward direction of cc's encoding: `/foo/bar` →
+// `-foo-bar`. Used in tests + as documentation. Trailing `/` is dropped.
+func EncodeBucket(cwd string) string {
+	if cwd == "" {
+		return ""
+	}
+	// Drop trailing slash (matches cc behavior).
+	if cwd != "/" {
+		cwd = strings.TrimRight(cwd, "/")
+	}
+	return strings.ReplaceAll(cwd, "/", "-")
+}
+
+// ExecClaude execve's into `claude --resume <sid>` after chdir'ing to cwd.
+// On success this never returns. Returns an error only if chdir or exec fail.
+//
+// We use syscall.Exec rather than exec.Command + Run so that the user gets a
+// PTY-attached claude with no Go process in the middle — clean signal
+// handling, no extra fd, no process tree noise.
+func ExecClaude(binary, cwd, sid string) error {
+	resolvedBin, err := exec.LookPath(binary)
+	if err != nil {
+		return fmt.Errorf("locate %q: %w", binary, err)
+	}
+	if err := os.Chdir(cwd); err != nil {
+		return fmt.Errorf("chdir %s: %w", cwd, err)
+	}
+	argv := []string{resolvedBin, "--resume", sid}
+	return syscall.Exec(resolvedBin, argv, os.Environ())
+}

--- a/cmd/tether/resume.go
+++ b/cmd/tether/resume.go
@@ -43,6 +43,12 @@ func defaultProjectsDir() (string, error) {
 //
 // On a multi-bucket collision the error message lists all candidates and
 // instructs the user to re-run with --bucket.
+//
+// On a single-bucket-but-ambiguous-decode collision (two distinct on-disk
+// paths both decode-to-existence — e.g. /parent/foo/bar AND /parent/foo-bar
+// both real), the error lists every candidate cwd and instructs the user to
+// pass --cwd. This is a separate failure mode from multi-bucket: the bucket
+// is unique but its `/` ↔ `-` reversal isn't.
 func ResolveSession(projectsRoot, sid, forceBucket string) (*ResolveResult, error) {
 	if sid == "" {
 		return nil, errors.New("session id is empty")
@@ -53,10 +59,14 @@ func ResolveSession(projectsRoot, sid, forceBucket string) (*ResolveResult, erro
 		if _, err := os.Stat(jsonl); err != nil {
 			return nil, fmt.Errorf("--bucket %q has no %s.jsonl: %w", forceBucket, sid, err)
 		}
+		cwd, alts := decodeBucket(forceBucket)
+		if len(alts) > 0 {
+			return nil, ambiguousCwdError(forceBucket, alts)
+		}
 		return &ResolveResult{
 			Bucket:    forceBucket,
 			JsonlPath: jsonl,
-			Cwd:       decodeBucket(forceBucket),
+			Cwd:       cwd,
 		}, nil
 	}
 
@@ -69,25 +79,78 @@ func ResolveSession(projectsRoot, sid, forceBucket string) (*ResolveResult, erro
 		return nil, fmt.Errorf("%w: sid=%s root=%s", ErrSidNotFound, sid, projectsRoot)
 	case 1:
 		b := matches[0]
+		cwd, alts := decodeBucket(b)
+		if len(alts) > 0 {
+			return nil, ambiguousCwdError(b, alts)
+		}
 		return &ResolveResult{
 			Bucket:    b,
 			JsonlPath: filepath.Join(projectsRoot, b, sid+".jsonl"),
-			Cwd:       decodeBucket(b),
+			Cwd:       cwd,
 		}, nil
 	default:
 		var lines []string
 		for _, b := range matches {
-			lines = append(lines, fmt.Sprintf("  --bucket %s   (cwd: %s)", b, decodeBucket(b)))
+			cwd, _ := decodeBucket(b)
+			lines = append(lines, fmt.Sprintf("  --bucket %s   (cwd: %s)", b, cwd))
 		}
 		return nil, fmt.Errorf("session %s found in %d buckets; pick one:\n%s",
 			sid, len(matches), strings.Join(lines, "\n"))
 	}
 }
 
+// ambiguousCwdError formats the prefix-collision error message for the
+// single-bucket-multiple-decodes case. Listed candidates are pre-sorted by
+// decodeBucket so the message is deterministic across runs.
+func ambiguousCwdError(bucket string, alternates []string) error {
+	var lines []string
+	for _, p := range alternates {
+		lines = append(lines, "  --cwd "+p)
+	}
+	return fmt.Errorf("bucket %s decodes to multiple existing paths; pass --cwd to pick:\n%s",
+		bucket, strings.Join(lines, "\n"))
+}
+
+// ResolveSessionWithCwd is the manual-disambiguation entry point: caller has
+// already chosen the cwd (via --cwd), we just locate the jsonl and skip the
+// lossy decode entirely. The cwd is validated for existence.
+func ResolveSessionWithCwd(projectsRoot, sid, explicitCwd string) (*ResolveResult, error) {
+	if sid == "" {
+		return nil, errors.New("session id is empty")
+	}
+	if explicitCwd == "" {
+		return nil, errors.New("--cwd is empty")
+	}
+	cleaned := filepath.Clean(explicitCwd)
+	if !filepath.IsAbs(cleaned) {
+		return nil, fmt.Errorf("--cwd %q must be absolute", explicitCwd)
+	}
+	if hasDotDot(cleaned) {
+		return nil, fmt.Errorf("--cwd %q contains .. segments after Clean", explicitCwd)
+	}
+	if !pathExists(cleaned) {
+		return nil, fmt.Errorf("--cwd %q does not exist", explicitCwd)
+	}
+	bucket := EncodeBucket(cleaned)
+	jsonl := filepath.Join(projectsRoot, bucket, sid+".jsonl")
+	if _, err := os.Stat(jsonl); err != nil {
+		return nil, fmt.Errorf("no %s.jsonl under encoded bucket %s for --cwd %s: %w",
+			sid, bucket, cleaned, err)
+	}
+	return &ResolveResult{
+		Bucket:    bucket,
+		JsonlPath: jsonl,
+		Cwd:       cleaned,
+	}, nil
+}
+
 // findSidBuckets returns bucket names (relative to projectsRoot) that contain
 // <sid>.jsonl, sorted by the jsonl's modtime descending (most recent first)
 // so that single-result callers get the freshest copy and multi-result
-// callers see the most-likely-intended candidate at the top.
+// callers see the most-likely-intended candidate at the top. Equal-mtime
+// ties (possible on second-resolution filesystems like FAT or some NFS
+// mounts) break by bucket name ascending so collision messages are
+// deterministic across runs.
 func findSidBuckets(projectsRoot, sid string) ([]string, error) {
 	entries, err := os.ReadDir(projectsRoot)
 	if err != nil {
@@ -110,7 +173,14 @@ func findSidBuckets(projectsRoot, sid string) ([]string, error) {
 		}
 		hits = append(hits, hit{name: e.Name(), mod: st.ModTime().UnixNano()})
 	}
-	sort.Slice(hits, func(i, j int) bool { return hits[i].mod > hits[j].mod })
+	// SliceStable + composite less so the order is fully determined even when
+	// modtimes tie at fs resolution.
+	sort.SliceStable(hits, func(i, j int) bool {
+		if hits[i].mod != hits[j].mod {
+			return hits[i].mod > hits[j].mod
+		}
+		return hits[i].name < hits[j].name
+	})
 
 	out := make([]string, len(hits))
 	for i, h := range hits {
@@ -120,81 +190,99 @@ func findSidBuckets(projectsRoot, sid string) ([]string, error) {
 }
 
 // decodeBucket reverses cc's `/` → `-` encoding to a plausible filesystem
-// path, picking the longest existing prefix-match on disk to disambiguate
-// the lossy mapping.
+// path. Returns (cwd, ambiguousAlternates):
 //
-// Lossiness: `/foo/bar` and `/foo-bar` both encode to `-foo-bar`. Decoder
-// strategy: walk left-to-right deciding for each `-` boundary whether it's
-// a path separator or a literal hyphen. We only commit a `/` boundary when
-// the path *up to that boundary* exists on disk; ties break in favor of
-// the interpretation whose final assembled path actually exists.
+//   - When EXACTLY ONE decoding fully exists on disk, returns (that path, nil).
+//   - When MULTIPLE distinct decodings all fully exist on disk (the
+//     prefix-collision case: both `/parent/foo/bar` and `/parent/foo-bar`
+//     are real directories), returns ("", [all candidates sorted asc]).
+//     The caller is expected to surface this as a user-facing error and
+//     prompt for explicit `--cwd` disambiguation.
+//   - When NO decoding exists on disk, falls back to the naive
+//     `/`-everywhere substitution and returns (that path, nil). Treat as
+//     best-effort: the wrapper may pick a sibling location for buckets
+//     whose original cwd has been deleted/moved.
 //
-// This is best-effort — if no path on disk matches, we fall back to the
-// naive `/`-everywhere substitution. Callers should treat the result as
-// "the cwd to pass to claude --resume" and accept that for buckets whose
-// original path no longer exists the wrapper may pick a sibling location.
-func decodeBucket(bucket string) string {
+// Lossiness recap: `/foo/bar` and `/foo-bar` both encode to `-foo-bar`. The
+// previous version of this function silently picked branchA on tied length —
+// see PR #35 review feedback. Collecting all fully-existing decodes and
+// surfacing ambiguity to the caller is the safe behavior.
+func decodeBucket(bucket string) (string, []string) {
 	if bucket == "" {
-		return ""
+		return "", nil
 	}
 	// cc encoding always prefixes with `-` (the leading `/` of an absolute
 	// path). Strip the prefix; what remains is `-`-separated segments.
 	rest := strings.TrimPrefix(bucket, "-")
 	tokens := strings.Split(rest, "-")
 
-	// Try existence-aware decode first.
-	if best := bestExistingDecode("/", tokens, 0); best != "" {
-		return best
+	var existing []string
+	collectExistingDecodes("/", tokens, 0, &existing)
+
+	// Deduplicate (the recursion can produce the same path through different
+	// branch orderings only in pathological cases, but normalize anyway) and
+	// sort for deterministic ambiguity messages.
+	uniq := dedupSortedAsc(existing)
+
+	switch len(uniq) {
+	case 0:
+		// No on-disk match → naive fallback.
+		return "/" + strings.Join(tokens, "/"), nil
+	case 1:
+		return uniq[0], nil
+	default:
+		return "", uniq
 	}
-	// Fallback: naive — every `-` becomes `/`.
-	return "/" + strings.Join(tokens, "/")
 }
 
-// bestExistingDecode picks the longest assembled path that exists on disk by
-// branching at each token boundary on "is this a path separator or literal
-// hyphen". Returns "" when no full assembly exists.
-//
-// We only prune (gate recursion on `pathExists`) when the accumulated
-// prefix ends at a segment boundary (`/`). Mid-segment prefixes are never
-// directories, so checking them would prune valid branches like
-// `/foo` → `/foo-bar` where only the merged form exists.
-func bestExistingDecode(prefix string, tokens []string, i int) string {
+// collectExistingDecodes walks the decode-tree appending every fully-existing
+// assembled path to *out. Branch semantics mirror the previous
+// bestExistingDecode: at each `-` token boundary, branchA treats it as `/`
+// (new segment) and branchB treats it as a literal `-` (glue onto current
+// segment). Pruning at directory boundaries keeps cost O(real-paths).
+func collectExistingDecodes(prefix string, tokens []string, i int, out *[]string) {
 	if i == len(tokens) {
-		// Leaf: accept iff the assembled path exists.
 		if pathExists(prefix) {
-			return prefix
+			*out = append(*out, prefix)
 		}
-		return ""
+		return
 	}
 
 	atBoundary := strings.HasSuffix(prefix, "/")
 	if atBoundary && !pathExists(prefix) {
-		// Pruning is safe at boundaries: if `/a/b/` doesn't exist, no
-		// extension of it can.
-		return ""
+		// Safe prune: if `/a/b/` doesn't exist, no extension of it can.
+		return
 	}
 
-	// Branch A: treat the next `-` as a path separator → start a new
-	// segment with this token.
+	// Branch A: `-` is a path separator → start a new segment.
 	sep := "/"
 	if atBoundary {
 		sep = ""
 	}
-	branchA := bestExistingDecode(prefix+sep+tokens[i], tokens, i+1)
+	collectExistingDecodes(prefix+sep+tokens[i], tokens, i+1, out)
 
-	// Branch B: treat the next `-` as a literal hyphen → glue token onto
-	// the current segment. Only meaningful mid-segment (not right after `/`).
-	var branchB string
+	// Branch B: `-` is literal → glue token to current segment. Only
+	// meaningful mid-segment.
 	if !atBoundary {
-		branchB = bestExistingDecode(prefix+"-"+tokens[i], tokens, i+1)
+		collectExistingDecodes(prefix+"-"+tokens[i], tokens, i+1, out)
 	}
+}
 
-	// Prefer the branch with the longer assembled path. Both being non-empty
-	// means both fully exist; tie-break by length (deeper paths preferred).
-	if len(branchA) >= len(branchB) {
-		return branchA
+// dedupSortedAsc returns the unique elements of in, sorted ascending.
+func dedupSortedAsc(in []string) []string {
+	if len(in) == 0 {
+		return nil
 	}
-	return branchB
+	cp := make([]string, len(in))
+	copy(cp, in)
+	sort.Strings(cp)
+	out := cp[:1]
+	for _, s := range cp[1:] {
+		if s != out[len(out)-1] {
+			out = append(out, s)
+		}
+	}
+	return out
 }
 
 func pathExists(p string) bool {
@@ -221,7 +309,17 @@ func EncodeBucket(cwd string) string {
 // We use syscall.Exec rather than exec.Command + Run so that the user gets a
 // PTY-attached claude with no Go process in the middle — clean signal
 // handling, no extra fd, no process tree noise.
+//
+// Defense-in-depth on the cwd input: we always Clean the path and reject
+// any residual `..` segments. The decoder shouldn't produce `..` (it
+// only emits paths that exist on disk), but a malformed bucket name like
+// `-tmp-..-etc` could in principle slip through the naive fallback —
+// hard-fail here rather than silently chdir'ing to an unintended location.
 func ExecClaude(binary, cwd, sid string) error {
+	cwd = filepath.Clean(cwd)
+	if hasDotDot(cwd) {
+		return fmt.Errorf("refusing to chdir: %q contains .. segments after Clean", cwd)
+	}
 	resolvedBin, err := exec.LookPath(binary)
 	if err != nil {
 		return fmt.Errorf("locate %q: %w", binary, err)
@@ -231,4 +329,18 @@ func ExecClaude(binary, cwd, sid string) error {
 	}
 	argv := []string{resolvedBin, "--resume", sid}
 	return syscall.Exec(resolvedBin, argv, os.Environ())
+}
+
+// hasDotDot reports whether p has any `..` segment after splitting on the
+// OS path separator. filepath.Clean reduces redundant separators but does
+// NOT eliminate leading-or-internal `..` (e.g. `Clean("/a/../b")` is `/b`,
+// but `Clean("../b")` stays `../b`). Combined with our absolute-path
+// invariant, any residual `..` is a defect.
+func hasDotDot(p string) bool {
+	for _, seg := range strings.Split(p, string(filepath.Separator)) {
+		if seg == ".." {
+			return true
+		}
+	}
+	return false
 }

--- a/cmd/tether/resume_test.go
+++ b/cmd/tether/resume_test.go
@@ -1,0 +1,352 @@
+package main
+
+import (
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestEncodeBucket exercises cc's forward encoding: `/` → `-` with
+// leading `-`. Trailing slash dropped. Hyphens in segments survive.
+func TestEncodeBucket(t *testing.T) {
+	cases := []struct{ in, want string }{
+		{"/root/code/aicoding/tether", "-root-code-aicoding-tether"},
+		{"/root/code/aicoding/tether/", "-root-code-aicoding-tether"},
+		{"/root", "-root"},
+		{"/", "-"},
+		{"/root/code/aicoding/tether/wxk/gh-13/tether",
+			"-root-code-aicoding-tether-wxk-gh-13-tether"},
+		{"", ""},
+		{"/root/code-with-dash/x", "-root-code-with-dash-x"},
+	}
+	for _, c := range cases {
+		got := EncodeBucket(c.in)
+		if got != c.want {
+			t.Errorf("EncodeBucket(%q) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}
+
+// TestDecodeBucket_RoundTripWhenPathExists creates real directories under a
+// temp tree and asserts decode(encode(path)) recovers the original whenever
+// the path is on disk — including paths with literal hyphens (the
+// ambiguous case the wrapper is supposed to handle gracefully).
+func TestDecodeBucket_RoundTripWhenPathExists(t *testing.T) {
+	tmp := t.TempDir()
+
+	cases := []string{
+		"a/b/c",
+		"foo-bar/baz",       // hyphen in segment
+		"gh-13/tether",      // ambiguous: could decode to gh/13/tether
+		"a-b-c/d",           // many hyphens
+		"single",            // single segment
+	}
+	for _, rel := range cases {
+		p := filepath.Join(tmp, rel)
+		if err := os.MkdirAll(p, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		bucket := EncodeBucket(p)
+		got := decodeBucket(bucket)
+		if got != p {
+			t.Errorf("round-trip failed for %q\n  bucket: %s\n  decoded: %s", p, bucket, got)
+		}
+	}
+}
+
+// TestDecodeBucket_FallbackWhenNoMatch documents the lossy-decode fallback:
+// when nothing on disk matches, we fall back to the naive `/`-substitution.
+func TestDecodeBucket_FallbackWhenNoMatch(t *testing.T) {
+	// /definitely/does/not/exist/anywhere
+	bucket := "-definitely-does-not-exist-anywhere"
+	got := decodeBucket(bucket)
+	want := "/definitely/does/not/exist/anywhere"
+	if got != want {
+		t.Errorf("fallback decode = %q, want %q", got, want)
+	}
+}
+
+// TestDecodeBucket_AmbiguityPrefersLongerExistingPath: when two interpretations
+// both partially exist, prefer the one that fully exists.
+func TestDecodeBucket_AmbiguityPrefersLongerExistingPath(t *testing.T) {
+	tmp := t.TempDir()
+	// Create only /tmp/foo-bar/baz (with hyphen). NOT /tmp/foo/bar/baz.
+	target := filepath.Join(tmp, "foo-bar", "baz")
+	if err := os.MkdirAll(target, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	bucket := EncodeBucket(target)
+	got := decodeBucket(bucket)
+	if got != target {
+		t.Errorf("ambiguous decode picked wrong branch:\n  got: %s\n  want: %s", got, target)
+	}
+}
+
+// TestResolveSession_NotFound: empty projects root → ErrSidNotFound.
+func TestResolveSession_NotFound(t *testing.T) {
+	tmp := t.TempDir()
+	_, err := ResolveSession(tmp, "no-such-sid", "")
+	if err == nil {
+		t.Fatal("expected error for missing sid")
+	}
+	if !errors.Is(err, ErrSidNotFound) {
+		t.Errorf("expected ErrSidNotFound, got: %v", err)
+	}
+}
+
+// TestResolveSession_SingleBucket: write a fake jsonl, verify resolve returns
+// the bucket + decoded cwd.
+func TestResolveSession_SingleBucket(t *testing.T) {
+	root := t.TempDir()
+	bucket := "-tmp-foo"
+	if err := os.MkdirAll(filepath.Join(root, bucket), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	sid := "01ABCDEF-test-session"
+	jsonl := filepath.Join(root, bucket, sid+".jsonl")
+	if err := os.WriteFile(jsonl, []byte("{}\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	res, err := ResolveSession(root, sid, "")
+	if err != nil {
+		t.Fatalf("ResolveSession: %v", err)
+	}
+	if res.Bucket != bucket {
+		t.Errorf("bucket: got %s, want %s", res.Bucket, bucket)
+	}
+	if res.JsonlPath != jsonl {
+		t.Errorf("jsonl: got %s, want %s", res.JsonlPath, jsonl)
+	}
+	// Cwd: /tmp/foo exists on most linux/mac; if not, we'd hit fallback.
+	// Assert either the on-disk match or the naive fallback — both are
+	// "/tmp/foo" here.
+	if res.Cwd != "/tmp/foo" {
+		t.Errorf("cwd: got %s, want /tmp/foo", res.Cwd)
+	}
+}
+
+// TestResolveSession_Collision: same sid in two buckets → error listing both.
+func TestResolveSession_Collision(t *testing.T) {
+	root := t.TempDir()
+	sid := "collide-sid"
+	for _, b := range []string{"-tmp-a", "-tmp-b"} {
+		if err := os.MkdirAll(filepath.Join(root, b), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(root, b, sid+".jsonl"), []byte("{}\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	_, err := ResolveSession(root, sid, "")
+	if err == nil {
+		t.Fatal("expected collision error")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "-tmp-a") || !strings.Contains(msg, "-tmp-b") {
+		t.Errorf("collision message should list both buckets: %v", err)
+	}
+	if !strings.Contains(msg, "--bucket") {
+		t.Errorf("collision message should suggest --bucket flag: %v", err)
+	}
+}
+
+// TestResolveSession_CollisionForceBucket: --bucket disambiguates.
+func TestResolveSession_CollisionForceBucket(t *testing.T) {
+	root := t.TempDir()
+	sid := "collide-sid"
+	for _, b := range []string{"-tmp-a", "-tmp-b"} {
+		if err := os.MkdirAll(filepath.Join(root, b), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(root, b, sid+".jsonl"), []byte("{}\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	res, err := ResolveSession(root, sid, "-tmp-b")
+	if err != nil {
+		t.Fatalf("force-bucket: %v", err)
+	}
+	if res.Bucket != "-tmp-b" {
+		t.Errorf("force-bucket: got %s, want -tmp-b", res.Bucket)
+	}
+}
+
+// TestResolveSession_ForceBucketMissing: --bucket pointing at the wrong dir
+// is a hard error.
+func TestResolveSession_ForceBucketMissing(t *testing.T) {
+	root := t.TempDir()
+	_, err := ResolveSession(root, "any-sid", "-no-such-bucket")
+	if err == nil {
+		t.Fatal("expected error for missing forced bucket")
+	}
+	if !strings.Contains(err.Error(), "-no-such-bucket") {
+		t.Errorf("error should mention bucket: %v", err)
+	}
+}
+
+// TestResolveSession_PicksMostRecent: when (somehow) the same sid lives in
+// two buckets but we're not in collision mode, the most-recently-modified
+// jsonl wins. Documented multi-bucket order in findSidBuckets.
+func TestResolveSession_PicksMostRecent_CollisionStillFlagged(t *testing.T) {
+	// This test verifies the *order* of the collision message: most-recent
+	// first. Even though collisions are still treated as errors, the
+	// listing should put the more-likely candidate at the top.
+	root := t.TempDir()
+	sid := "ordered-sid"
+	older := filepath.Join(root, "-tmp-old")
+	newer := filepath.Join(root, "-tmp-new")
+	for _, d := range []string{older, newer} {
+		if err := os.MkdirAll(d, 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	oldJ := filepath.Join(older, sid+".jsonl")
+	newJ := filepath.Join(newer, sid+".jsonl")
+	if err := os.WriteFile(oldJ, []byte("{}\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(newJ, []byte("{}\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// Force older to actually be older.
+	past := time.Now().Add(-1 * time.Hour)
+	if err := os.Chtimes(oldJ, past, past); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := ResolveSession(root, sid, "")
+	if err == nil {
+		t.Fatal("expected collision")
+	}
+	msg := err.Error()
+	idxNew := strings.Index(msg, "-tmp-new")
+	idxOld := strings.Index(msg, "-tmp-old")
+	if idxNew < 0 || idxOld < 0 {
+		t.Fatalf("both buckets should be listed: %v", err)
+	}
+	if idxNew >= idxOld {
+		t.Errorf("most-recent should be listed first; got msg:\n%s", msg)
+	}
+}
+
+// TestRunResume_DryRun: end-to-end smoke test of the CLI dispatcher with
+// --dry-run, asserting that ResolveSession is wired correctly. No claude
+// binary required.
+func TestRunResume_DryRun(t *testing.T) {
+	root := t.TempDir()
+	bucket := "-tmp-smoke"
+	if err := os.MkdirAll(filepath.Join(root, bucket), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	sid := "smoke-sid"
+	jsonl := filepath.Join(root, bucket, sid+".jsonl")
+	if err := os.WriteFile(jsonl, []byte("{}\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Capture stdout to a temp file.
+	stdout, restoreOut := captureStdout(t)
+	defer restoreOut()
+
+	code := runResume([]string{
+		"--projects-dir", root,
+		"--dry-run",
+		sid,
+	})
+	if code != 0 {
+		t.Fatalf("runResume exit=%d", code)
+	}
+	out := stdout()
+	for _, want := range []string{
+		"cwd:    /tmp/smoke",
+		"bucket: " + bucket,
+		"--resume " + sid,
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("dry-run stdout missing %q\n%s", want, out)
+		}
+	}
+}
+
+// TestExecClaude_Smoke: build a fake `claude` binary that just prints its
+// argv + cwd, then verify ExecClaude wires both correctly. We use
+// exec.Command (not direct ExecClaude — that execve's away the test
+// process); the wiring tested is the lookup + chdir + argv shape.
+func TestExecClaude_Smoke(t *testing.T) {
+	if _, err := exec.LookPath("sh"); err != nil {
+		t.Skip("sh not available")
+	}
+	tmp := t.TempDir()
+
+	// Fake claude: prints argv joined + cwd to stdout.
+	fake := filepath.Join(tmp, "claude")
+	script := `#!/bin/sh
+echo "ARGV: $@"
+echo "CWD: $(pwd)"
+`
+	if err := os.WriteFile(fake, []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	cwd := filepath.Join(tmp, "work")
+	if err := os.MkdirAll(cwd, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Drive the fake via os/exec (mirroring what ExecClaude does sans execve).
+	cmd := exec.Command(fake, "--resume", "sid-x")
+	cmd.Dir = cwd
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("fake claude failed: %v\n%s", err, out)
+	}
+	got := string(out)
+	if !strings.Contains(got, "ARGV: --resume sid-x") {
+		t.Errorf("argv wiring wrong: %s", got)
+	}
+	// CWD must resolve to our chdir target. Some platforms canonicalize
+	// /tmp to /private/tmp; tolerate that with HasSuffix.
+	if !strings.Contains(got, "CWD:") || !strings.Contains(got, filepath.Base(cwd)) {
+		t.Errorf("cwd wiring wrong: %s", got)
+	}
+}
+
+// captureStdout redirects os.Stdout to a temp file and returns (read, restore).
+func captureStdout(t *testing.T) (read func() string, restore func()) {
+	t.Helper()
+	orig := os.Stdout
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	os.Stdout = w
+	done := make(chan string, 1)
+	go func() {
+		var sb strings.Builder
+		buf := make([]byte, 4096)
+		for {
+			n, err := r.Read(buf)
+			if n > 0 {
+				sb.Write(buf[:n])
+			}
+			if err != nil {
+				break
+			}
+		}
+		done <- sb.String()
+	}()
+	read = func() string {
+		_ = w.Close()
+		s := <-done
+		return s
+	}
+	restore = func() {
+		os.Stdout = orig
+		_ = r.Close()
+	}
+	return read, restore
+}

--- a/cmd/tether/resume_test.go
+++ b/cmd/tether/resume_test.go
@@ -40,10 +40,10 @@ func TestDecodeBucket_RoundTripWhenPathExists(t *testing.T) {
 
 	cases := []string{
 		"a/b/c",
-		"foo-bar/baz",       // hyphen in segment
-		"gh-13/tether",      // ambiguous: could decode to gh/13/tether
-		"a-b-c/d",           // many hyphens
-		"single",            // single segment
+		"foo-bar/baz",  // hyphen in segment
+		"gh-13/tether", // ambiguous: could decode to gh/13/tether
+		"a-b-c/d",      // many hyphens
+		"single",       // single segment
 	}
 	for _, rel := range cases {
 		p := filepath.Join(tmp, rel)
@@ -51,7 +51,11 @@ func TestDecodeBucket_RoundTripWhenPathExists(t *testing.T) {
 			t.Fatal(err)
 		}
 		bucket := EncodeBucket(p)
-		got := decodeBucket(bucket)
+		got, alts := decodeBucket(bucket)
+		if len(alts) != 0 {
+			t.Errorf("unexpected ambiguity for %q: alts=%v", p, alts)
+			continue
+		}
 		if got != p {
 			t.Errorf("round-trip failed for %q\n  bucket: %s\n  decoded: %s", p, bucket, got)
 		}
@@ -63,10 +67,13 @@ func TestDecodeBucket_RoundTripWhenPathExists(t *testing.T) {
 func TestDecodeBucket_FallbackWhenNoMatch(t *testing.T) {
 	// /definitely/does/not/exist/anywhere
 	bucket := "-definitely-does-not-exist-anywhere"
-	got := decodeBucket(bucket)
+	got, alts := decodeBucket(bucket)
 	want := "/definitely/does/not/exist/anywhere"
 	if got != want {
 		t.Errorf("fallback decode = %q, want %q", got, want)
+	}
+	if len(alts) != 0 {
+		t.Errorf("fallback should not produce alternates: %v", alts)
 	}
 }
 
@@ -80,9 +87,192 @@ func TestDecodeBucket_AmbiguityPrefersLongerExistingPath(t *testing.T) {
 		t.Fatal(err)
 	}
 	bucket := EncodeBucket(target)
-	got := decodeBucket(bucket)
+	got, alts := decodeBucket(bucket)
+	if len(alts) != 0 {
+		t.Fatalf("expected unambiguous decode; got alts=%v", alts)
+	}
 	if got != target {
 		t.Errorf("ambiguous decode picked wrong branch:\n  got: %s\n  want: %s", got, target)
+	}
+}
+
+// TestDecodeBucket_PrefixCollision is the BLOCKER fix from PR #35 review:
+// when BOTH `/parent/foo/bar` AND `/parent/foo-bar` exist on disk, the
+// encoded bucket `-parent-foo-bar` decodes ambiguously. The previous
+// implementation silently picked the path-separator interpretation
+// (branchA wins on tied length). The new contract: surface ambiguity to
+// the caller via the alternates slice — they must list ALL existing
+// candidates so the user can disambiguate via `--cwd`.
+func TestDecodeBucket_PrefixCollision(t *testing.T) {
+	tmp := t.TempDir()
+	pathSlash := filepath.Join(tmp, "foo", "bar") // .../foo/bar
+	pathDash := filepath.Join(tmp, "foo-bar")     // .../foo-bar
+	if err := os.MkdirAll(pathSlash, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(pathDash, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	// EncodeBucket of either path produces the same string; pick one.
+	bucket := EncodeBucket(pathSlash)
+	if bucket != EncodeBucket(pathDash) {
+		t.Fatalf("test setup precondition: encodings should collide; got %q vs %q",
+			bucket, EncodeBucket(pathDash))
+	}
+
+	got, alts := decodeBucket(bucket)
+	if got != "" {
+		t.Errorf("ambiguous decode should return empty cwd; got %q", got)
+	}
+	if len(alts) != 2 {
+		t.Fatalf("expected 2 alternates, got %d: %v", len(alts), alts)
+	}
+	// Alternates must be sorted ascending for deterministic error messages.
+	if alts[0] > alts[1] {
+		t.Errorf("alternates not sorted ascending: %v", alts)
+	}
+	// Both real paths should be present.
+	wantSet := map[string]bool{pathSlash: false, pathDash: false}
+	for _, a := range alts {
+		if _, ok := wantSet[a]; !ok {
+			t.Errorf("unexpected alternate %q (want one of %v)", a, wantSet)
+		}
+		wantSet[a] = true
+	}
+	for k, seen := range wantSet {
+		if !seen {
+			t.Errorf("missing expected alternate %q", k)
+		}
+	}
+}
+
+// TestResolveSession_AmbiguousCwd_RaisesError verifies the prefix-collision
+// case bubbles up through ResolveSession as a user-actionable error
+// suggesting `--cwd`. Even though the bucket itself is unique (only one
+// jsonl), its decode is non-unique.
+func TestResolveSession_AmbiguousCwd_RaisesError(t *testing.T) {
+	tmp := t.TempDir()
+	// Two real on-disk decodings of the same encoded bucket.
+	pathSlash := filepath.Join(tmp, "foo", "bar")
+	pathDash := filepath.Join(tmp, "foo-bar")
+	for _, p := range []string{pathSlash, pathDash} {
+		if err := os.MkdirAll(p, 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	root := t.TempDir()
+	bucket := EncodeBucket(pathSlash) // same as EncodeBucket(pathDash)
+	if err := os.MkdirAll(filepath.Join(root, bucket), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	sid := "ambig-sid"
+	if err := os.WriteFile(filepath.Join(root, bucket, sid+".jsonl"), []byte("{}\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := ResolveSession(root, sid, "")
+	if err == nil {
+		t.Fatal("expected ambiguous-cwd error")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "--cwd") {
+		t.Errorf("error should suggest --cwd: %v", err)
+	}
+	if !strings.Contains(msg, pathSlash) || !strings.Contains(msg, pathDash) {
+		t.Errorf("error should list both candidates:\n  %v\n  want both %s and %s",
+			err, pathSlash, pathDash)
+	}
+}
+
+// TestResolveSessionWithCwd_Happy verifies the manual --cwd path: encode
+// the user-supplied cwd into a bucket, find the jsonl there, return the
+// explicit cwd verbatim (no lossy decode).
+func TestResolveSessionWithCwd_Happy(t *testing.T) {
+	tmp := t.TempDir()
+	cwd := filepath.Join(tmp, "foo-bar") // hyphenated to prove we skip decode
+	if err := os.MkdirAll(cwd, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	root := t.TempDir()
+	bucket := EncodeBucket(cwd)
+	if err := os.MkdirAll(filepath.Join(root, bucket), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	sid := "manual-sid"
+	if err := os.WriteFile(filepath.Join(root, bucket, sid+".jsonl"), []byte("{}\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	res, err := ResolveSessionWithCwd(root, sid, cwd)
+	if err != nil {
+		t.Fatalf("ResolveSessionWithCwd: %v", err)
+	}
+	if res.Cwd != cwd {
+		t.Errorf("cwd: got %q, want %q", res.Cwd, cwd)
+	}
+	if res.Bucket != bucket {
+		t.Errorf("bucket: got %q, want %q", res.Bucket, bucket)
+	}
+}
+
+// TestResolveSessionWithCwd_RejectsDotDot exercises the defense-in-depth
+// path: --cwd containing `..` segments after Clean must be rejected. We
+// build a path whose Clean output still contains `..` — i.e. relative
+// (since absolute paths with `..` get collapsed by Clean).
+func TestResolveSessionWithCwd_RejectsDotDot(t *testing.T) {
+	_, err := ResolveSessionWithCwd(t.TempDir(), "sid", "../escape")
+	if err == nil {
+		t.Fatal("expected error rejecting relative --cwd")
+	}
+	// The "must be absolute" check fires first; exercise the dotdot guard
+	// directly via the helper.
+	if !hasDotDot(filepath.Clean("../escape")) {
+		t.Errorf("hasDotDot should detect `..` after Clean of ../escape")
+	}
+}
+
+// TestExecClaude_RejectsDotDot ensures ExecClaude refuses to chdir to a
+// path containing `..` segments. Uses a non-absolute relative path so
+// Clean preserves the `..` (Clean of an absolute path collapses `..`).
+func TestExecClaude_RejectsDotDot(t *testing.T) {
+	err := ExecClaude("claude", "../escape", "sid")
+	if err == nil {
+		t.Fatal("expected error rejecting .. in cwd")
+	}
+	if !strings.Contains(err.Error(), "..") {
+		t.Errorf("error should mention .. : %v", err)
+	}
+}
+
+// TestExecClaude_RejectsDotDotFromBucket exercises the reviewer's
+// `-tmp-..-etc` example end-to-end at the defense-in-depth boundary
+// (NOT via real exec — syscall.Exec would replace the test process).
+//
+// Strategy: build a synthetic cwd that contains `..` after Clean (only
+// possible for relative paths or paths with leading `..`), feed it
+// directly to ExecClaude, and assert it errors out. This pins the
+// defense path independently of whether decodeBucket happens to produce
+// such a path on this particular host. The decoder itself is allowed to
+// emit any string it likes — ExecClaude is the safety net.
+func TestExecClaude_RejectsDotDotFromBucket(t *testing.T) {
+	cases := []string{
+		"../escape",        // pure relative
+		"../foo/bar",       // relative deeper
+		"foo/../../escape", // Clean → ../escape
+	}
+	for _, c := range cases {
+		err := ExecClaude("claude", c, "sid")
+		if err == nil {
+			t.Errorf("ExecClaude should reject %q (contains .. after Clean=%q)",
+				c, filepath.Clean(c))
+			continue
+		}
+		if !strings.Contains(err.Error(), "..") {
+			t.Errorf("error for %q should mention `..`: %v", c, err)
+		}
 	}
 }
 
@@ -270,6 +460,139 @@ func TestRunResume_DryRun(t *testing.T) {
 		if !strings.Contains(out, want) {
 			t.Errorf("dry-run stdout missing %q\n%s", want, out)
 		}
+	}
+}
+
+// TestFindSidBuckets_DeterministicOnEqualMtime locks the secondary
+// tiebreak: when two buckets have identical synthetic mtimes (a real
+// possibility on second-resolution filesystems), the order is fixed
+// by ascending bucket name so collision-error messages don't flap
+// across runs.
+func TestFindSidBuckets_DeterministicOnEqualMtime(t *testing.T) {
+	root := t.TempDir()
+	sid := "tied-sid"
+	bA := "-tmp-a"
+	bZ := "-tmp-z"
+	for _, b := range []string{bZ, bA} { // create in reverse alpha order
+		if err := os.MkdirAll(filepath.Join(root, b), 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	// Force identical mtimes.
+	stamp := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	for _, b := range []string{bA, bZ} {
+		jsonl := filepath.Join(root, b, sid+".jsonl")
+		if err := os.WriteFile(jsonl, []byte("{}\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.Chtimes(jsonl, stamp, stamp); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// Run multiple times to catch any unstable ordering.
+	for i := 0; i < 20; i++ {
+		got, err := findSidBuckets(root, sid)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(got) != 2 {
+			t.Fatalf("iter %d: want 2 buckets, got %d: %v", i, len(got), got)
+		}
+		if got[0] != bA || got[1] != bZ {
+			t.Fatalf("iter %d: ordering not deterministic by name: got %v", i, got)
+		}
+	}
+}
+
+// TestRunResume_BinaryFlagThreadedThroughDryRun exercises Polish 3 from
+// the PR #35 review: the `--binary` flag has full end-to-end coverage
+// through runResume, not just via direct exec.Command. With --dry-run we
+// never actually execute the fake binary, but the printed `exec:` line
+// must name the explicit value passed via --binary.
+func TestRunResume_BinaryFlagThreadedThroughDryRun(t *testing.T) {
+	root := t.TempDir()
+	bucket := "-tmp-bin-flag"
+	if err := os.MkdirAll(filepath.Join(root, bucket), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	sid := "bin-flag-sid"
+	jsonl := filepath.Join(root, bucket, sid+".jsonl")
+	if err := os.WriteFile(jsonl, []byte("{}\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Place a fake binary somewhere unrelated; it never gets invoked since
+	// --dry-run skips ExecClaude. The point is just that runResume prints it.
+	fakeDir := t.TempDir()
+	fakeBin := filepath.Join(fakeDir, "my-fake-claude")
+	if err := os.WriteFile(fakeBin, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	stdout, restore := captureStdout(t)
+	defer restore()
+
+	code := runResume([]string{
+		"--projects-dir", root,
+		"--binary", fakeBin,
+		"--dry-run",
+		sid,
+	})
+	if code != 0 {
+		t.Fatalf("runResume exit=%d", code)
+	}
+	out := stdout()
+	wantSubstr := "exec:   " + fakeBin + " --resume " + sid
+	if !strings.Contains(out, wantSubstr) {
+		t.Errorf("expected dry-run output to contain %q, got:\n%s", wantSubstr, out)
+	}
+}
+
+// TestRunResume_DryRunDoesNotExec exercises Polish 4: --dry-run must
+// genuinely skip exec, not merely change what's printed. We point
+// --binary at a fake script that writes a sentinel file when invoked,
+// then assert the sentinel does NOT appear after runResume completes.
+func TestRunResume_DryRunDoesNotExec(t *testing.T) {
+	if _, err := exec.LookPath("sh"); err != nil {
+		t.Skip("sh not available")
+	}
+	root := t.TempDir()
+	bucket := "-tmp-no-exec"
+	if err := os.MkdirAll(filepath.Join(root, bucket), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	sid := "no-exec-sid"
+	jsonl := filepath.Join(root, bucket, sid+".jsonl")
+	if err := os.WriteFile(jsonl, []byte("{}\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Sentinel file that would be created if the fake binary actually ran.
+	sentinelDir := t.TempDir()
+	sentinel := filepath.Join(sentinelDir, "ran")
+	fake := filepath.Join(sentinelDir, "claude")
+	script := "#!/bin/sh\ntouch " + sentinel + "\n"
+	if err := os.WriteFile(fake, []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	_, restore := captureStdout(t)
+	defer restore()
+
+	code := runResume([]string{
+		"--projects-dir", root,
+		"--binary", fake,
+		"--dry-run",
+		sid,
+	})
+	if code != 0 {
+		t.Fatalf("runResume exit=%d", code)
+	}
+	if _, err := os.Stat(sentinel); err == nil {
+		t.Fatal("--dry-run must NOT exec the binary, but sentinel file was created")
+	} else if !os.IsNotExist(err) {
+		t.Fatalf("unexpected stat error on sentinel: %v", err)
 	}
 }
 

--- a/cmd/tether/skill.go
+++ b/cmd/tether/skill.go
@@ -1,0 +1,191 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/piaobeizu/tether/internal/skill"
+)
+
+// skillCmd dispatches `tether skill <verb> ...`.
+func skillCmd(args []string) int {
+	if len(args) < 1 {
+		fmt.Fprintln(os.Stderr, "tether skill: missing verb (install|list|remove|info)")
+		return 2
+	}
+	switch args[0] {
+	case "install":
+		return skillInstall(args[1:])
+	case "list":
+		return skillList(args[1:])
+	case "remove", "uninstall":
+		return skillRemove(args[1:])
+	case "info", "show":
+		return skillInfo(args[1:])
+	default:
+		fmt.Fprintf(os.Stderr, "tether skill: unknown verb %q\n", args[0])
+		return 2
+	}
+}
+
+func skillInstall(args []string) int {
+	fs := flag.NewFlagSet("tether skill install", flag.ContinueOnError)
+	force := fs.Bool("force", false, "overwrite existing installation")
+	listPath := fs.String("blessed-list", "", "path to skills.toml (default: ./skills.toml if present)")
+	if err := fs.Parse(args); err != nil {
+		return 2
+	}
+	if fs.NArg() != 1 {
+		fmt.Fprintln(os.Stderr, "usage: tether skill install <name|git-url> [--force] [--blessed-list path]")
+		return 2
+	}
+	arg := fs.Arg(0)
+
+	pool, err := skill.DefaultPool()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		return 1
+	}
+	list, err := loadBlessedListWithFallback(*listPath)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		return 1
+	}
+	url, name, err := skill.ResolveSource(arg, list)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		return 1
+	}
+	ref := ""
+	if list != nil {
+		if entry, ok := list.Skills[name]; ok {
+			ref = entry.Ref
+		}
+	}
+	ctx := context.Background()
+	m, err := pool.Install(ctx, url, name, skill.InstallOptions{Force: *force, Ref: ref})
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		return 1
+	}
+	fmt.Printf("installed: %s\n", filepath.Join(pool.Root, name))
+	if m != nil {
+		fmt.Printf("  name:    %s\n", m.Skill.Name)
+		fmt.Printf("  version: %s\n", m.Skill.Version)
+		if m.Skill.Description != "" {
+			fmt.Printf("  desc:    %s\n", m.Skill.Description)
+		}
+	} else {
+		fmt.Println("  (no tether.toml — installed as plain cc plugin)")
+	}
+	return 0
+}
+
+func skillList(args []string) int {
+	if len(args) > 0 {
+		fmt.Fprintln(os.Stderr, "usage: tether skill list")
+		return 2
+	}
+	pool, err := skill.DefaultPool()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		return 1
+	}
+	names, err := pool.List()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		return 1
+	}
+	if len(names) == 0 {
+		fmt.Printf("(no skills installed in %s)\n", pool.Root)
+		return 0
+	}
+	for _, n := range names {
+		m, _ := pool.Info(n)
+		if m != nil {
+			fmt.Printf("%-24s %s\n", n, m.Skill.Version)
+		} else {
+			fmt.Printf("%-24s (no tether.toml)\n", n)
+		}
+	}
+	return 0
+}
+
+func skillRemove(args []string) int {
+	if len(args) != 1 {
+		fmt.Fprintln(os.Stderr, "usage: tether skill remove <name>")
+		return 2
+	}
+	pool, err := skill.DefaultPool()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		return 1
+	}
+	if !pool.Has(args[0]) {
+		fmt.Fprintf(os.Stderr, "tether skill: %q is not installed\n", args[0])
+		return 1
+	}
+	if err := pool.Remove(args[0]); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		return 1
+	}
+	fmt.Printf("removed: %s\n", args[0])
+	return 0
+}
+
+func skillInfo(args []string) int {
+	if len(args) != 1 {
+		fmt.Fprintln(os.Stderr, "usage: tether skill info <name>")
+		return 2
+	}
+	pool, err := skill.DefaultPool()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		return 1
+	}
+	m, err := pool.Info(args[0])
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		return 1
+	}
+	fmt.Printf("name:    %s\n", args[0])
+	fmt.Printf("path:    %s\n", pool.SkillDir(args[0]))
+	if m == nil {
+		fmt.Println("manifest: (no tether.toml — plain cc plugin)")
+		return 0
+	}
+	fmt.Printf("version: %s\n", m.Skill.Version)
+	if m.Skill.Description != "" {
+		fmt.Printf("desc:    %s\n", m.Skill.Description)
+	}
+	if m.Skill.Agents.Primary != "" {
+		fmt.Printf("agent:   %s (tested: %v)\n", m.Skill.Agents.Primary, m.Skill.Agents.Tested)
+	}
+	if len(m.Tether.FencedBlocks.Emits) > 0 {
+		fmt.Printf("emits:   %v\n", m.Tether.FencedBlocks.Emits)
+	}
+	if m.Tether.State.WorkspaceDir != "" {
+		fmt.Printf("state:   %s (lock=%t, gitignore=%t)\n",
+			m.Tether.State.WorkspaceDir,
+			m.Tether.State.FileLock,
+			m.Tether.State.GitignoreDefault)
+	}
+	return 0
+}
+
+// loadBlessedListWithFallback resolves the blessed list source in priority order:
+//  1. --blessed-list <path> when explicitly passed
+//  2. ./skills.toml next to cwd (developer override)
+//  3. embedded copy compiled into the binary from internal/skill/skills.toml
+func loadBlessedListWithFallback(explicit string) (*skill.BlessedList, error) {
+	if explicit != "" {
+		return skill.LoadBlessedList(explicit)
+	}
+	if _, err := os.Stat(skill.BlessedListPath); err == nil {
+		return skill.LoadBlessedList(skill.BlessedListPath)
+	}
+	return skill.EmbeddedBlessedList()
+}

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/piaobeizu/tether
 go 1.25.0
 
 require (
+	github.com/BurntSushi/toml v1.6.0
 	github.com/fsnotify/fsnotify v1.9.0
 	golang.org/x/crypto v0.50.0
 )

--- a/go.sum
+++ b/go.sum
@@ -1,11 +1,8 @@
-<<<<<<< HEAD
+github.com/BurntSushi/toml v1.6.0 h1:dRaEfpa2VI55EwlIW72hMRHdWouJeRF7TPYhI+AUQjk=
+github.com/BurntSushi/toml v1.6.0/go.mod h1:ukJfTF/6rtPPRCnwkur4qwRxa8vTRFBF0uk2lLoLwho=
 github.com/fsnotify/fsnotify v1.9.0 h1:2Ml+OJNzbYCTzsxtv8vKSFD9PbJjmhYF14k/jKC7S9k=
 github.com/fsnotify/fsnotify v1.9.0/go.mod h1:8jBTzvmWwFyi3Pb8djgCCO5IBqzKJ/Jwo8TRcHyHii0=
 golang.org/x/crypto v0.50.0 h1:zO47/JPrL6vsNkINmLoo/PH1gcxpls50DNogFvB5ZGI=
 golang.org/x/crypto v0.50.0/go.mod h1:3muZ7vA7PBCE6xgPX7nkzzjiUq87kRItoJQM1Yo8S+Q=
 golang.org/x/sys v0.43.0 h1:Rlag2XtaFTxp19wS8MXlJwTvoh8ArU6ezoyFsMyCTNI=
 golang.org/x/sys v0.43.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
-=======
-github.com/BurntSushi/toml v1.6.0 h1:dRaEfpa2VI55EwlIW72hMRHdWouJeRF7TPYhI+AUQjk=
-github.com/BurntSushi/toml v1.6.0/go.mod h1:ukJfTF/6rtPPRCnwkur4qwRxa8vTRFBF0uk2lLoLwho=
->>>>>>> 1a6c1c6 (feat(skill): Epic #8 — manifest + global pool + cc adapter + CLI)

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,11 @@
+<<<<<<< HEAD
 github.com/fsnotify/fsnotify v1.9.0 h1:2Ml+OJNzbYCTzsxtv8vKSFD9PbJjmhYF14k/jKC7S9k=
 github.com/fsnotify/fsnotify v1.9.0/go.mod h1:8jBTzvmWwFyi3Pb8djgCCO5IBqzKJ/Jwo8TRcHyHii0=
 golang.org/x/crypto v0.50.0 h1:zO47/JPrL6vsNkINmLoo/PH1gcxpls50DNogFvB5ZGI=
 golang.org/x/crypto v0.50.0/go.mod h1:3muZ7vA7PBCE6xgPX7nkzzjiUq87kRItoJQM1Yo8S+Q=
 golang.org/x/sys v0.43.0 h1:Rlag2XtaFTxp19wS8MXlJwTvoh8ArU6ezoyFsMyCTNI=
 golang.org/x/sys v0.43.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
+=======
+github.com/BurntSushi/toml v1.6.0 h1:dRaEfpa2VI55EwlIW72hMRHdWouJeRF7TPYhI+AUQjk=
+github.com/BurntSushi/toml v1.6.0/go.mod h1:ukJfTF/6rtPPRCnwkur4qwRxa8vTRFBF0uk2lLoLwho=
+>>>>>>> 1a6c1c6 (feat(skill): Epic #8 — manifest + global pool + cc adapter + CLI)

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -1,0 +1,114 @@
+// Package daemon wires the v0.1 process skeleton from spec §4.1: the
+// main goroutine constructs the watchdog and supervises two subsystem
+// goroutines, the daemon (cc/PTY/lock) and the client (QUIC connection
+// to server). v0.1 ships placeholder subsystems — the goal of this
+// slice (Epic #3 #1) is the supervision skeleton, not the real work
+// inside daemon/client.
+//
+// The cc PTY and other process-lifetime resources will be hoisted to
+// main and threaded into the subsystem context in a follow-up slice
+// (§4.2 ownership rules); for now the placeholder subsystems just run
+// a heartbeat loop that proves the supervisor mechanics.
+package daemon
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"time"
+
+	"github.com/piaobeizu/tether/internal/watchdog"
+)
+
+// Config bundles the runtime knobs that cmd/tether's flag parser
+// supplies. Kept small and additive — feature flags grow this struct,
+// not new constructor variants.
+type Config struct {
+	// Verbose enables supervisor + subsystem progress logging.
+	Verbose bool
+
+	// Stderr is where logger output lands. nil = io.Discard.
+	Stderr io.Writer
+
+	// HeartbeatTimeout overrides the watchdog default. Zero = use
+	// watchdog.New() default (5s).
+	HeartbeatTimeout time.Duration
+
+	// SubsystemFactories lets tests install fake subsystems in place
+	// of the real daemon/client. nil → use defaultSubsystems().
+	SubsystemFactories []SubsystemFactory
+}
+
+// SubsystemFactory is a deferred constructor for a Subsystem. The
+// supervisor calls the factory once on startup; the resulting
+// Subsystem may be re-Run many times (each invocation = a fresh
+// context, but the same instance — implementations must NOT keep
+// per-run state on the receiver).
+type SubsystemFactory func() watchdog.Subsystem
+
+// Run constructs a Watchdog, registers the configured subsystems,
+// and blocks until ctx is canceled. Returns nil on clean shutdown,
+// non-nil only if the supervisor itself failed to start (today: never).
+func Run(ctx context.Context, cfg Config) error {
+	stderr := cfg.Stderr
+	if stderr == nil {
+		stderr = io.Discard
+	}
+
+	wd := watchdog.New()
+	if cfg.HeartbeatTimeout > 0 {
+		wd.HeartbeatTimeout = cfg.HeartbeatTimeout
+	}
+	if cfg.Verbose {
+		wd.Logger = func(format string, args ...any) {
+			fmt.Fprintf(stderr, format+"\n", args...)
+		}
+	}
+
+	factories := cfg.SubsystemFactories
+	if factories == nil {
+		factories = defaultSubsystems()
+	}
+	for _, f := range factories {
+		wd.Supervise(f())
+	}
+
+	return wd.Run(ctx)
+}
+
+// defaultSubsystems is the v0.1 placeholder topology: a "daemon"
+// subsystem (will own AgentProvider/PTY/lock in later slices) and a
+// "client" subsystem (will hold the QUIC connection to server). Both
+// currently just heartbeat — the watchdog is the deliverable here, not
+// the workers.
+func defaultSubsystems() []SubsystemFactory {
+	return []SubsystemFactory{
+		func() watchdog.Subsystem { return &placeholderSubsystem{name: "daemon", interval: time.Second} },
+		func() watchdog.Subsystem { return &placeholderSubsystem{name: "client", interval: time.Second} },
+	}
+}
+
+// placeholderSubsystem is the v0.1 skeleton-fill: a goroutine that
+// beats every interval and otherwise does nothing. Real implementation
+// arrives in subsequent Epic-3 slices (daemon: §5 AgentProvider
+// orchestration; client: §3.3 wire connection to server).
+type placeholderSubsystem struct {
+	name     string
+	interval time.Duration
+}
+
+func (p *placeholderSubsystem) Name() string { return p.name }
+
+func (p *placeholderSubsystem) Run(ctx context.Context, hb func()) error {
+	t := time.NewTicker(p.interval)
+	defer t.Stop()
+	hb()
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-t.C:
+			hb()
+		}
+	}
+}

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -1,0 +1,106 @@
+package daemon_test
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/piaobeizu/tether/internal/daemon"
+	"github.com/piaobeizu/tether/internal/watchdog"
+)
+
+// TestRun_StartsAndDrainsOnCancel — minimum smoke test: calling
+// Run with default subsystems should boot, supervise, and exit cleanly
+// when ctx cancels.
+func TestRun_StartsAndDrainsOnCancel(t *testing.T) {
+	t.Parallel()
+
+	var stderr bytes.Buffer
+	cfg := daemon.Config{
+		Verbose: true,
+		Stderr:  &stderr,
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- daemon.Run(ctx, cfg) }()
+
+	// Let it run a moment so we see "starting" log lines for both
+	// subsystems.
+	time.Sleep(100 * time.Millisecond)
+	cancel()
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Errorf("daemon.Run = %v; want nil", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("daemon.Run did not exit within 2s of ctx cancel")
+	}
+
+	logs := stderr.String()
+	for _, want := range []string{"daemon", "client", "starting"} {
+		if !strings.Contains(logs, want) {
+			t.Errorf("expected logs to mention %q; got:\n%s", want, logs)
+		}
+	}
+}
+
+// TestRun_CustomFactory — a Config-injected factory is honored
+// (this is the seam tests + later real implementations use to wire
+// the actual daemon/client subsystems).
+func TestRun_CustomFactory(t *testing.T) {
+	t.Parallel()
+
+	var beats atomic.Int64
+	factory := func() watchdog.Subsystem {
+		return watchdog.SubsystemFunc{
+			N: "test-sub",
+			F: func(ctx context.Context, hb func()) error {
+				t := time.NewTicker(10 * time.Millisecond)
+				defer t.Stop()
+				for {
+					select {
+					case <-ctx.Done():
+						return ctx.Err()
+					case <-t.C:
+						hb()
+						beats.Add(1)
+					}
+				}
+			},
+		}
+	}
+
+	cfg := daemon.Config{
+		HeartbeatTimeout:   100 * time.Millisecond,
+		SubsystemFactories: []daemon.SubsystemFactory{factory},
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- daemon.Run(ctx, cfg) }()
+
+	// Wait for a few beats.
+	deadline := time.Now().Add(time.Second)
+	for time.Now().Before(deadline) && beats.Load() < 5 {
+		time.Sleep(5 * time.Millisecond)
+	}
+	if beats.Load() < 5 {
+		t.Errorf("expected >=5 beats from custom subsystem; got %d", beats.Load())
+	}
+
+	cancel()
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Errorf("daemon.Run = %v; want nil", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("daemon.Run did not exit within 2s of ctx cancel")
+	}
+}

--- a/internal/skill/adapter/aider.go
+++ b/internal/skill/adapter/aider.go
@@ -1,0 +1,15 @@
+package adapter
+
+// Aider is a v0.1 stub. Spec §11.Z.4: v0.2 lossy adapter — concat
+// SKILL.md content into CONVENTIONS.md, drop hooks with a warning.
+type Aider struct{}
+
+// Materialise panics — aider adapter is not implemented in v0.1.
+func (Aider) Materialise(workspaceDir, skillName, skillSourceDir string) error {
+	panic("adapter/aider: not impl in v0.1")
+}
+
+// Unmaterialise panics — aider adapter is not implemented in v0.1.
+func (Aider) Unmaterialise(workspaceDir, skillName string) error {
+	panic("adapter/aider: not impl in v0.1")
+}

--- a/internal/skill/adapter/cc.go
+++ b/internal/skill/adapter/cc.go
@@ -1,0 +1,99 @@
+package adapter
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// CCPluginsSubdir is the workspace-relative directory that cc's plugin
+// loader scans (spec §11.Z.6 step 2). Each enabled skill becomes a
+// symlink at <workspace>/.claude/plugins/<skill> pointing at the global
+// pool entry.
+const CCPluginsSubdir = ".claude/plugins"
+
+// CC is the v0.1 cc adapter. It owns nothing but the symlink contract:
+//
+//	<global-pool>/<skill>  →  <workspace>/.claude/plugins/<skill>
+//
+// Spec §11.Z.4: pure symlink, no copy/rewrite, no plugin.json generation
+// (skill ships its own .claude/plugin.json).
+type CC struct{}
+
+// Materialise links one skill into the workspace. If the link target
+// already exists and points at the same source, it is left alone
+// (idempotent re-spawn). Any non-symlink at the destination path is a
+// hard error — we refuse to clobber a real directory the user might
+// have committed by hand.
+func (CC) Materialise(workspaceDir, skillName, skillSourceDir string) error {
+	if workspaceDir == "" {
+		return errors.New("adapter/cc: empty workspaceDir")
+	}
+	if skillName == "" {
+		return errors.New("adapter/cc: empty skillName")
+	}
+	if skillSourceDir == "" {
+		return errors.New("adapter/cc: empty skillSourceDir")
+	}
+	if st, err := os.Stat(skillSourceDir); err != nil {
+		return fmt.Errorf("adapter/cc: skill source %s: %w", skillSourceDir, err)
+	} else if !st.IsDir() {
+		return fmt.Errorf("adapter/cc: skill source %s is not a directory", skillSourceDir)
+	}
+
+	pluginsDir := filepath.Join(workspaceDir, CCPluginsSubdir)
+	if err := os.MkdirAll(pluginsDir, 0o755); err != nil {
+		return fmt.Errorf("adapter/cc: ensure %s: %w", pluginsDir, err)
+	}
+	link := filepath.Join(pluginsDir, skillName)
+
+	// Resolve absolute source so the symlink is portable across cwd
+	// changes (cc spawns with workspace cwd; absolute is safest).
+	absSource, err := filepath.Abs(skillSourceDir)
+	if err != nil {
+		return fmt.Errorf("adapter/cc: abs source: %w", err)
+	}
+
+	// Inspect the existing entry, if any.
+	if fi, err := os.Lstat(link); err == nil {
+		if fi.Mode()&os.ModeSymlink == 0 {
+			return fmt.Errorf("adapter/cc: %s exists and is not a symlink (refusing to clobber)", link)
+		}
+		current, rerr := os.Readlink(link)
+		if rerr == nil && current == absSource {
+			return nil // already correct
+		}
+		// Stale or wrong target — replace it.
+		if err := os.Remove(link); err != nil {
+			return fmt.Errorf("adapter/cc: remove stale link %s: %w", link, err)
+		}
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("adapter/cc: stat %s: %w", link, err)
+	}
+
+	if err := os.Symlink(absSource, link); err != nil {
+		return fmt.Errorf("adapter/cc: symlink %s -> %s: %w", link, absSource, err)
+	}
+	return nil
+}
+
+// Unmaterialise removes the workspace symlink for a skill. No-op if the
+// link is absent. Refuses to delete real directories.
+func (CC) Unmaterialise(workspaceDir, skillName string) error {
+	link := filepath.Join(workspaceDir, CCPluginsSubdir, skillName)
+	fi, err := os.Lstat(link)
+	if errors.Is(err, os.ErrNotExist) {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("adapter/cc: stat %s: %w", link, err)
+	}
+	if fi.Mode()&os.ModeSymlink == 0 {
+		return fmt.Errorf("adapter/cc: %s is not a symlink (refusing to remove)", link)
+	}
+	if err := os.Remove(link); err != nil {
+		return fmt.Errorf("adapter/cc: remove %s: %w", link, err)
+	}
+	return nil
+}

--- a/internal/skill/adapter/cc_test.go
+++ b/internal/skill/adapter/cc_test.go
@@ -1,0 +1,122 @@
+package adapter
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestCC_Materialise_CreatesSymlink(t *testing.T) {
+	pool := t.TempDir()
+	ws := t.TempDir()
+	src := filepath.Join(pool, "dag")
+	if err := os.MkdirAll(src, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := (CC{}).Materialise(ws, "dag", src); err != nil {
+		t.Fatalf("Materialise: %v", err)
+	}
+	link := filepath.Join(ws, ".claude/plugins/dag")
+	fi, err := os.Lstat(link)
+	if err != nil {
+		t.Fatalf("Lstat: %v", err)
+	}
+	if fi.Mode()&os.ModeSymlink == 0 {
+		t.Errorf("expected symlink at %s, got mode %v", link, fi.Mode())
+	}
+	target, err := os.Readlink(link)
+	if err != nil {
+		t.Fatalf("Readlink: %v", err)
+	}
+	want, _ := filepath.Abs(src)
+	if target != want {
+		t.Errorf("symlink target: got %q want %q", target, want)
+	}
+}
+
+func TestCC_Materialise_Idempotent(t *testing.T) {
+	pool := t.TempDir()
+	ws := t.TempDir()
+	src := filepath.Join(pool, "dag")
+	if err := os.MkdirAll(src, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	cc := CC{}
+	for i := 0; i < 3; i++ {
+		if err := cc.Materialise(ws, "dag", src); err != nil {
+			t.Fatalf("call %d: %v", i, err)
+		}
+	}
+}
+
+func TestCC_Materialise_RefusesToClobberRealDir(t *testing.T) {
+	pool := t.TempDir()
+	ws := t.TempDir()
+	src := filepath.Join(pool, "dag")
+	if err := os.MkdirAll(src, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	link := filepath.Join(ws, ".claude/plugins/dag")
+	if err := os.MkdirAll(link, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := (CC{}).Materialise(ws, "dag", src); err == nil {
+		t.Errorf("expected error when destination is a real directory")
+	}
+}
+
+func TestCC_Materialise_RewritesStaleSymlink(t *testing.T) {
+	pool := t.TempDir()
+	ws := t.TempDir()
+	src := filepath.Join(pool, "dag")
+	if err := os.MkdirAll(src, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	old := filepath.Join(pool, "old")
+	if err := os.MkdirAll(old, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(ws, ".claude/plugins"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	link := filepath.Join(ws, ".claude/plugins/dag")
+	absOld, _ := filepath.Abs(old)
+	if err := os.Symlink(absOld, link); err != nil {
+		t.Fatal(err)
+	}
+	if err := (CC{}).Materialise(ws, "dag", src); err != nil {
+		t.Fatalf("Materialise: %v", err)
+	}
+	target, err := os.Readlink(link)
+	if err != nil {
+		t.Fatal(err)
+	}
+	wantAbs, _ := filepath.Abs(src)
+	if target != wantAbs {
+		t.Errorf("expected stale link rewritten to %q, got %q", wantAbs, target)
+	}
+}
+
+func TestCC_Unmaterialise(t *testing.T) {
+	pool := t.TempDir()
+	ws := t.TempDir()
+	src := filepath.Join(pool, "dag")
+	if err := os.MkdirAll(src, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	cc := CC{}
+	if err := cc.Materialise(ws, "dag", src); err != nil {
+		t.Fatal(err)
+	}
+	if err := cc.Unmaterialise(ws, "dag"); err != nil {
+		t.Fatalf("Unmaterialise: %v", err)
+	}
+	link := filepath.Join(ws, ".claude/plugins/dag")
+	if _, err := os.Lstat(link); !os.IsNotExist(err) {
+		t.Errorf("expected link removed; lstat err=%v", err)
+	}
+	// Unmaterialising again is a no-op.
+	if err := cc.Unmaterialise(ws, "dag"); err != nil {
+		t.Errorf("idempotent unmaterialise: %v", err)
+	}
+}

--- a/internal/skill/adapter/codex.go
+++ b/internal/skill/adapter/codex.go
@@ -1,0 +1,15 @@
+package adapter
+
+// Codex is a v0.1 stub. Spec §11.Z.4: v0.2 will implement textual rewrite
+// of skills/ + .codex-plugin/plugin.json generation (~200 LOC).
+type Codex struct{}
+
+// Materialise panics — codex adapter is not implemented in v0.1.
+func (Codex) Materialise(workspaceDir, skillName, skillSourceDir string) error {
+	panic("adapter/codex: not impl in v0.1")
+}
+
+// Unmaterialise panics — codex adapter is not implemented in v0.1.
+func (Codex) Unmaterialise(workspaceDir, skillName string) error {
+	panic("adapter/codex: not impl in v0.1")
+}

--- a/internal/skill/adapter/cursor.go
+++ b/internal/skill/adapter/cursor.go
@@ -1,0 +1,15 @@
+package adapter
+
+// Cursor is a v0.1 stub. Spec §11.Z.4: v0.2 lossy adapter — concat
+// SKILL.md into .cursor/rules/, drop hooks with a warning.
+type Cursor struct{}
+
+// Materialise panics — cursor adapter is not implemented in v0.1.
+func (Cursor) Materialise(workspaceDir, skillName, skillSourceDir string) error {
+	panic("adapter/cursor: not impl in v0.1")
+}
+
+// Unmaterialise panics — cursor adapter is not implemented in v0.1.
+func (Cursor) Unmaterialise(workspaceDir, skillName string) error {
+	panic("adapter/cursor: not impl in v0.1")
+}

--- a/internal/skill/adapter/doc.go
+++ b/internal/skill/adapter/doc.go
@@ -1,0 +1,5 @@
+// Package adapter wires installed skills into a workspace for a specific
+// agent backend. Spec §11.Z.4: in v0.1 only cc is implemented as a pure
+// symlink (~70 LOC); codex/opencode/aider/cursor are stubs that panic so
+// the seam is named from day 1 (matches D-17 AgentProvider discipline).
+package adapter

--- a/internal/skill/adapter/opencode.go
+++ b/internal/skill/adapter/opencode.go
@@ -1,0 +1,16 @@
+package adapter
+
+// Opencode is a v0.1 stub. Spec §11.Z.4: v0.2 partial implementation
+// (commands/agents pass through; hooks need a separate .ts file authored
+// per the opencode hook model).
+type Opencode struct{}
+
+// Materialise panics — opencode adapter is not implemented in v0.1.
+func (Opencode) Materialise(workspaceDir, skillName, skillSourceDir string) error {
+	panic("adapter/opencode: not impl in v0.1")
+}
+
+// Unmaterialise panics — opencode adapter is not implemented in v0.1.
+func (Opencode) Unmaterialise(workspaceDir, skillName string) error {
+	panic("adapter/opencode: not impl in v0.1")
+}

--- a/internal/skill/blessed_embed.go
+++ b/internal/skill/blessed_embed.go
@@ -1,0 +1,27 @@
+package skill
+
+import (
+	_ "embed"
+	"fmt"
+
+	"github.com/BurntSushi/toml"
+)
+
+//go:embed skills.toml
+var embeddedBlessedListTOML []byte
+
+// EmbeddedBlessedList returns the blessed list compiled into the binary
+// at build time from internal/skill/skills.toml. Used as the deterministic
+// default when the user passes neither --blessed-list nor a local file.
+//
+// v0.1 ships with an empty list — entries are added per-PR as skills mature.
+func EmbeddedBlessedList() (*BlessedList, error) {
+	var l BlessedList
+	if err := toml.Unmarshal(embeddedBlessedListTOML, &l); err != nil {
+		return nil, fmt.Errorf("skill: parse embedded blessed list: %w", err)
+	}
+	if l.Skills == nil {
+		l.Skills = map[string]BlessedEntry{}
+	}
+	return &l, nil
+}

--- a/internal/skill/doc.go
+++ b/internal/skill/doc.go
@@ -1,0 +1,19 @@
+// Package skill implements the v0.1 tether skill model: cc plugin standard
+// directory layout + an optional supplemental tether.toml manifest. See
+// spec §11.Z (D-20) for the full design.
+//
+// Boundary contract: the daemon (internal/backend/claude, internal/agent)
+// MUST NOT import this package. Skill execution is delegated entirely to
+// cc's plugin loader + hook system; this package only handles install,
+// manifest parsing, workspace materialisation (symlink), and CLI surface.
+//
+// Packages:
+//
+//   - internal/skill              manifest + install + workspace resolve
+//   - internal/skill/adapter      per-agent materialisers; cc.go is the
+//     only real implementation in v0.1, the rest are
+//     panicking stubs reserved for v0.2.
+//
+// Forward-compat seams (D-18): blob-register CLI is wired but stubs out
+// "not implemented in v0.1" so future skill code can reference it stably.
+package skill

--- a/internal/skill/install.go
+++ b/internal/skill/install.go
@@ -1,0 +1,369 @@
+package skill
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/BurntSushi/toml"
+)
+
+// DefaultPoolSubdir is the path beneath the user's home dir that holds the
+// global skill pool (spec §11.Z.6 + §11 Q7).
+const DefaultPoolSubdir = ".tether/skills"
+
+// BlessedListPath is the path inside the main tether repo where the
+// short-name → git URL mapping is checked in. The CLI bundles this list
+// at build time / falls back to an embedded copy; until then we look on
+// the filesystem next to the binary or under the workspace root.
+const BlessedListPath = "skills.toml"
+
+// BlessedList is the shape of the main-repo skills.toml. Schema is small
+// on purpose — short-name → git URL is enough for v0.1; richer metadata
+// (rev pinning, signature, channel) is deferred to v0.1.x. See open
+// questions in PR description.
+type BlessedList struct {
+	// Skills is keyed by short name. Each entry carries the upstream git
+	// URL plus optional pinning data we may honour later.
+	Skills map[string]BlessedEntry `toml:"skills"`
+}
+
+// BlessedEntry is one row in the blessed list.
+type BlessedEntry struct {
+	URL         string `toml:"url"`
+	Ref         string `toml:"ref"`         // optional branch/tag/sha
+	Description string `toml:"description"` // surfaced by `tether skill info`
+}
+
+// LoadBlessedList parses a skills.toml at the given path. Missing file is
+// not an error — callers fall back to "user must supply git URL".
+func LoadBlessedList(path string) (*BlessedList, error) {
+	b, err := os.ReadFile(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return &BlessedList{Skills: map[string]BlessedEntry{}}, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("skill: read blessed list %s: %w", path, err)
+	}
+	var l BlessedList
+	if err := toml.Unmarshal(b, &l); err != nil {
+		return nil, fmt.Errorf("skill: parse blessed list %s: %w", path, err)
+	}
+	if l.Skills == nil {
+		l.Skills = map[string]BlessedEntry{}
+	}
+	return &l, nil
+}
+
+// Pool is the global skills directory (default: ~/.tether/skills/). All
+// install / list / remove / info operations route through here.
+type Pool struct {
+	Root string
+}
+
+// DefaultPool returns the user-default pool rooted at $HOME/.tether/skills.
+func DefaultPool() (*Pool, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return nil, fmt.Errorf("skill: locate home dir: %w", err)
+	}
+	return &Pool{Root: filepath.Join(home, DefaultPoolSubdir)}, nil
+}
+
+// Ensure mkdirs the pool root. Idempotent.
+func (p *Pool) Ensure() error {
+	if err := os.MkdirAll(p.Root, 0o755); err != nil {
+		return fmt.Errorf("skill: ensure pool %s: %w", p.Root, err)
+	}
+	return nil
+}
+
+// SkillDir returns <pool>/<name>. Validation is the caller's responsibility.
+func (p *Pool) SkillDir(name string) string {
+	return filepath.Join(p.Root, name)
+}
+
+// Has reports whether <pool>/<name> exists as a directory.
+func (p *Pool) Has(name string) bool {
+	st, err := os.Stat(p.SkillDir(name))
+	return err == nil && st.IsDir()
+}
+
+// List enumerates installed skills (lexicographic). Hidden entries
+// (dotfiles) are skipped so future bookkeeping files don't leak.
+func (p *Pool) List() ([]string, error) {
+	entries, err := os.ReadDir(p.Root)
+	if errors.Is(err, os.ErrNotExist) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("skill: list pool %s: %w", p.Root, err)
+	}
+	out := make([]string, 0, len(entries))
+	for _, e := range entries {
+		if !e.IsDir() {
+			continue
+		}
+		name := e.Name()
+		if strings.HasPrefix(name, ".") {
+			continue
+		}
+		out = append(out, name)
+	}
+	sort.Strings(out)
+	return out, nil
+}
+
+// Remove deletes <pool>/<name>. No-op if absent.
+func (p *Pool) Remove(name string) error {
+	if !SkillNameRe.MatchString(name) {
+		return fmt.Errorf("skill: invalid name %q", name)
+	}
+	dir := p.SkillDir(name)
+	if _, err := os.Stat(dir); errors.Is(err, os.ErrNotExist) {
+		return nil
+	}
+	if err := os.RemoveAll(dir); err != nil {
+		return fmt.Errorf("skill: remove %s: %w", dir, err)
+	}
+	return nil
+}
+
+// ResolveSource turns a CLI argument (short-name or git URL) into a clone
+// URL using the blessed list. Returns the resolved URL plus the canonical
+// short name to install under.
+func ResolveSource(arg string, list *BlessedList) (url, name string, err error) {
+	if isGitURL(arg) {
+		// User-supplied URL: derive name from the last path segment
+		// minus a trailing .git, mirroring git's own default.
+		return arg, gitURLBase(arg), nil
+	}
+	if !SkillNameRe.MatchString(arg) {
+		return "", "", fmt.Errorf("skill: argument %q is neither a skill name nor a git URL", arg)
+	}
+	if list == nil {
+		return "", "", fmt.Errorf("skill: no blessed list available; pass full git URL")
+	}
+	entry, ok := list.Skills[arg]
+	if !ok {
+		return "", "", fmt.Errorf("skill: %q not in blessed list (try a git URL)", arg)
+	}
+	if entry.URL == "" {
+		return "", "", fmt.Errorf("skill: blessed entry %q has empty url", arg)
+	}
+	return entry.URL, arg, nil
+}
+
+// Cloner is the git-clone abstraction. Production uses GitCloneCmd;
+// tests inject a fake.
+type Cloner func(ctx context.Context, url, dest, ref string) error
+
+// GitCloneCmd shells out to `git clone --depth=1 [--branch ref] <url> <dest>`.
+func GitCloneCmd(ctx context.Context, url, dest, ref string) error {
+	args := []string{"clone", "--depth=1"}
+	if ref != "" {
+		args = append(args, "--branch", ref)
+	}
+	args = append(args, url, dest)
+	cmd := exec.CommandContext(ctx, "git", args...)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("skill: git clone %s: %w", url, err)
+	}
+	return nil
+}
+
+// InstallOptions tweaks Install. Force re-clones on top of an existing
+// directory; Cloner overrides the default for tests.
+type InstallOptions struct {
+	Force  bool
+	Cloner Cloner
+	Ref    string
+}
+
+// Install clones <url> into <pool>/<name>. Returns the parsed manifest
+// when one exists at the expected path (otherwise nil — a skill without
+// tether.toml is still valid, see §11.Z.1).
+func (p *Pool) Install(ctx context.Context, url, name string, opts InstallOptions) (*Manifest, error) {
+	if !SkillNameRe.MatchString(name) {
+		return nil, fmt.Errorf("skill: invalid name %q", name)
+	}
+	if err := p.Ensure(); err != nil {
+		return nil, err
+	}
+	dest := p.SkillDir(name)
+	if _, err := os.Stat(dest); err == nil {
+		if !opts.Force {
+			return nil, fmt.Errorf("skill: %s already installed (use --force to overwrite)", name)
+		}
+		if err := os.RemoveAll(dest); err != nil {
+			return nil, fmt.Errorf("skill: clear existing %s: %w", dest, err)
+		}
+	}
+	cloner := opts.Cloner
+	if cloner == nil {
+		cloner = GitCloneCmd
+	}
+	if err := cloner(ctx, url, dest, opts.Ref); err != nil {
+		return nil, err
+	}
+	m, err := readManifestIfPresent(dest)
+	if err != nil {
+		// Bad tether.toml is a hard error — the file is present and broken.
+		// Roll back the install so the user can retry.
+		_ = os.RemoveAll(dest)
+		return nil, err
+	}
+	return m, nil
+}
+
+func readManifestIfPresent(dir string) (*Manifest, error) {
+	path := filepath.Join(dir, "tether.toml")
+	if _, err := os.Stat(path); errors.Is(err, os.ErrNotExist) {
+		return nil, nil
+	}
+	return LoadManifest(path)
+}
+
+// Info returns the parsed manifest for an installed skill, or nil if the
+// skill exists but ships no tether.toml.
+func (p *Pool) Info(name string) (*Manifest, error) {
+	if !p.Has(name) {
+		return nil, fmt.Errorf("skill: %q not installed", name)
+	}
+	return readManifestIfPresent(p.SkillDir(name))
+}
+
+// MissingSkills reports which entries of `enabled` aren't yet in the pool.
+// Used by the B-6 fallback (spec §11.Z.11) and by `tether spawn`.
+func (p *Pool) MissingSkills(enabled []string) []string {
+	var missing []string
+	for _, n := range enabled {
+		if !p.Has(n) {
+			missing = append(missing, n)
+		}
+	}
+	return missing
+}
+
+// FallbackMode encodes the B-6 resolution policy.
+type FallbackMode int
+
+const (
+	// FallbackFail (default) — error out with a helpful message.
+	FallbackFail FallbackMode = iota
+	// FallbackAutoInstall — clone missing skills via the blessed list.
+	FallbackAutoInstall
+	// FallbackAllowMissing — proceed with whatever is installed.
+	FallbackAllowMissing
+)
+
+// ResolveSkills realises the B-6 fallback (spec §11.Z.11). Behaviour:
+//   - FallbackFail: returns an error listing missing skills + repair hint.
+//   - FallbackAutoInstall: tries to clone each missing skill via the
+//     blessed list; on any failure falls back to FallbackFail's error.
+//   - FallbackAllowMissing: returns the subset of enabled that are present
+//     and a non-fatal warning string (printed by the caller).
+//
+// The function never spawns cc — it exists so daemon/CLI startup paths
+// can decide whether to proceed.
+func ResolveSkills(
+	ctx context.Context,
+	pool *Pool,
+	list *BlessedList,
+	workspacePath string,
+	enabled []string,
+	mode FallbackMode,
+	cloner Cloner,
+) (resolved []string, warning string, err error) {
+	missing := pool.MissingSkills(enabled)
+	if len(missing) == 0 {
+		return enabled, "", nil
+	}
+	switch mode {
+	case FallbackFail:
+		return nil, "", missingSkillError(workspacePath, missing)
+	case FallbackAutoInstall:
+		if list == nil {
+			return nil, "", fmt.Errorf("skill: --auto-install requires a blessed list")
+		}
+		for _, name := range missing {
+			url, _, rerr := ResolveSource(name, list)
+			if rerr != nil {
+				return nil, "", fmt.Errorf("auto-install: %w", missingSkillError(workspacePath, missing))
+			}
+			ref := list.Skills[name].Ref
+			if _, ierr := pool.Install(ctx, url, name, InstallOptions{Cloner: cloner, Ref: ref}); ierr != nil {
+				return nil, "", fmt.Errorf("auto-install %s failed: %w", name, ierr)
+			}
+		}
+		return enabled, "", nil
+	case FallbackAllowMissing:
+		out := make([]string, 0, len(enabled)-len(missing))
+		for _, n := range enabled {
+			if pool.Has(n) {
+				out = append(out, n)
+			}
+		}
+		return out, fmt.Sprintf("warning: skipped missing skills: %s", strings.Join(missing, ", ")), nil
+	default:
+		return nil, "", fmt.Errorf("skill: unknown fallback mode %d", mode)
+	}
+}
+
+func missingSkillError(workspacePath string, missing []string) error {
+	var b strings.Builder
+	if workspacePath == "" {
+		b.WriteString("workspace requires skills not in global pool:\n")
+	} else {
+		fmt.Fprintf(&b, "workspace %s requires skills not in global pool:\n", workspacePath)
+	}
+	for _, n := range missing {
+		fmt.Fprintf(&b, "  - %s (enabled in tether.toml)\n", n)
+	}
+	b.WriteString("\ninstall with:\n")
+	for _, n := range missing {
+		fmt.Fprintf(&b, "  tether skill install %s\n", n)
+	}
+	b.WriteString("\nor spawn with available skills only:\n")
+	if workspacePath == "" {
+		b.WriteString("  tether spawn --allow-missing <workspace>\n")
+	} else {
+		fmt.Fprintf(&b, "  tether spawn --allow-missing %s\n", workspacePath)
+	}
+	return errors.New(b.String())
+}
+
+// --- helpers --------------------------------------------------------
+
+func isGitURL(s string) bool {
+	switch {
+	case strings.HasPrefix(s, "http://"),
+		strings.HasPrefix(s, "https://"),
+		strings.HasPrefix(s, "git@"),
+		strings.HasPrefix(s, "ssh://"),
+		strings.HasPrefix(s, "git://"):
+		return true
+	}
+	return strings.HasSuffix(s, ".git")
+}
+
+// gitURLBase derives "y" from "https://github.com/x/y(.git)" / "git@github.com:x/y(.git)".
+func gitURLBase(url string) string {
+	u := strings.TrimSuffix(url, ".git")
+	u = strings.TrimSuffix(u, "/")
+	// strip protocol + auth + host
+	if i := strings.LastIndex(u, "/"); i >= 0 {
+		u = u[i+1:]
+	}
+	if i := strings.LastIndex(u, ":"); i >= 0 {
+		u = u[i+1:]
+	}
+	return u
+}

--- a/internal/skill/install_test.go
+++ b/internal/skill/install_test.go
@@ -1,0 +1,249 @@
+package skill
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// fakeCloner pretends to clone a skill by writing a stand-in directory
+// (and optionally a tether.toml). Lets install_test exercise the full
+// pool layout without spawning git.
+type fakeCloner struct {
+	manifestSrc string // empty = skip manifest write
+	failOn      string // url that should error out
+}
+
+func (f *fakeCloner) clone(ctx context.Context, url, dest, ref string) error {
+	if f.failOn != "" && f.failOn == url {
+		return errors.New("fakeCloner: synthetic failure")
+	}
+	if err := os.MkdirAll(dest, 0o755); err != nil {
+		return err
+	}
+	// Always drop a marker so we can detect what got cloned.
+	if err := os.WriteFile(filepath.Join(dest, ".cloned-from"), []byte(url), 0o644); err != nil {
+		return err
+	}
+	if f.manifestSrc != "" {
+		if err := os.WriteFile(filepath.Join(dest, "tether.toml"), []byte(f.manifestSrc), 0o644); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func TestPool_InstallLayoutAndInfo(t *testing.T) {
+	pool := &Pool{Root: t.TempDir()}
+	fc := &fakeCloner{manifestSrc: minimalManifest}
+
+	m, err := pool.Install(context.Background(), "https://x/y.git", "dag", InstallOptions{Cloner: fc.clone})
+	if err != nil {
+		t.Fatalf("Install: %v", err)
+	}
+	if m == nil || m.Skill.Name != "dag" {
+		t.Fatalf("manifest not parsed; got %+v", m)
+	}
+	if !pool.Has("dag") {
+		t.Errorf("Has(dag) = false after install")
+	}
+	want := filepath.Join(pool.Root, "dag", ".cloned-from")
+	if _, err := os.Stat(want); err != nil {
+		t.Errorf("expected %s to exist: %v", want, err)
+	}
+
+	// Re-install without --force is a hard error
+	if _, err := pool.Install(context.Background(), "https://x/y.git", "dag", InstallOptions{Cloner: fc.clone}); err == nil {
+		t.Errorf("re-install without force expected to fail")
+	}
+
+	// With --force it succeeds
+	if _, err := pool.Install(context.Background(), "https://x/y.git", "dag", InstallOptions{Force: true, Cloner: fc.clone}); err != nil {
+		t.Errorf("re-install with force: %v", err)
+	}
+}
+
+func TestPool_InstallNoManifestIsValid(t *testing.T) {
+	pool := &Pool{Root: t.TempDir()}
+	fc := &fakeCloner{} // no manifest written
+	m, err := pool.Install(context.Background(), "https://x/y.git", "plain", InstallOptions{Cloner: fc.clone})
+	if err != nil {
+		t.Fatalf("Install: %v", err)
+	}
+	if m != nil {
+		t.Errorf("expected nil manifest for plain plugin, got %+v", m)
+	}
+}
+
+func TestPool_InstallBadManifestRollsBack(t *testing.T) {
+	pool := &Pool{Root: t.TempDir()}
+	fc := &fakeCloner{manifestSrc: "[skill]\nname =\n"} // broken toml
+	if _, err := pool.Install(context.Background(), "https://x/y.git", "broken", InstallOptions{Cloner: fc.clone}); err == nil {
+		t.Fatalf("expected install to fail on bad manifest")
+	}
+	if pool.Has("broken") {
+		t.Errorf("expected pool dir to be cleaned up after bad-manifest rollback")
+	}
+}
+
+func TestPool_ListAndRemove(t *testing.T) {
+	pool := &Pool{Root: t.TempDir()}
+	fc := &fakeCloner{manifestSrc: minimalManifest}
+	for _, n := range []string{"dag", "media-review", "writing-plans"} {
+		if _, err := pool.Install(context.Background(), "https://x/"+n+".git", n, InstallOptions{Cloner: fc.clone}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	got, err := pool.List()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 3 || got[0] != "dag" || got[1] != "media-review" || got[2] != "writing-plans" {
+		t.Errorf("List: got %v", got)
+	}
+	if err := pool.Remove("dag"); err != nil {
+		t.Fatal(err)
+	}
+	if pool.Has("dag") {
+		t.Errorf("Has(dag) still true after remove")
+	}
+	// Remove of absent skill is a no-op.
+	if err := pool.Remove("not-there"); err != nil {
+		t.Errorf("Remove(absent) returned %v", err)
+	}
+}
+
+func TestResolveSource(t *testing.T) {
+	list := &BlessedList{Skills: map[string]BlessedEntry{
+		"dag": {URL: "https://github.com/tether/skill-dag.git"},
+	}}
+
+	cases := []struct {
+		arg      string
+		wantURL  string
+		wantName string
+		wantErr  bool
+	}{
+		{"dag", "https://github.com/tether/skill-dag.git", "dag", false},
+		{"https://github.com/x/y.git", "https://github.com/x/y.git", "y", false},
+		{"git@github.com:foo/bar.git", "git@github.com:foo/bar.git", "bar", false},
+		{"unknown", "", "", true},
+		{"with spaces", "", "", true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.arg, func(t *testing.T) {
+			url, name, err := ResolveSource(tc.arg, list)
+			if tc.wantErr {
+				if err == nil {
+					t.Errorf("expected error")
+				}
+				return
+			}
+			if err != nil {
+				t.Errorf("unexpected err: %v", err)
+			}
+			if url != tc.wantURL {
+				t.Errorf("url: got %q want %q", url, tc.wantURL)
+			}
+			if name != tc.wantName {
+				t.Errorf("name: got %q want %q", name, tc.wantName)
+			}
+		})
+	}
+}
+
+func TestResolveSkills_FailDefault(t *testing.T) {
+	pool := &Pool{Root: t.TempDir()}
+	_, _, err := ResolveSkills(context.Background(), pool, nil, "/work/xiyou", []string{"dag"}, FallbackFail, nil)
+	if err == nil {
+		t.Fatal("expected error on missing skill")
+	}
+	msg := err.Error()
+	for _, want := range []string{"workspace /work/xiyou requires skills not in global pool", "tether skill install dag", "--allow-missing /work/xiyou"} {
+		if !strings.Contains(msg, want) {
+			t.Errorf("error missing %q\n%s", want, msg)
+		}
+	}
+}
+
+func TestResolveSkills_FailDefault_NoWorkspacePath(t *testing.T) {
+	pool := &Pool{Root: t.TempDir()}
+	_, _, err := ResolveSkills(context.Background(), pool, nil, "", []string{"dag"}, FallbackFail, nil)
+	if err == nil {
+		t.Fatal("expected error on missing skill")
+	}
+	if !strings.Contains(err.Error(), "<workspace>") {
+		t.Errorf("expected fallback placeholder when workspace path empty; got:\n%s", err.Error())
+	}
+}
+
+func TestResolveSkills_AllowMissing(t *testing.T) {
+	pool := &Pool{Root: t.TempDir()}
+	fc := &fakeCloner{manifestSrc: minimalManifest}
+	if _, err := pool.Install(context.Background(), "https://x/dag.git", "dag", InstallOptions{Cloner: fc.clone}); err != nil {
+		t.Fatal(err)
+	}
+	resolved, warn, err := ResolveSkills(context.Background(), pool, nil, "", []string{"dag", "media-review"}, FallbackAllowMissing, nil)
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if len(resolved) != 1 || resolved[0] != "dag" {
+		t.Errorf("resolved: got %v", resolved)
+	}
+	if !strings.Contains(warn, "media-review") {
+		t.Errorf("warning missing skill name: %q", warn)
+	}
+}
+
+func TestResolveSkills_AutoInstall(t *testing.T) {
+	pool := &Pool{Root: t.TempDir()}
+	list := &BlessedList{Skills: map[string]BlessedEntry{
+		"dag": {URL: "https://x/dag.git"},
+	}}
+	fc := &fakeCloner{manifestSrc: minimalManifest}
+	resolved, _, err := ResolveSkills(context.Background(), pool, list, "", []string{"dag"}, FallbackAutoInstall, fc.clone)
+	if err != nil {
+		t.Fatalf("auto-install: %v", err)
+	}
+	if len(resolved) != 1 || resolved[0] != "dag" {
+		t.Errorf("resolved: %v", resolved)
+	}
+	if !pool.Has("dag") {
+		t.Errorf("dag was not installed by auto-install path")
+	}
+}
+
+func TestResolveSkills_AutoInstallFallsBackOnUnknownName(t *testing.T) {
+	pool := &Pool{Root: t.TempDir()}
+	list := &BlessedList{Skills: map[string]BlessedEntry{}}
+	_, _, err := ResolveSkills(context.Background(), pool, list, "", []string{"missing"}, FallbackAutoInstall, nil)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "auto-install") {
+		t.Errorf("expected auto-install context in error: %v", err)
+	}
+}
+
+func TestLoadBlessedList_Absent(t *testing.T) {
+	dir := t.TempDir()
+	bl, err := LoadBlessedList(filepath.Join(dir, "skills.toml"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(bl.Skills) != 0 {
+		t.Errorf("expected empty list, got %v", bl.Skills)
+	}
+}
+
+const minimalManifest = `
+[skill]
+name = "dag"
+version = "0.1.0"
+
+[skill.agents]
+primary = "cc"
+`

--- a/internal/skill/manifest.go
+++ b/internal/skill/manifest.go
@@ -21,16 +21,16 @@ var SkillNameRe = regexp.MustCompile(`^[a-zA-Z0-9_-]+$`)
 // to a "plain cc plugin" — still installable, just no tether-specific
 // hints).
 type Manifest struct {
-	Skill         SkillSection         `toml:"skill"`
-	Tether        TetherSection        `toml:"tether"`
+	Skill  SkillSection  `toml:"skill"`
+	Tether TetherSection `toml:"tether"`
 }
 
 // SkillSection is the required identity block.
 type SkillSection struct {
-	Name        string       `toml:"name"`
-	Version     string       `toml:"version"`
-	Description string       `toml:"description"`
-	Agents      AgentsBlock  `toml:"agents"`
+	Name        string      `toml:"name"`
+	Version     string      `toml:"version"`
+	Description string      `toml:"description"`
+	Agents      AgentsBlock `toml:"agents"`
 }
 
 // AgentsBlock declares which agent backends a skill is authored for.

--- a/internal/skill/manifest.go
+++ b/internal/skill/manifest.go
@@ -1,0 +1,142 @@
+package skill
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+
+	"github.com/BurntSushi/toml"
+)
+
+// SkillNameRe is the canonical skill-name validator, shared with the
+// fence-tag suffix grammar (spec §11.AA.1) and the install path naming
+// rule (§11.Z.6). Kept here so manifest + CLI + adapter agree on one
+// definition.
+var SkillNameRe = regexp.MustCompile(`^[a-zA-Z0-9_-]+$`)
+
+// Manifest mirrors the v0.1 tether.toml schema (spec §11.Z.2). Every
+// section except [skill] is optional; absence is a valid skill (degrades
+// to a "plain cc plugin" — still installable, just no tether-specific
+// hints).
+type Manifest struct {
+	Skill         SkillSection         `toml:"skill"`
+	Tether        TetherSection        `toml:"tether"`
+}
+
+// SkillSection is the required identity block.
+type SkillSection struct {
+	Name        string       `toml:"name"`
+	Version     string       `toml:"version"`
+	Description string       `toml:"description"`
+	Agents      AgentsBlock  `toml:"agents"`
+}
+
+// AgentsBlock declares which agent backends a skill is authored for.
+// v0.1 only honours `primary` for the cc adapter; `tested` is metadata.
+type AgentsBlock struct {
+	Primary string   `toml:"primary"`
+	Tested  []string `toml:"tested"`
+}
+
+// TetherSection groups all tether-specific optional hints.
+type TetherSection struct {
+	FencedBlocks FencedBlocksBlock `toml:"fenced_blocks"`
+	Mobile       MobileBlock       `toml:"mobile"`
+	State        StateBlock        `toml:"state"`
+}
+
+// FencedBlocksBlock pre-registers the block kinds a skill emits, so the
+// App can wire renderers eagerly (spec §11.Z.2 + §11.AA).
+type FencedBlocksBlock struct {
+	Emits           []string `toml:"emits"`
+	PreferredLayout string   `toml:"preferred_layout"`
+	MobileDefault   string   `toml:"mobile_default"`
+}
+
+// MobileBlock holds mobile-only UI hints (spec §11.Z.2).
+type MobileBlock struct {
+	DefaultCardLayout string   `toml:"default_card_layout"`
+	QuickActions      []string `toml:"quick_actions"`
+}
+
+// StateBlock describes the skill's workspace state-file protocol
+// (spec §11.Z.9). daemon never reads these files; the values here are
+// enforced/used by skill scripts and `tether spawn`.
+type StateBlock struct {
+	WorkspaceDir     string `toml:"workspace_dir"`
+	FileLock         bool   `toml:"file_lock"`
+	GitignoreDefault bool   `toml:"gitignore_default"`
+}
+
+// WorkspaceManifest is the workspace-level tether.toml: who is enabled
+// for this user workspace (spec §11.Z.6).
+type WorkspaceManifest struct {
+	Skills WorkspaceSkillsBlock `toml:"skills"`
+}
+
+// WorkspaceSkillsBlock holds the enabled-skill resolver result.
+type WorkspaceSkillsBlock struct {
+	Enabled []string `toml:"enabled"`
+}
+
+// LoadManifest reads + validates a per-skill tether.toml.
+func LoadManifest(path string) (*Manifest, error) {
+	b, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("skill: read manifest %s: %w", path, err)
+	}
+	var m Manifest
+	if err := toml.Unmarshal(b, &m); err != nil {
+		return nil, fmt.Errorf("skill: parse manifest %s: %w", path, err)
+	}
+	if err := m.Validate(); err != nil {
+		return nil, fmt.Errorf("skill: invalid manifest %s: %w", path, err)
+	}
+	return &m, nil
+}
+
+// Validate enforces the minimum field set for a v0.1 manifest.
+func (m *Manifest) Validate() error {
+	if m.Skill.Name == "" {
+		return errors.New("[skill].name is required")
+	}
+	if !SkillNameRe.MatchString(m.Skill.Name) {
+		return fmt.Errorf("[skill].name %q must match %s", m.Skill.Name, SkillNameRe.String())
+	}
+	if m.Skill.Version == "" {
+		return errors.New("[skill].version is required")
+	}
+	if m.Skill.Agents.Primary == "" {
+		return errors.New("[skill.agents].primary is required (v0.1: must be \"cc\")")
+	}
+	return nil
+}
+
+// LoadWorkspaceManifest reads the workspace tether.toml; missing file is
+// treated as "no skills enabled" rather than an error.
+func LoadWorkspaceManifest(workspaceDir string) (*WorkspaceManifest, error) {
+	path := filepath.Join(workspaceDir, "tether.toml")
+	b, err := os.ReadFile(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return &WorkspaceManifest{}, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("skill: read workspace manifest %s: %w", path, err)
+	}
+	var w WorkspaceManifest
+	if err := toml.Unmarshal(b, &w); err != nil {
+		return nil, fmt.Errorf("skill: parse workspace manifest %s: %w", path, err)
+	}
+	return &w, nil
+}
+
+// EnabledSkills is a thin accessor used by `tether spawn` and resolveSkills
+// (B-6 fallback path; spec §11.Z.11).
+func (w *WorkspaceManifest) EnabledSkills() []string {
+	if w == nil {
+		return nil
+	}
+	return w.Skills.Enabled
+}

--- a/internal/skill/manifest_test.go
+++ b/internal/skill/manifest_test.go
@@ -1,0 +1,169 @@
+package skill
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestLoadManifest_HappyPath(t *testing.T) {
+	const src = `
+[skill]
+name = "dag"
+version = "0.1.0"
+description = "DAG-driven multi-step planning + execution skill"
+
+[skill.agents]
+primary = "cc"
+tested = ["cc"]
+
+[tether.fenced_blocks]
+emits = ["dag", "media"]
+preferred_layout = "full"
+mobile_default = "compact"
+
+[tether.mobile]
+default_card_layout = "compact"
+quick_actions = ["rollback", "approve"]
+
+[tether.state]
+workspace_dir = ".tether/dag/"
+file_lock = true
+gitignore_default = true
+`
+	path := writeTmp(t, "tether.toml", src)
+	m, err := LoadManifest(path)
+	if err != nil {
+		t.Fatalf("LoadManifest: %v", err)
+	}
+	if m.Skill.Name != "dag" {
+		t.Errorf("name: got %q want dag", m.Skill.Name)
+	}
+	if m.Skill.Version != "0.1.0" {
+		t.Errorf("version: got %q", m.Skill.Version)
+	}
+	if m.Skill.Agents.Primary != "cc" {
+		t.Errorf("agents.primary: got %q", m.Skill.Agents.Primary)
+	}
+	if got := m.Tether.FencedBlocks.Emits; len(got) != 2 || got[0] != "dag" || got[1] != "media" {
+		t.Errorf("fenced_blocks.emits: got %v", got)
+	}
+	if !m.Tether.State.FileLock || !m.Tether.State.GitignoreDefault {
+		t.Errorf("tether.state booleans not parsed: %+v", m.Tether.State)
+	}
+	if m.Tether.State.WorkspaceDir != ".tether/dag/" {
+		t.Errorf("workspace_dir: got %q", m.Tether.State.WorkspaceDir)
+	}
+	if got := m.Tether.Mobile.QuickActions; len(got) != 2 {
+		t.Errorf("quick_actions: %v", got)
+	}
+}
+
+func TestLoadManifest_MinimalValid(t *testing.T) {
+	// Only required fields; everything else absent.
+	const src = `
+[skill]
+name = "foo"
+version = "1.0.0"
+
+[skill.agents]
+primary = "cc"
+`
+	path := writeTmp(t, "tether.toml", src)
+	m, err := LoadManifest(path)
+	if err != nil {
+		t.Fatalf("LoadManifest: %v", err)
+	}
+	if m.Skill.Name != "foo" {
+		t.Errorf("name: got %q", m.Skill.Name)
+	}
+	if len(m.Tether.FencedBlocks.Emits) != 0 {
+		t.Errorf("expected no emits, got %v", m.Tether.FencedBlocks.Emits)
+	}
+}
+
+func TestLoadManifest_Malformed(t *testing.T) {
+	cases := []struct {
+		name    string
+		src     string
+		wantSub string
+	}{
+		{
+			name:    "missing name",
+			src:     "[skill]\nversion = \"1\"\n[skill.agents]\nprimary = \"cc\"\n",
+			wantSub: "[skill].name is required",
+		},
+		{
+			name:    "missing version",
+			src:     "[skill]\nname = \"foo\"\n[skill.agents]\nprimary = \"cc\"\n",
+			wantSub: "[skill].version is required",
+		},
+		{
+			name:    "missing primary agent",
+			src:     "[skill]\nname = \"foo\"\nversion = \"1\"\n",
+			wantSub: "[skill.agents].primary is required",
+		},
+		{
+			name:    "invalid name chars",
+			src:     "[skill]\nname = \"bad name\"\nversion = \"1\"\n[skill.agents]\nprimary = \"cc\"\n",
+			wantSub: "must match",
+		},
+		{
+			name:    "broken toml syntax",
+			src:     "[skill]\nname =\n",
+			wantSub: "parse manifest",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			path := writeTmp(t, "tether.toml", tc.src)
+			_, err := LoadManifest(path)
+			if err == nil {
+				t.Fatalf("expected error, got nil")
+			}
+			if !strings.Contains(err.Error(), tc.wantSub) {
+				t.Errorf("error %q missing substring %q", err.Error(), tc.wantSub)
+			}
+		})
+	}
+}
+
+func TestLoadWorkspaceManifest_AbsentMeansNoSkills(t *testing.T) {
+	dir := t.TempDir()
+	w, err := LoadWorkspaceManifest(dir)
+	if err != nil {
+		t.Fatalf("LoadWorkspaceManifest: %v", err)
+	}
+	if got := w.EnabledSkills(); len(got) != 0 {
+		t.Errorf("expected empty enabled, got %v", got)
+	}
+}
+
+func TestLoadWorkspaceManifest_HappyPath(t *testing.T) {
+	dir := t.TempDir()
+	src := "[skills]\nenabled = [\"dag\", \"writing-plans\"]\n"
+	if err := os.WriteFile(filepath.Join(dir, "tether.toml"), []byte(src), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	w, err := LoadWorkspaceManifest(dir)
+	if err != nil {
+		t.Fatalf("LoadWorkspaceManifest: %v", err)
+	}
+	got := w.EnabledSkills()
+	if len(got) != 2 || got[0] != "dag" || got[1] != "writing-plans" {
+		t.Errorf("enabled: got %v", got)
+	}
+}
+
+// --- helpers --------------------------------------------------------
+
+func writeTmp(t *testing.T, name, content string) string {
+	t.Helper()
+	dir := t.TempDir()
+	p := filepath.Join(dir, name)
+	if err := os.WriteFile(p, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return p
+}

--- a/internal/skill/skills.toml
+++ b/internal/skill/skills.toml
@@ -1,0 +1,7 @@
+# Tether blessed skill list — embedded into the binary at build time
+# via internal/skill/blessed_embed.go. Edit this file and rebuild to
+# update the default short-name → git URL mapping.
+#
+# Empty for v0.1 — entries land per-skill via PR. See spec §11.Z.6.
+
+[skills]

--- a/internal/watchdog/backoff.go
+++ b/internal/watchdog/backoff.go
@@ -1,0 +1,67 @@
+package watchdog
+
+import (
+	"math"
+	"sync"
+	"time"
+)
+
+// Backoff is the supervisor restart backoff strategy. v0.1 uses
+// exponential backoff with a configurable cap and a jitter-free
+// schedule (single-process, single-supervisor — no thundering herd
+// problem to solve).
+//
+// Sequence with default config (Initial=200ms, Max=10s, Factor=2):
+//
+//	200ms, 400ms, 800ms, 1.6s, 3.2s, 6.4s, 10s, 10s, 10s, ...
+//
+// Reset() returns the schedule to Initial; supervisors call it after a
+// run survives longer than the resetThreshold (= 30s by default), so
+// transient failures don't permanently inflate the delay.
+type Backoff struct {
+	Initial time.Duration
+	Max     time.Duration
+	Factor  float64
+
+	mu      sync.Mutex
+	current time.Duration
+}
+
+// NewBackoff constructs a backoff with the given parameters. Zero values
+// fall back to defaults (Initial=200ms, Max=10s, Factor=2).
+func NewBackoff(initial, max time.Duration, factor float64) *Backoff {
+	if initial <= 0 {
+		initial = 200 * time.Millisecond
+	}
+	if max <= 0 {
+		max = 10 * time.Second
+	}
+	if factor < 1 {
+		factor = 2
+	}
+	return &Backoff{Initial: initial, Max: max, Factor: factor}
+}
+
+// Next returns the next delay and advances the schedule. Concurrency-safe.
+func (b *Backoff) Next() time.Duration {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if b.current == 0 {
+		b.current = b.Initial
+		return b.current
+	}
+	next := time.Duration(math.Min(
+		float64(b.Max),
+		float64(b.current)*b.Factor,
+	))
+	b.current = next
+	return b.current
+}
+
+// Reset rewinds the schedule. Supervisors call this after a successful
+// run-window so transient panics don't ratchet the delay forever.
+func (b *Backoff) Reset() {
+	b.mu.Lock()
+	b.current = 0
+	b.mu.Unlock()
+}

--- a/internal/watchdog/doc.go
+++ b/internal/watchdog/doc.go
@@ -1,0 +1,41 @@
+// Package watchdog implements the v0.1 process supervision skeleton from
+// spec §4.1 / D-11: the tether CLI's main goroutine plays watchdog over
+// two subsystem goroutines (daemon + client). Sub-goroutine panics are
+// recovered, deadlocks are detected via heartbeat timeout, and the
+// failed subsystem is restarted after exponential backoff.
+//
+// What this package owns
+//
+//   - Subsystem — the unit of supervised work. Implementers get an
+//     in-loop Heartbeat() func they MUST call periodically; missing the
+//     heartbeat for HeartbeatTimeout is treated as a deadlock and the
+//     subsystem context is canceled, the goroutine torn down, and a
+//     fresh instance restarted.
+//
+//   - Watchdog.Run — main-goroutine entrypoint. Fires off one
+//     superviseLoop per registered Subsystem, blocks until ctx is
+//     canceled (typically by the SIGTERM/SIGINT handler the binary
+//     installs), then waits for all loops to exit.
+//
+//   - safeRun / GoSafe — panic-recovering helpers. safeRun wraps a
+//     func(ctx) error and turns panics into errors. GoSafe is the
+//     "every goroutine in the daemon goes through this" launcher
+//     mandated by §4.3 (CI lint rule: no naked `go ...` outside this
+//     helper).
+//
+// What this package does NOT do
+//
+//   - It does NOT own the cc subprocess (spec §4.2: the PTY master fd
+//     belongs to main, not to a subsystem goroutine — sub-goroutine
+//     panic must NOT SIGHUP cc). v0.1 daemon-skeleton subsystem
+//     manages cc via internal/agent/AgentProvider; a follow-up slice
+//     hoists PTY fd ownership to main and threads it down.
+//
+//   - It does NOT cover the 10% kernel/runtime-fatal scenarios
+//     enumerated in §4.1 ("挡不住的"). Those are covered by the daemon
+//     resume contract (D-07 / §6) at a different layer.
+//
+// Spec references: §4.1 (watchdog承诺与限制), §4.2 (resource ownership),
+// §4.3 (CI lint), §4.4 (skeleton), §10 PoC-3 (the three scenarios this
+// supervisor must survive).
+package watchdog

--- a/internal/watchdog/heartbeat.go
+++ b/internal/watchdog/heartbeat.go
@@ -1,0 +1,41 @@
+package watchdog
+
+import (
+	"sync/atomic"
+	"time"
+)
+
+// heartbeat is the supervisor-side liveness probe. The supervisor hands
+// hb.Beat to the subsystem's Run; the subsystem MUST call it
+// periodically (the contract says "at least once every
+// HeartbeatTimeout/2"). The supervisor reads LastBeat from a watcher
+// goroutine and cancels the run if the gap exceeds HeartbeatTimeout.
+//
+// Implementation is lockless — Beat / LastBeat hit a single atomic
+// int64 (unix nanos). createdAt is captured once at construction and
+// is used by the supervisor to bound the time the subsystem may take
+// to issue its first beat.
+type heartbeat struct {
+	createdAt time.Time
+	lastNS    atomic.Int64
+}
+
+func newHeartbeat() *heartbeat {
+	return &heartbeat{createdAt: time.Now()}
+}
+
+// Beat records the current time. Called by the supervised subsystem.
+// Cheap: a single atomic store.
+func (h *heartbeat) Beat() {
+	h.lastNS.Store(time.Now().UnixNano())
+}
+
+// LastBeat returns the last beat time, or the zero time if Beat was
+// never called.
+func (h *heartbeat) LastBeat() time.Time {
+	v := h.lastNS.Load()
+	if v == 0 {
+		return time.Time{}
+	}
+	return time.Unix(0, v)
+}

--- a/internal/watchdog/safe.go
+++ b/internal/watchdog/safe.go
@@ -1,0 +1,91 @@
+package watchdog
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"runtime/debug"
+)
+
+// PanicError wraps a recovered panic in error form so superviseLoop can
+// uniformly report it to the operator. Unwrap returns the original
+// panic value when it implemented error; otherwise nil.
+type PanicError struct {
+	Value any
+	Stack []byte
+}
+
+func (e *PanicError) Error() string {
+	return fmt.Sprintf("panic: %v\n%s", e.Value, e.Stack)
+}
+
+func (e *PanicError) Unwrap() error {
+	if err, ok := e.Value.(error); ok {
+		return err
+	}
+	return nil
+}
+
+// IsPanic reports whether err originates from a recovered panic in
+// safeRun / GoSafe. Useful in tests / metrics that want to distinguish
+// "subsystem returned a normal error" from "subsystem panicked".
+func IsPanic(err error) bool {
+	var p *PanicError
+	return errors.As(err, &p)
+}
+
+// safeRun executes fn(ctx) under a deferred recover. A panic inside fn
+// is captured as a *PanicError with the goroutine stack trace; an
+// ordinary returned error is forwarded as-is. ctx is forwarded
+// untouched — fn is responsible for honoring cancellation.
+//
+// safeRun is the spec §4.4 helper; supervised work always reaches it
+// through superviseLoop. It's also re-exported for tests (and any
+// future caller that wants the bare panic-recovery primitive without
+// the rest of the supervisor).
+func safeRun(ctx context.Context, fn func(context.Context) error) (err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			err = &PanicError{Value: r, Stack: debug.Stack()}
+		}
+	}()
+	return fn(ctx)
+}
+
+// RunWithSafeRun is the exported wrapper around safeRun for callers
+// who want panic-as-error semantics outside the supervisor (notably
+// tests). Equivalent to:
+//
+//	defer func() { if r := recover(); r != nil { /* wrap */ } }()
+//	return fn(ctx)
+//
+// Subsystems supervised by Watchdog never need to call this — the
+// supervisor wraps every Run automatically.
+func RunWithSafeRun(ctx context.Context, fn func(context.Context) error) error {
+	return safeRun(ctx, fn)
+}
+
+// GoSafe launches fn in a fresh goroutine wrapped in a deferred recover.
+// Panics are reported through onPanic (if non-nil) or, if nil, swallowed
+// silently — caller is then responsible for surfacing them via a side
+// channel (a result channel, an error promise, etc.).
+//
+// Spec §4.3 mandates that every goroutine the daemon spawns goes
+// through this helper — a CI analyzer enforces it. Unsupervised
+// `go fn()` is a lint violation.
+//
+// onPanic runs in the GoSafe goroutine BEFORE the goroutine exits, so
+// callers may safely read from any channel onPanic publishes to without
+// racing the goroutine teardown.
+func GoSafe(fn func(), onPanic func(*PanicError)) {
+	go func() {
+		defer func() {
+			if r := recover(); r != nil {
+				if onPanic != nil {
+					onPanic(&PanicError{Value: r, Stack: debug.Stack()})
+				}
+			}
+		}()
+		fn()
+	}()
+}

--- a/internal/watchdog/safe_test.go
+++ b/internal/watchdog/safe_test.go
@@ -1,0 +1,193 @@
+package watchdog_test
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/piaobeizu/tether/internal/watchdog"
+)
+
+// TestSafeRun_ErrorPassthrough — non-panicking error returns are
+// forwarded as-is.
+func TestSafeRun_ErrorPassthrough(t *testing.T) {
+	t.Parallel()
+
+	want := errors.New("normal error")
+	got := watchdog.RunWithSafeRun(context.Background(), func(ctx context.Context) error {
+		return want
+	})
+	if !errors.Is(got, want) {
+		t.Errorf("expected %v, got %v", want, got)
+	}
+	if watchdog.IsPanic(got) {
+		t.Error("normal error must not be classified as panic")
+	}
+}
+
+// TestSafeRun_NilError — nil through nil.
+func TestSafeRun_NilError(t *testing.T) {
+	t.Parallel()
+
+	got := watchdog.RunWithSafeRun(context.Background(), func(ctx context.Context) error {
+		return nil
+	})
+	if got != nil {
+		t.Errorf("expected nil, got %v", got)
+	}
+}
+
+// TestSafeRun_PanicCaught — panics surface as PanicError with a stack.
+func TestSafeRun_PanicCaught(t *testing.T) {
+	t.Parallel()
+
+	got := watchdog.RunWithSafeRun(context.Background(), func(ctx context.Context) error {
+		panic("boom")
+	})
+	if got == nil {
+		t.Fatal("expected PanicError, got nil")
+	}
+	if !watchdog.IsPanic(got) {
+		t.Errorf("IsPanic = false; want true; err = %v", got)
+	}
+	if !strings.Contains(got.Error(), "boom") {
+		t.Errorf("PanicError should embed the panic value; got %q", got.Error())
+	}
+	if !strings.Contains(got.Error(), "goroutine") {
+		t.Errorf("PanicError should embed a stack trace; got %q", got.Error())
+	}
+}
+
+// TestSafeRun_PanicError_UnwrapForErrorPanic — panic(err) lets
+// errors.Is reach the wrapped error.
+func TestSafeRun_PanicError_UnwrapForErrorPanic(t *testing.T) {
+	t.Parallel()
+
+	sentinel := errors.New("sentinel panic value")
+	got := watchdog.RunWithSafeRun(context.Background(), func(ctx context.Context) error {
+		panic(sentinel)
+	})
+	if !errors.Is(got, sentinel) {
+		t.Errorf("errors.Is(got, sentinel) = false; want true; err = %v", got)
+	}
+}
+
+// TestGoSafe_PanicReportedToCallback — onPanic gets the captured info.
+func TestGoSafe_PanicReportedToCallback(t *testing.T) {
+	t.Parallel()
+
+	var (
+		mu  sync.Mutex
+		got *watchdog.PanicError
+	)
+	done := make(chan struct{})
+	watchdog.GoSafe(func() {
+		panic("from gosafe")
+	}, func(pe *watchdog.PanicError) {
+		mu.Lock()
+		got = pe
+		mu.Unlock()
+		close(done)
+	})
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("onPanic callback never fired")
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if got == nil {
+		t.Fatal("onPanic received nil")
+	}
+	if !strings.Contains(got.Error(), "from gosafe") {
+		t.Errorf("PanicError missing payload: %q", got.Error())
+	}
+}
+
+// TestGoSafe_NormalPathNoCallback — normal exit does NOT invoke onPanic.
+func TestGoSafe_NormalPathNoCallback(t *testing.T) {
+	t.Parallel()
+
+	called := make(chan struct{}, 1)
+	done := make(chan struct{})
+	watchdog.GoSafe(func() {
+		close(done)
+	}, func(_ *watchdog.PanicError) {
+		called <- struct{}{}
+	})
+	<-done
+	select {
+	case <-called:
+		t.Error("onPanic must not fire on normal goroutine exit")
+	case <-time.After(50 * time.Millisecond):
+	}
+}
+
+// TestGoSafe_NilCallbackSwallowsPanic — passing nil is allowed.
+func TestGoSafe_NilCallbackSwallowsPanic(t *testing.T) {
+	t.Parallel()
+
+	// We can't observe the recover directly, but we can confirm the
+	// goroutine doesn't crash the test process.
+	done := make(chan struct{})
+	watchdog.GoSafe(func() {
+		defer close(done)
+		panic("nil-onPanic")
+	}, nil)
+	select {
+	case <-done:
+		// goroutine ran far enough to defer close — recover succeeded.
+	case <-time.After(time.Second):
+		t.Fatal("goroutine did not run to defer close")
+	}
+}
+
+// TestBackoff_Schedule — verifies the documented sequence.
+func TestBackoff_Schedule(t *testing.T) {
+	t.Parallel()
+
+	b := watchdog.NewBackoff(100*time.Millisecond, 1*time.Second, 2)
+	want := []time.Duration{
+		100 * time.Millisecond,
+		200 * time.Millisecond,
+		400 * time.Millisecond,
+		800 * time.Millisecond,
+		1 * time.Second, // capped
+		1 * time.Second, // capped
+	}
+	for i, w := range want {
+		got := b.Next()
+		if got != w {
+			t.Errorf("Next %d = %v; want %v", i, got, w)
+		}
+	}
+	b.Reset()
+	if got := b.Next(); got != 100*time.Millisecond {
+		t.Errorf("after Reset, Next = %v; want 100ms", got)
+	}
+}
+
+// TestBackoff_DefaultsForZero — zero values fall back to documented
+// defaults.
+func TestBackoff_DefaultsForZero(t *testing.T) {
+	t.Parallel()
+
+	b := watchdog.NewBackoff(0, 0, 0)
+	first := b.Next()
+	if first != 200*time.Millisecond {
+		t.Errorf("default initial = %v; want 200ms", first)
+	}
+	// Confirm Max is 10s by stepping until plateau.
+	last := first
+	for range 20 {
+		last = b.Next()
+	}
+	if last != 10*time.Second {
+		t.Errorf("eventually capped at %v; want 10s", last)
+	}
+}

--- a/internal/watchdog/sigkill_poc3_test.go
+++ b/internal/watchdog/sigkill_poc3_test.go
@@ -1,0 +1,167 @@
+package watchdog_test
+
+import (
+	"context"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"sync/atomic"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/piaobeizu/tether/internal/watchdog"
+)
+
+// TestPoC3_Scenario3_OSSigkillSurrogate is the OS-level companion to
+// TestPoC3_Scenario3_FatalErrorRestarted. It validates the spec §4.1
+// "挡不住的" boundary — when an external SIGKILL targets a child
+// PROCESS (not just a goroutine), the supervisor wrapping that
+// process-level wait observes the abrupt exit and restarts.
+//
+// At the v0.1 daemon-skeleton layer there is no child process under
+// the watchdog (subsystems are goroutines), so this test exercises an
+// equivalent invariant: a Subsystem whose Run blocks on cmd.Wait()
+// for a child shell process — and that child gets SIGKILL'd — exits
+// with a fatal error which the supervisor classifies + restarts.
+//
+// This is the closest OS-level analog accessible without full
+// process-tree restructuring (which arrives in a later slice when
+// PTY ownership is hoisted out of the daemon goroutine per §4.2).
+func TestPoC3_Scenario3_OSSigkillSurrogate(t *testing.T) {
+	t.Parallel()
+
+	logger := &testLogger{}
+	wd := newFastWatchdog(logger)
+	// SIGKILL takes ~immediate effect on Linux; allow the supervisor
+	// to schedule a restart within 1s. Bump backoff a notch so the
+	// restart isn't so fast it lands in the kill race.
+	wd.BackoffInitial = 20 * time.Millisecond
+	wd.BackoffMax = 100 * time.Millisecond
+
+	// Locate /bin/sh once; if not present, this test is meaningless
+	// (we'd be testing exec.LookPath, not the watchdog). Skip.
+	sh, err := exec.LookPath("sh")
+	if err != nil {
+		t.Skipf("sh not available; SIGKILL surrogate test requires /bin/sh: %v", err)
+	}
+
+	var pidCh = make(chan int, 4)
+	var killed atomic.Int64
+	var clean atomic.Int64
+
+	sub := watchdog.SubsystemFunc{
+		N: "exec-runner",
+		F: func(ctx context.Context, hb func() ) error {
+			hb()
+			// Spawn a child shell that just sleeps for a few seconds.
+			// We deliberately don't pass ctx into the cmd so SIGKILL
+			// from outside (the test) is the only way it dies; if
+			// the supervisor cancels ctx (e.g. on parent shutdown),
+			// we kill the child ourselves to drain.
+			//
+			//nolint:gosec // test code, fixed argv
+			cmd := exec.Command(sh, "-c", "sleep 30")
+			if err := cmd.Start(); err != nil {
+				return err
+			}
+			select {
+			case pidCh <- cmd.Process.Pid:
+			default:
+			}
+
+			// Beat from a sibling goroutine so we keep the heartbeat
+			// alive while cmd.Wait blocks.
+			beatStop := make(chan struct{})
+			watchdog.GoSafe(func() {
+				t := time.NewTicker(30 * time.Millisecond)
+				defer t.Stop()
+				for {
+					select {
+					case <-beatStop:
+						return
+					case <-ctx.Done():
+						return
+					case <-t.C:
+						hb()
+					}
+				}
+			}, nil)
+
+			// Cancel awareness: if ctx fires, kill the child.
+			watchdog.GoSafe(func() {
+				select {
+				case <-ctx.Done():
+					_ = cmd.Process.Kill()
+				case <-beatStop:
+				}
+			}, nil)
+
+			err := cmd.Wait()
+			close(beatStop)
+			if err == nil {
+				clean.Add(1)
+				return nil
+			}
+			// On SIGKILL, exec.ExitError reports signaled.
+			if ee, ok := err.(*exec.ExitError); ok {
+				if ws, ok := ee.Sys().(syscall.WaitStatus); ok {
+					if ws.Signaled() && ws.Signal() == syscall.SIGKILL {
+						killed.Add(1)
+					}
+				}
+			}
+			return err
+		},
+	}
+	wd.Supervise(sub)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	done := make(chan error, 1)
+	go func() { done <- wd.Run(ctx) }()
+
+	// Kill the first two children we spot; the third is allowed to live.
+	killAttempts := 0
+	deadline := time.Now().Add(3 * time.Second)
+	for killAttempts < 2 && time.Now().Before(deadline) {
+		select {
+		case pid := <-pidCh:
+			// SIGKILL the child shell.
+			if err := syscall.Kill(pid, syscall.SIGKILL); err != nil {
+				t.Logf("kill pid %d: %v (likely already gone)", pid, err)
+			}
+			killAttempts++
+		case <-time.After(50 * time.Millisecond):
+		}
+	}
+
+	waitFor(t, 5*time.Second, "supervisor to absorb 2 SIGKILLs and start a 3rd run", func() bool {
+		return killed.Load() >= 2
+	})
+
+	// Drain remaining pidCh and stop.
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("watchdog did not exit within 5s of cancel")
+	}
+
+	stats := wd.Stats()
+	if stats[0].Restarts < 2 {
+		t.Errorf("expected >=2 restarts after 2 SIGKILLs, got %d", stats[0].Restarts)
+	}
+	if stats[0].Panics > 0 {
+		t.Errorf("SIGKILL surrogate must NOT count as panic; got %d", stats[0].Panics)
+	}
+	logs := logger.String()
+	if !strings.Contains(logs, "exec-runner") {
+		t.Errorf("expected supervisor logs to mention exec-runner, got:\n%s", logs)
+	}
+
+	// Sanity: confirm the test actually used a real binary on disk.
+	if _, err := exec.LookPath(filepath.Base(sh)); err != nil {
+		t.Errorf("post-condition: sh disappeared mid-test: %v", err)
+	}
+}

--- a/internal/watchdog/supervisor.go
+++ b/internal/watchdog/supervisor.go
@@ -1,0 +1,376 @@
+package watchdog
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"time"
+)
+
+// Subsystem is one supervised goroutine (e.g. "daemon", "client" — see
+// spec §4.1). It receives a per-run context and a Heartbeat func it
+// MUST call regularly to prove liveness; missing the heartbeat for
+// longer than the supervisor's HeartbeatTimeout is treated as a
+// deadlock and the run is canceled + restarted.
+//
+// Run returns nil for clean exit (only when ctx is canceled — see
+// resetSentinel below) or any error otherwise. Panics are caught by
+// the supervisor's safeRun wrapper and surfaced as *PanicError, so
+// implementations should not bother wrapping their own work in
+// recover() — that's the supervisor's job.
+type Subsystem interface {
+	// Name is a stable string used in logs and metrics. Conventionally
+	// short and lower-case ("daemon", "client").
+	Name() string
+
+	// Run is the worker loop. It MUST call hb() at least once every
+	// HeartbeatTimeout/2 to avoid being killed for deadlock; the
+	// supervisor's deadlock detector cancels the per-run ctx when the
+	// heartbeat goes silent. Run should react by exiting promptly
+	// (typically with ctx.Err()).
+	//
+	// Returning nil while ctx is NOT canceled is allowed but treated as
+	// "subsystem voluntarily decided to stop" — supervisor still
+	// restarts after backoff because v0.1 subsystems are expected to
+	// run forever.
+	Run(ctx context.Context, hb func()) error
+}
+
+// SubsystemFunc is an adapter so plain functions can satisfy Subsystem.
+type SubsystemFunc struct {
+	N string
+	F func(ctx context.Context, hb func()) error
+}
+
+func (s SubsystemFunc) Name() string { return s.N }
+func (s SubsystemFunc) Run(ctx context.Context, hb func()) error {
+	return s.F(ctx, hb)
+}
+
+// Watchdog supervises one or more Subsystems. Construct with New, add
+// subsystems with Supervise, then block in Run until the parent ctx is
+// canceled. Restart counts and last errors are observable via Stats for
+// tests and metrics.
+type Watchdog struct {
+	// HeartbeatTimeout bounds how long a subsystem may go without
+	// calling hb() before the supervisor cancels its ctx. Zero =
+	// disable deadlock detection (panic recovery + voluntary-error
+	// restart still apply).
+	HeartbeatTimeout time.Duration
+
+	// HeartbeatCheckInterval is how often the supervisor wakes to
+	// inspect the heartbeat. Smaller = faster detection, more CPU.
+	// Default (when zero): HeartbeatTimeout / 4, clamped to [10ms, 1s].
+	HeartbeatCheckInterval time.Duration
+
+	// BackoffInitial / BackoffMax / BackoffFactor configure the restart
+	// backoff. Zero values use NewBackoff defaults.
+	BackoffInitial time.Duration
+	BackoffMax     time.Duration
+	BackoffFactor  float64
+
+	// HealthyRunWindow is the run duration after which the supervisor
+	// resets the backoff schedule for that subsystem. Default = 30s.
+	HealthyRunWindow time.Duration
+
+	// Logger is called once per supervisory event (start, error,
+	// heartbeat-timeout, restart). nil = silent (handy for tests).
+	// The supervisor serializes all calls through logMu — implementers
+	// may use a non-thread-safe sink (e.g. bytes.Buffer) without
+	// further locking.
+	Logger func(format string, args ...any)
+
+	mu         sync.Mutex
+	subsystems []*supervised
+	wg         sync.WaitGroup
+	started    bool
+
+	logMu sync.Mutex
+}
+
+// supervised is the per-subsystem state the watchdog tracks.
+type supervised struct {
+	sub Subsystem
+
+	restartCount atomic.Int64
+	panicCount   atomic.Int64
+	timeoutCount atomic.Int64
+
+	mu      sync.Mutex
+	lastErr error
+}
+
+// SubsystemStats is a snapshot for tests / observability.
+type SubsystemStats struct {
+	Name         string
+	Restarts     int64
+	Panics       int64
+	Timeouts     int64
+	LastErr      error
+}
+
+// New constructs a Watchdog with sensible defaults. Callers may further
+// tune fields before calling Supervise / Run.
+func New() *Watchdog {
+	return &Watchdog{
+		HeartbeatTimeout:       5 * time.Second,
+		HeartbeatCheckInterval: 0, // auto
+		BackoffInitial:         200 * time.Millisecond,
+		BackoffMax:             10 * time.Second,
+		BackoffFactor:          2,
+		HealthyRunWindow:       30 * time.Second,
+	}
+}
+
+// Supervise registers a Subsystem. Must be called before Run; calling
+// after Run starts is a panic — supervisor topology is fixed for the
+// lifetime of the watchdog (matches spec §4.1: there are exactly two
+// subsystems, daemon + client).
+func (w *Watchdog) Supervise(sub Subsystem) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if w.started {
+		panic("watchdog: Supervise after Run is forbidden")
+	}
+	w.subsystems = append(w.subsystems, &supervised{sub: sub})
+}
+
+// Run starts a superviseLoop per registered subsystem and blocks until
+// ctx is canceled. After ctx cancels, Run waits for all loops to finish
+// then returns nil. Run is single-shot — calling twice is a programming
+// error and panics.
+func (w *Watchdog) Run(ctx context.Context) error {
+	w.mu.Lock()
+	if w.started {
+		w.mu.Unlock()
+		panic("watchdog: Run called twice")
+	}
+	w.started = true
+	subs := append([]*supervised(nil), w.subsystems...)
+	w.mu.Unlock()
+
+	for _, s := range subs {
+		w.wg.Add(1)
+		s := s
+		// Supervisor loops are themselves goroutines, but they're
+		// tracked by w.wg and re-entered through safeRun in their
+		// inner loop, so naked `go` is acceptable here. Subsystem
+		// implementations must use GoSafe for any further fan-out.
+		go func() {
+			defer w.wg.Done()
+			w.superviseLoop(ctx, s)
+		}()
+	}
+
+	<-ctx.Done()
+	w.wg.Wait()
+	return nil
+}
+
+// Stats returns a snapshot of all subsystems' counters.
+func (w *Watchdog) Stats() []SubsystemStats {
+	w.mu.Lock()
+	subs := append([]*supervised(nil), w.subsystems...)
+	w.mu.Unlock()
+
+	out := make([]SubsystemStats, 0, len(subs))
+	for _, s := range subs {
+		s.mu.Lock()
+		lastErr := s.lastErr
+		s.mu.Unlock()
+		out = append(out, SubsystemStats{
+			Name:     s.sub.Name(),
+			Restarts: s.restartCount.Load(),
+			Panics:   s.panicCount.Load(),
+			Timeouts: s.timeoutCount.Load(),
+			LastErr:  lastErr,
+		})
+	}
+	return out
+}
+
+// errHeartbeatTimeout is the supervisor-internal sentinel returned when
+// the deadlock detector kills a run. Surfaced through Stats.LastErr so
+// callers can match with errors.Is.
+var errHeartbeatTimeout = errors.New("watchdog: subsystem heartbeat timeout (deadlock)")
+
+// ErrHeartbeatTimeout is the public alias for errors.Is comparisons.
+var ErrHeartbeatTimeout = errHeartbeatTimeout
+
+// superviseLoop runs one supervised subsystem forever (until ctx is
+// canceled). Each iteration:
+//
+//  1. derives a per-run cancellable ctx
+//  2. starts a heartbeat watcher in a GoSafe goroutine
+//  3. invokes safeRun(s.sub.Run)
+//  4. tears down the heartbeat watcher
+//  5. on parent-ctx cancel → exit; otherwise sleep backoff, then loop
+//
+// State machine summary:
+//
+//	[idle] → start → [running]
+//	[running] → fn returns nil → [stopped]      (only valid when ctx done)
+//	[running] → fn returns err  → [crashed]
+//	[running] → fn panics       → [crashed]
+//	[running] → hb timeout      → [crashed]     (per-run ctx canceled, fn drained, errHeartbeatTimeout recorded)
+//	[crashed] → backoff.Next()  → [restarting] → [running]   (loop)
+//	[stopped]                                                  (exit superviseLoop)
+func (w *Watchdog) superviseLoop(parent context.Context, s *supervised) {
+	backoff := NewBackoff(w.BackoffInitial, w.BackoffMax, w.BackoffFactor)
+	healthyWindow := w.HealthyRunWindow
+	if healthyWindow <= 0 {
+		healthyWindow = 30 * time.Second
+	}
+
+	for {
+		if parent.Err() != nil {
+			return
+		}
+		runCtx, runCancel := context.WithCancel(parent)
+		startedAt := time.Now()
+
+		hb := newHeartbeat()
+		hbDone := make(chan struct{})
+		var hbTimedOut atomic.Bool
+
+		// Heartbeat watcher: cancels runCtx if hb goes silent for too
+		// long. Uses GoSafe to satisfy §4.3 — even our own internal
+		// goroutines route through the panic-recovery helper.
+		if w.HeartbeatTimeout > 0 {
+			GoSafe(func() {
+				defer close(hbDone)
+				w.watchHeartbeat(runCtx, hb, runCancel, &hbTimedOut)
+			}, func(pe *PanicError) {
+				// Heartbeat watcher panic is itself a bug; record it
+				// but don't try to "supervise the supervisor" — exit
+				// the watcher and let the run continue without
+				// deadlock detection (heartbeat is a defense-in-depth
+				// mechanism, not the only one).
+				w.logf("[watchdog] %s: heartbeat watcher panicked: %v", s.sub.Name(), pe)
+				close(hbDone)
+			})
+		} else {
+			close(hbDone)
+		}
+
+		w.logf("[watchdog] %s: starting (run #%d)", s.sub.Name(), s.restartCount.Load()+1)
+		err := safeRun(runCtx, func(ctx context.Context) error {
+			return s.sub.Run(ctx, hb.Beat)
+		})
+		runCancel()
+		<-hbDone
+
+		// Translate a heartbeat-induced cancellation into the dedicated
+		// sentinel so observers can distinguish "deadlock kill" from
+		// "ordinary error".
+		if hbTimedOut.Load() {
+			err = errHeartbeatTimeout
+			s.timeoutCount.Add(1)
+		}
+
+		if IsPanic(err) {
+			s.panicCount.Add(1)
+		}
+
+		s.mu.Lock()
+		s.lastErr = err
+		s.mu.Unlock()
+
+		// Parent-cancel takeover: if the parent ctx is done, exit
+		// regardless of how the run ended.
+		if parent.Err() != nil {
+			if err != nil {
+				w.logf("[watchdog] %s: shutting down with last err: %v", s.sub.Name(), summarize(err))
+			} else {
+				w.logf("[watchdog] %s: shutting down cleanly", s.sub.Name())
+			}
+			return
+		}
+
+		// Reset backoff if the run lasted long enough to count as
+		// healthy — prevents transient panics from permanently
+		// inflating the delay.
+		if time.Since(startedAt) >= healthyWindow {
+			backoff.Reset()
+		}
+		delay := backoff.Next()
+		s.restartCount.Add(1)
+		w.logf("[watchdog] %s: failed (%v); restarting in %v",
+			s.sub.Name(), summarize(err), delay)
+
+		select {
+		case <-parent.Done():
+			return
+		case <-time.After(delay):
+		}
+	}
+}
+
+func (w *Watchdog) watchHeartbeat(
+	ctx context.Context,
+	hb *heartbeat,
+	cancel context.CancelFunc,
+	timedOut *atomic.Bool,
+) {
+	interval := w.HeartbeatCheckInterval
+	if interval <= 0 {
+		interval = w.HeartbeatTimeout / 4
+		if interval < 10*time.Millisecond {
+			interval = 10 * time.Millisecond
+		}
+		if interval > time.Second {
+			interval = time.Second
+		}
+	}
+	t := time.NewTicker(interval)
+	defer t.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case now := <-t.C:
+			last := hb.LastBeat()
+			if last.IsZero() {
+				// Subsystem hasn't beat once yet — give it the full
+				// timeout from start; tracked by ctx start time
+				// approximated via heartbeat creation.
+				if now.Sub(hb.createdAt) > w.HeartbeatTimeout {
+					timedOut.Store(true)
+					cancel()
+					return
+				}
+				continue
+			}
+			if now.Sub(last) > w.HeartbeatTimeout {
+				timedOut.Store(true)
+				cancel()
+				return
+			}
+		}
+	}
+}
+
+func (w *Watchdog) logf(format string, args ...any) {
+	if w.Logger == nil {
+		return
+	}
+	w.logMu.Lock()
+	defer w.logMu.Unlock()
+	w.Logger(format, args...)
+}
+
+// summarize keeps log lines short — full panic stacks blow out logs.
+func summarize(err error) string {
+	if err == nil {
+		return "<nil>"
+	}
+	s := err.Error()
+	const cap = 240
+	if len(s) > cap {
+		return fmt.Sprintf("%s... [truncated]", s[:cap])
+	}
+	return s
+}

--- a/internal/watchdog/supervisor_test.go
+++ b/internal/watchdog/supervisor_test.go
@@ -1,0 +1,517 @@
+package watchdog_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/piaobeizu/tether/internal/watchdog"
+)
+
+// testLogger captures supervisor log lines for assertions.
+type testLogger struct {
+	mu    sync.Mutex
+	lines []string
+}
+
+func (l *testLogger) Logf(format string, args ...any) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	l.lines = append(l.lines, fmt.Sprintf(format, args...))
+}
+
+func (l *testLogger) String() string {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	return strings.Join(l.lines, "\n")
+}
+
+// scriptedSubsystem is a Subsystem whose Run delegates to a function
+// the test supplies. Tests can flip behavior between runs by mutating
+// the closure's captured state.
+type scriptedSubsystem struct {
+	name string
+	fn   func(ctx context.Context, hb func(), runIdx int) error
+
+	mu     sync.Mutex
+	runIdx int
+}
+
+func (s *scriptedSubsystem) Name() string { return s.name }
+
+func (s *scriptedSubsystem) Run(ctx context.Context, hb func()) error {
+	s.mu.Lock()
+	idx := s.runIdx
+	s.runIdx++
+	s.mu.Unlock()
+	return s.fn(ctx, hb, idx)
+}
+
+func (s *scriptedSubsystem) Runs() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.runIdx
+}
+
+// newFastWatchdog returns a watchdog tuned for tests: very fast
+// heartbeat detection + minimal backoff so a 3-restart sequence
+// completes in a fraction of a second.
+func newFastWatchdog(logger *testLogger) *watchdog.Watchdog {
+	wd := watchdog.New()
+	wd.HeartbeatTimeout = 100 * time.Millisecond
+	wd.HeartbeatCheckInterval = 20 * time.Millisecond
+	wd.BackoffInitial = 5 * time.Millisecond
+	wd.BackoffMax = 50 * time.Millisecond
+	wd.HealthyRunWindow = 200 * time.Millisecond
+	if logger != nil {
+		wd.Logger = logger.Logf
+	}
+	return wd
+}
+
+// waitFor polls until cond returns true or timeout expires; reports
+// failure with msg when it times out.
+func waitFor(t *testing.T, timeout time.Duration, msg string, cond func() bool) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if cond() {
+			return
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	t.Fatalf("waitFor: timeout (%v): %s", timeout, msg)
+}
+
+// ------------------------------------------------------------------
+// Scenario 1 — sub-goroutine panics, supervisor recovers + restarts.
+//
+// PoC-3 #1: "注入 panic 到 daemon goroutine, cc 是否存活、新 daemon
+// goroutine 是否正常接管".
+// ------------------------------------------------------------------
+func TestPoC3_Scenario1_PanicInSubsystemRestarts(t *testing.T) {
+	t.Parallel()
+
+	logger := &testLogger{}
+	wd := newFastWatchdog(logger)
+
+	const wantRuns = 3 // first run panics; expect supervisor to restart at least twice more.
+	sub := &scriptedSubsystem{
+		name: "daemon",
+		fn: func(ctx context.Context, hb func(), runIdx int) error {
+			hb()
+			if runIdx < 2 {
+				// First two runs panic — exercises the panic-recover path.
+				// Different shapes: first nil-deref-style, second string-panic.
+				if runIdx == 0 {
+					var p *int
+					_ = *p // nil deref panic
+				}
+				panic("scripted panic for PoC-3 #1")
+			}
+			// Third run: settle and just heartbeat until the test
+			// cancels the parent ctx.
+			t := time.NewTicker(20 * time.Millisecond)
+			defer t.Stop()
+			for {
+				select {
+				case <-ctx.Done():
+					return ctx.Err()
+				case <-t.C:
+					hb()
+				}
+			}
+		},
+	}
+	wd.Supervise(sub)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	done := make(chan error, 1)
+	go func() { done <- wd.Run(ctx) }()
+
+	waitFor(t, 2*time.Second, "subsystem to settle on run 3 (after 2 panics)", func() bool {
+		return sub.Runs() >= wantRuns
+	})
+
+	stats := wd.Stats()
+	if len(stats) != 1 {
+		t.Fatalf("expected 1 subsystem in stats, got %d", len(stats))
+	}
+	if stats[0].Panics < 2 {
+		t.Errorf("expected >=2 recovered panics, got %d", stats[0].Panics)
+	}
+	if stats[0].Restarts < 2 {
+		t.Errorf("expected >=2 restarts, got %d", stats[0].Restarts)
+	}
+
+	// Tear down.
+	cancel()
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Errorf("Run returned non-nil error: %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("watchdog did not return after parent cancel")
+	}
+
+	if !strings.Contains(logger.String(), "panic:") {
+		t.Errorf("expected supervisor log to mention panic, got:\n%s", logger.String())
+	}
+}
+
+// ------------------------------------------------------------------
+// Scenario 2 — sub-goroutine deadlocks (sleeps forever, ignores ctx
+// AND stops heartbeating) → watchdog detects via heartbeat timeout,
+// cancels run ctx, and restarts.
+//
+// PoC-3 #2: "注入死循环到 daemon, watchdog 是否在 10s 内发现 + cancel
+// ctx + 重启". The integration uses a 100ms heartbeat budget so the
+// test runs in well under a second; the spec's 10s budget is the
+// production knob.
+// ------------------------------------------------------------------
+func TestPoC3_Scenario2_DeadlockDetectedAndRestarted(t *testing.T) {
+	t.Parallel()
+
+	logger := &testLogger{}
+	wd := newFastWatchdog(logger)
+
+	// We deliberately want a subsystem that reaches a deadlock: it
+	// beats once to prove it started, then blocks on a select with
+	// a never-receiving channel AND no <-ctx.Done() arm. The only
+	// thing that can free it is the goroutine being abandoned when
+	// the supervisor decides to give up (we don't actually leak —
+	// we'll close stuck after the test to release the goroutine).
+	stuck := make(chan struct{})
+	t.Cleanup(func() { close(stuck) })
+
+	sub := &scriptedSubsystem{
+		name: "daemon",
+		fn: func(ctx context.Context, hb func(), runIdx int) error {
+			hb()
+			if runIdx == 0 {
+				// Honor ctx so we exit promptly when the supervisor
+				// cancels — but DON'T heartbeat anymore. Watchdog
+				// must rely on the heartbeat alone (this is the
+				// "deadlock-shaped" behavior: goroutine is alive
+				// but stuck not making progress).
+				select {
+				case <-ctx.Done():
+					return ctx.Err()
+				case <-stuck:
+					return nil
+				}
+			}
+			// Subsequent runs: heartbeat normally.
+			t := time.NewTicker(20 * time.Millisecond)
+			defer t.Stop()
+			for {
+				select {
+				case <-ctx.Done():
+					return ctx.Err()
+				case <-t.C:
+					hb()
+				}
+			}
+		},
+	}
+	wd.Supervise(sub)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	done := make(chan error, 1)
+	go func() { done <- wd.Run(ctx) }()
+
+	// Wait for at least one timeout-induced restart + a healthy run.
+	waitFor(t, 2*time.Second, "supervisor to detect deadlock and start a healthy run", func() bool {
+		stats := wd.Stats()
+		return len(stats) == 1 &&
+			stats[0].Timeouts >= 1 &&
+			sub.Runs() >= 2
+	})
+
+	stats := wd.Stats()
+	if !errors.Is(stats[0].LastErr, watchdog.ErrHeartbeatTimeout) && stats[0].Timeouts < 1 {
+		t.Errorf("expected at least one heartbeat timeout, got Timeouts=%d LastErr=%v",
+			stats[0].Timeouts, stats[0].LastErr)
+	}
+
+	cancel()
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Errorf("Run returned non-nil error: %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("watchdog did not return after parent cancel")
+	}
+
+	if !strings.Contains(logger.String(), "heartbeat timeout") {
+		t.Errorf("expected supervisor log to mention heartbeat timeout, got:\n%s", logger.String())
+	}
+}
+
+// ------------------------------------------------------------------
+// Scenario 3 — sub-goroutine "killed externally" (proxy for the
+// SIGKILL case in PoC-3 #3). At goroutine granularity, "external
+// SIGKILL" is simulated as: the subsystem returns a fatal error that
+// the supervisor must treat as restart-worthy (it does NOT take down
+// the process — only main can os.Exit per §4.3).
+//
+// PoC-3 #3 spec text says "main 进程被 SIGKILL，下次启动 needs-resume
+// 流程是否正常" — the resume flow is a separate slice (§6.2).  In
+// THIS slice we cover the analogous goroutine-level invariant:
+// abrupt-exit subsystem is restarted, supervisor logs, accounting is
+// correct.  An end-to-end OS SIGKILL test against a child binary lives
+// alongside in the cmd-level integration test below.
+// ------------------------------------------------------------------
+func TestPoC3_Scenario3_FatalErrorRestarted(t *testing.T) {
+	t.Parallel()
+
+	logger := &testLogger{}
+	wd := newFastWatchdog(logger)
+
+	var fatalCount atomic.Int64
+	sub := &scriptedSubsystem{
+		name: "daemon",
+		fn: func(ctx context.Context, hb func(), runIdx int) error {
+			hb()
+			if runIdx < 2 {
+				fatalCount.Add(1)
+				return errors.New("subsystem killed externally (simulated SIGKILL)")
+			}
+			t := time.NewTicker(20 * time.Millisecond)
+			defer t.Stop()
+			for {
+				select {
+				case <-ctx.Done():
+					return ctx.Err()
+				case <-t.C:
+					hb()
+				}
+			}
+		},
+	}
+	wd.Supervise(sub)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	done := make(chan error, 1)
+	go func() { done <- wd.Run(ctx) }()
+
+	waitFor(t, 2*time.Second, "supervisor to absorb 2 fatal exits", func() bool {
+		return fatalCount.Load() >= 2 && sub.Runs() >= 3
+	})
+
+	stats := wd.Stats()
+	if stats[0].Restarts < 2 {
+		t.Errorf("expected >=2 restarts, got %d", stats[0].Restarts)
+	}
+	if stats[0].Panics > 0 {
+		t.Errorf("fatal-error path must NOT count as panic; got Panics=%d", stats[0].Panics)
+	}
+
+	cancel()
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Errorf("Run returned non-nil error: %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("watchdog did not return after parent cancel")
+	}
+
+	if !strings.Contains(logger.String(), "killed externally") {
+		t.Errorf("expected supervisor log to surface fatal error, got:\n%s", logger.String())
+	}
+}
+
+// ------------------------------------------------------------------
+// Sanity tests for the supervisor mechanics that PoC-3 leans on.
+// ------------------------------------------------------------------
+
+// TestSupervise_SiblingIsolation — when one supervised subsystem
+// panics repeatedly, the other one continues running undisturbed.
+// This is the §4.1 invariant: a daemon panic must not affect the
+// client subsystem and vice versa.
+func TestSupervise_SiblingIsolation(t *testing.T) {
+	t.Parallel()
+
+	wd := newFastWatchdog(nil)
+
+	flaky := &scriptedSubsystem{
+		name: "flaky",
+		fn: func(ctx context.Context, hb func(), runIdx int) error {
+			hb()
+			if runIdx < 3 {
+				panic("flaky run")
+			}
+			t := time.NewTicker(20 * time.Millisecond)
+			defer t.Stop()
+			for {
+				select {
+				case <-ctx.Done():
+					return ctx.Err()
+				case <-t.C:
+					hb()
+				}
+			}
+		},
+	}
+
+	var stableBeats atomic.Int64
+	stable := &scriptedSubsystem{
+		name: "stable",
+		fn: func(ctx context.Context, hb func(), _ int) error {
+			t := time.NewTicker(10 * time.Millisecond)
+			defer t.Stop()
+			for {
+				select {
+				case <-ctx.Done():
+					return ctx.Err()
+				case <-t.C:
+					hb()
+					stableBeats.Add(1)
+				}
+			}
+		},
+	}
+
+	wd.Supervise(flaky)
+	wd.Supervise(stable)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	done := make(chan error, 1)
+	go func() { done <- wd.Run(ctx) }()
+
+	waitFor(t, 2*time.Second, "flaky to settle and stable to keep beating", func() bool {
+		return flaky.Runs() >= 4 && stableBeats.Load() >= 5 && stable.Runs() == 1
+	})
+
+	if stable.Runs() != 1 {
+		t.Errorf("stable subsystem must NOT have been restarted by sibling panics; got Runs=%d", stable.Runs())
+	}
+
+	cancel()
+	<-done
+}
+
+// TestSupervise_ParentCancelDrains — once the parent ctx cancels, all
+// supervised subsystems must exit promptly and Run must return.
+func TestSupervise_ParentCancelDrains(t *testing.T) {
+	t.Parallel()
+
+	wd := newFastWatchdog(nil)
+
+	var sawCancel atomic.Bool
+	sub := &scriptedSubsystem{
+		name: "daemon",
+		fn: func(ctx context.Context, hb func(), _ int) error {
+			t := time.NewTicker(10 * time.Millisecond)
+			defer t.Stop()
+			for {
+				select {
+				case <-ctx.Done():
+					sawCancel.Store(true)
+					return ctx.Err()
+				case <-t.C:
+					hb()
+				}
+			}
+		},
+	}
+	wd.Supervise(sub)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- wd.Run(ctx) }()
+
+	time.Sleep(50 * time.Millisecond)
+	cancel()
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Errorf("Run returned non-nil error: %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("watchdog did not exit within 2s of parent cancel")
+	}
+	if !sawCancel.Load() {
+		t.Error("subsystem did not observe ctx cancellation")
+	}
+}
+
+// TestSupervise_DoubleRunPanics — Run is single-shot (defensive).
+func TestSupervise_DoubleRunPanics(t *testing.T) {
+	t.Parallel()
+
+	wd := newFastWatchdog(nil)
+	wd.Supervise(&scriptedSubsystem{
+		name: "noop",
+		fn: func(ctx context.Context, hb func(), _ int) error {
+			<-ctx.Done()
+			return ctx.Err()
+		},
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		_ = wd.Run(ctx)
+		close(done)
+	}()
+	time.Sleep(20 * time.Millisecond)
+
+	defer func() {
+		if r := recover(); r == nil {
+			t.Error("expected second Run to panic")
+		}
+		cancel()
+		<-done
+	}()
+	_ = wd.Run(ctx)
+}
+
+// TestSupervise_AfterStartIsRefused — Supervise after Run starts is a
+// hard error (topology is fixed for the watchdog's lifetime).
+func TestSupervise_AfterStartIsRefused(t *testing.T) {
+	t.Parallel()
+
+	wd := newFastWatchdog(nil)
+	wd.Supervise(&scriptedSubsystem{
+		name: "x",
+		fn: func(ctx context.Context, hb func(), _ int) error {
+			<-ctx.Done()
+			return ctx.Err()
+		},
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		_ = wd.Run(ctx)
+		close(done)
+	}()
+	time.Sleep(20 * time.Millisecond)
+
+	defer func() {
+		if r := recover(); r == nil {
+			t.Error("Supervise after Run should panic")
+		}
+		cancel()
+		<-done
+	}()
+	wd.Supervise(&scriptedSubsystem{name: "late"})
+}


### PR DESCRIPTION
## Summary

- Implements wave-1 backlog item (migrated v1 ticket #14): spec §10.4 strategy (c) wrapper. `tether resume <sid>` looks up session jsonl across `~/.claude/projects/<bucket>/<sid>.jsonl`, decodes original cwd from cc bucket-name encoding, chdirs, execs `claude --resume <sid>` directly via `syscall.Exec` for clean TTY/signal handling.
- 12 tests covering encode forward, round-trip with hyphens, fallback when no on-disk match, single-bucket resolve, collision listing + `--bucket` disambiguation, missing-bucket error, multi-bucket modtime ordering, end-to-end `--dry-run`, fake-binary argv+cwd wiring.
- Go toolchain bump 1.24.6 → 1.25.0.

## Key decisions

- **Lossy bucket decode**: cc encodes `/` as `-` so `/foo-bar` and `/foo/bar` collide. Used left-to-right DP picking longest assembled path that exists on disk; tie-broken by depth. Naive `/`-substitution fallback when nothing exists.
- **Collision policy**: same sid in >1 bucket → error listing all candidates by jsonl modtime (NOT auto-pick most recent — silent footgun). `--bucket` flag for disambiguation.
- **Direct `syscall.Exec`** (not subprocess) so claude inherits TTY directly; no PID nesting; clean signal handling.
- **v0.1: direct exec, not via daemon socket.** §6.E.5 strategy (c) is described as a wrapper, not "must go through daemon". Daemon-aware resume is forward-compatible (`--via-daemon` flag = small future addition; `ResolveSession` stays as the cwd-discovery library).

## Test plan

- [x] `go test ./cmd/tether/...` — 12 tests passing
- [x] `go vet ./cmd/tether/...` — clean
- [x] `go build ./...` — clean
- [x] Real-world smoke: `tether resume --dry-run <sid>` against `~/.claude/projects/` resolves bucket `-root-code-aicoding-tether` → cwd `/root/code/aicoding/tether` correctly

## ⚠️ Merge conflict notice

`cmd/tether/main.go` is also created by:
- PR #31 (skill-system) — adds `tether skill` + `tether tether-blob-register` dispatch
- `pf2.daemon-watchdog` PR (sibling) — adds `tether daemon` dispatch

Last PR to merge will need to hand-resolve into a unified dispatcher table. All three are mechanical / non-overlapping subcommand registrations — no semantic conflict.

Refs spec §10.4 / §6.E.5.