### PR TITLE
Epic #3 integration: PTY + JSONL→envelope + Unix attach socket

### DIFF
--- a/cmd/tether/main.go
+++ b/cmd/tether/main.go
@@ -62,6 +62,10 @@ func runDaemon(args []string) int {
 	fs := flag.NewFlagSet("tether daemon", flag.ContinueOnError)
 	fs.SetOutput(os.Stderr)
 	verbose := fs.Bool("v", false, "verbose supervisor logging")
+	projectsDir := fs.String("projects-dir", "",
+		"cc projects directory to tail (default $HOME/.claude/projects)")
+	attachSocket := fs.String("attach-socket", "",
+		"path for the local attach Unix socket (default $HOME/.tether/attach.sock)")
 	if err := fs.Parse(args); err != nil {
 		return 2
 	}
@@ -80,8 +84,10 @@ func runDaemon(args []string) int {
 	}()
 
 	cfg := daemon.Config{
-		Verbose: *verbose,
-		Stderr:  os.Stderr,
+		Verbose:          *verbose,
+		Stderr:           os.Stderr,
+		ProjectsDir:      *projectsDir,
+		AttachSocketPath: *attachSocket,
 	}
 	if err := daemon.Run(ctx, cfg); err != nil {
 		fmt.Fprintf(os.Stderr, "tether daemon: %v\n", err)

--- a/go.mod
+++ b/go.mod
@@ -8,4 +8,7 @@ require (
 	golang.org/x/crypto v0.50.0
 )
 
-require golang.org/x/sys v0.43.0 // indirect
+require (
+	github.com/creack/pty v1.1.24 // indirect
+	golang.org/x/sys v0.43.0 // indirect
+)

--- a/go.mod
+++ b/go.mod
@@ -4,11 +4,9 @@ go 1.25.0
 
 require (
 	github.com/BurntSushi/toml v1.6.0
+	github.com/creack/pty v1.1.24
 	github.com/fsnotify/fsnotify v1.9.0
 	golang.org/x/crypto v0.50.0
 )
 
-require (
-	github.com/creack/pty v1.1.24 // indirect
-	golang.org/x/sys v0.43.0 // indirect
-)
+require golang.org/x/sys v0.43.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 github.com/BurntSushi/toml v1.6.0 h1:dRaEfpa2VI55EwlIW72hMRHdWouJeRF7TPYhI+AUQjk=
 github.com/BurntSushi/toml v1.6.0/go.mod h1:ukJfTF/6rtPPRCnwkur4qwRxa8vTRFBF0uk2lLoLwho=
+github.com/creack/pty v1.1.24 h1:bJrF4RRfyJnbTJqzRLHzcGaZK1NeM5kTC9jGgovnR1s=
+github.com/creack/pty v1.1.24/go.mod h1:08sCNb52WyoAwi2QDyzUCTgcvVFhUzewun7wtTfvcwE=
 github.com/fsnotify/fsnotify v1.9.0 h1:2Ml+OJNzbYCTzsxtv8vKSFD9PbJjmhYF14k/jKC7S9k=
 github.com/fsnotify/fsnotify v1.9.0/go.mod h1:8jBTzvmWwFyi3Pb8djgCCO5IBqzKJ/Jwo8TRcHyHii0=
 golang.org/x/crypto v0.50.0 h1:zO47/JPrL6vsNkINmLoo/PH1gcxpls50DNogFvB5ZGI=

--- a/internal/agent/attach_socket.go
+++ b/internal/agent/attach_socket.go
@@ -141,6 +141,7 @@ type attachConn struct {
 	sid      string
 	mode     AttachMode
 	client   lock.ClientID
+	heldLock bool // true once Lock.TryAcquire has succeeded for this client
 	cancelEm func() // tear down envelope subscription
 	done     chan struct{}
 }
@@ -285,8 +286,11 @@ func (s *AttachServer) handleNewConn(ctx context.Context, c net.Conn) {
 			if conn.cancelEm != nil {
 				conn.cancelEm()
 			}
-			// On rw disconnect, release the lock if we still hold it.
-			if conn.mode == AttachModeReadWrite && conn.client != (lock.ClientID{}) {
+			// On rw disconnect, release the lock only if THIS conn
+			// actually acquired it (heldLock=true). Otherwise Release
+			// would return ErrNotHolder (silently dropped today, but
+			// noisy when we eventually log lock errors).
+			if conn.mode == AttachModeReadWrite && conn.heldLock {
 				_ = s.cfg.Lock.Release(conn.client)
 			}
 		}()
@@ -294,10 +298,25 @@ func (s *AttachServer) handleNewConn(ctx context.Context, c net.Conn) {
 	}()
 }
 
+// MaxHeaderBytes caps the size of the newline-terminated JSON header
+// line a client may send on connect. The legitimate header is well
+// under 1KB (sessionId + mode + client kind/deviceId); 64KB is a
+// generous ceiling that still bounds memory growth from a malicious
+// or buggy local client that opens a connection and streams bytes
+// without ever sending '\n'. Without this bound, bufio.Reader's
+// ReadBytes('\n') grows its internal slice unboundedly via repeated
+// ReadSlice + concat, OOMing the daemon.
+const MaxHeaderBytes = 64 * 1024
+
 // serveConn implements the framed protocol for one client.
 func (s *AttachServer) serveConn(ctx context.Context, conn *attachConn) {
 	br := bufio.NewReader(conn.c)
-	headerLine, err := br.ReadBytes('\n')
+	// Bound the header read at MaxHeaderBytes. We use a LimitReader
+	// wrapped around the same underlying conn for just the header
+	// read — once we're past the header we go back to using br
+	// directly, so this doesn't constrain frame reads (which have
+	// their own ErrFrameTooLarge cap below).
+	headerLine, err := readBoundedLine(br, MaxHeaderBytes)
 	if err != nil {
 		s.reportError(fmt.Errorf("attach: read header: %w", err))
 		return
@@ -419,6 +438,10 @@ func (s *AttachServer) readInputs(_ context.Context, conn *attachConn, br *bufio
 			// frame; v0.1 of this socket wires that as a follow-up).
 			continue
 		}
+		// Mark held so the disconnect path's Release fires only when
+		// we actually acquired (avoids noisy ErrNotHolder for clients
+		// that never sent a byte).
+		conn.heldLock = true
 
 		if err := s.cfg.InputSink(conn.sid, buf); err != nil {
 			s.reportError(fmt.Errorf("attach: input sink: %w", err))
@@ -484,6 +507,30 @@ func WriteInputFrame(w io.Writer, payload []byte) error {
 // ErrFrameTooLarge is returned by ReadFrame when the length prefix
 // exceeds the 1MB safety cap.
 var ErrFrameTooLarge = errors.New("agent: attach frame > 1MB")
+
+// ErrHeaderTooLarge is returned by serveConn when the newline-
+// terminated header read exceeds MaxHeaderBytes.
+var ErrHeaderTooLarge = errors.New("agent: attach header > MaxHeaderBytes")
+
+// readBoundedLine reads bytes up to and including the next '\n', or
+// up to limit bytes (whichever comes first). Returns ErrHeaderTooLarge
+// if limit is hit without seeing a newline. Implementation pulls one
+// byte at a time from the bufio.Reader so we don't grow an unbounded
+// internal slice the way bufio.Reader.ReadBytes('\n') would.
+func readBoundedLine(br *bufio.Reader, limit int) ([]byte, error) {
+	buf := make([]byte, 0, 256)
+	for len(buf) < limit {
+		b, err := br.ReadByte()
+		if err != nil {
+			return buf, err
+		}
+		buf = append(buf, b)
+		if b == '\n' {
+			return buf, nil
+		}
+	}
+	return buf, ErrHeaderTooLarge
+}
 
 // isClosedConn matches typical "use of closed network connection"
 // error variants we want to swallow rather than log.

--- a/internal/agent/attach_socket.go
+++ b/internal/agent/attach_socket.go
@@ -1,0 +1,502 @@
+// Package agent — local Unix socket listener (spec §4.4 ctrlListener +
+// §11.U attach entry point).
+//
+// The attach socket lives at ~/.tether/attach.sock by default and
+// accepts connections from `tether attach` (or any other local client
+// running as the same user). Wire framing:
+//
+//	1. Client connects, sends a single newline-terminated JSON header
+//	   { "sessionId": "<sid>", "mode": "ro" | "rw", "client": {...} }
+//
+//	2. Server replies with one length-prefixed JSON envelope per cc
+//	   event (4-byte big-endian length + payload). Frame 0 is the
+//	   accept ack:
+//
+//	     {"type":"attach.ack", "mode":"<granted-mode>", "sessionId":"..."}
+//
+//	   Subsequent frames are wire envelopes from the JSONL watcher
+//	   (output.agent-event / output.hook-event / session.state).
+//
+//	3. If mode == "rw", server reads length-prefixed user-input frames
+//	   from the same connection:
+//
+//	     [4-byte BE length][payload bytes]
+//
+//	   payload is opaque bytes destined for the PTY. Server passes
+//	   through PTYSession.SendInput AFTER acquiring the lock; on
+//	   ErrInUse the server replies with one length-prefixed
+//	   {"type":"attach.lock-denied"} frame and ignores the input.
+//
+// v0.1 keeps this minimal — no auth (Unix socket perms = 0600 = trusted
+// local user only), no compression, no resume cursor. Reconnect logic
+// lives in the client; the daemon teardown on disconnect is clean.
+
+package agent
+
+import (
+	"bufio"
+	"context"
+	"encoding/binary"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"os"
+	"path/filepath"
+	"sync"
+	"time"
+
+	"github.com/piaobeizu/tether/internal/lock"
+)
+
+// DefaultAttachSocketPath is the conventional path. Daemon resolves
+// $HOME at startup.
+const DefaultAttachSocketPath = ".tether/attach.sock"
+
+// AttachMode names the read-only vs read-write attach affordance.
+type AttachMode string
+
+const (
+	AttachModeReadOnly  AttachMode = "ro"
+	AttachModeReadWrite AttachMode = "rw"
+)
+
+// AttachHeader is the first frame the client sends.
+type AttachHeader struct {
+	SessionID string `json:"sessionId"`
+	Mode      string `json:"mode"`
+	// Client identifies the attach client for lock attribution.
+	// Kind = "terminal" / "mobile"; DeviceID = stable per-pairing id.
+	Client struct {
+		Kind     string `json:"kind"`
+		DeviceID string `json:"deviceId"`
+	} `json:"client"`
+}
+
+// AckFrame is the first server-to-client frame (mode confirmation).
+type AckFrame struct {
+	Type      string `json:"type"`
+	SessionID string `json:"sessionId"`
+	Mode      string `json:"mode"`
+	Message   string `json:"message,omitempty"`
+}
+
+// LockDeniedFrame is sent in response to a write that the server can't
+// authorize because the lock is held.
+type LockDeniedFrame struct {
+	Type   string `json:"type"`
+	Reason string `json:"reason"`
+	Holder struct {
+		Kind     string `json:"kind"`
+		DeviceID string `json:"deviceId"`
+	} `json:"holder"`
+}
+
+// AttachServerConfig configures NewAttachServer.
+type AttachServerConfig struct {
+	// SocketPath is the absolute path to the listening socket. Caller
+	// resolves $HOME / cleanup on prior run. Required.
+	SocketPath string
+
+	// Emitter provides per-session envelope subscriptions.
+	Emitter *EnvelopeEmitter
+
+	// Lock is the per-session writer-lock. v0.1 has one global lock
+	// shared across all sessions on this daemon (cc model: one user,
+	// one cc instance). Callers building multi-session daemons can
+	// pass a different Lock per accept handler — but that's later.
+	Lock *lock.Lock
+
+	// InputSink, when non-nil, is called with raw input bytes from
+	// rw-mode clients AFTER lock acquisition + Touch. It is the wire
+	// to PTYSession.SendInput in the daemon topology; tests inject a
+	// channel-recording sink. nil InputSink rejects rw mode (clients
+	// that ask for rw get auto-downgraded to ro and warned in ack
+	// message).
+	InputSink func(sessionID string, data []byte) error
+
+	// OnError surfaces accept-loop / per-conn errors to the daemon
+	// log. Optional.
+	OnError func(err error)
+
+	// SocketPerm lets tests dial without root; production uses
+	// 0600 (owner-only). Zero = use 0600.
+	SocketPerm os.FileMode
+}
+
+// AttachServer accepts attach socket connections.
+type AttachServer struct {
+	cfg AttachServerConfig
+	lis net.Listener
+
+	mu     sync.Mutex
+	closed bool
+	conns  map[*attachConn]struct{}
+}
+
+// attachConn tracks one connected client.
+type attachConn struct {
+	c        net.Conn
+	sid      string
+	mode     AttachMode
+	client   lock.ClientID
+	cancelEm func() // tear down envelope subscription
+	done     chan struct{}
+}
+
+// NewAttachServer creates the Unix socket listener. The socket file is
+// ensured-removed before listen (recover from a previous unclean
+// shutdown). Returns an error on bind failure.
+func NewAttachServer(cfg AttachServerConfig) (*AttachServer, error) {
+	if cfg.SocketPath == "" {
+		return nil, errors.New("agent: AttachServerConfig.SocketPath required")
+	}
+	if cfg.Emitter == nil {
+		return nil, errors.New("agent: AttachServerConfig.Emitter required")
+	}
+	if cfg.Lock == nil {
+		return nil, errors.New("agent: AttachServerConfig.Lock required")
+	}
+	perm := cfg.SocketPerm
+	if perm == 0 {
+		perm = 0o600
+	}
+
+	if err := os.MkdirAll(filepath.Dir(cfg.SocketPath), 0o700); err != nil {
+		return nil, fmt.Errorf("agent: mkdir socket dir: %w", err)
+	}
+	// Best-effort cleanup of stale socket.
+	_ = os.Remove(cfg.SocketPath)
+
+	lis, err := net.Listen("unix", cfg.SocketPath)
+	if err != nil {
+		return nil, fmt.Errorf("agent: listen unix %s: %w", cfg.SocketPath, err)
+	}
+	if err := os.Chmod(cfg.SocketPath, perm); err != nil {
+		_ = lis.Close()
+		_ = os.Remove(cfg.SocketPath)
+		return nil, fmt.Errorf("agent: chmod socket: %w", err)
+	}
+
+	return &AttachServer{
+		cfg:   cfg,
+		lis:   lis,
+		conns: make(map[*attachConn]struct{}),
+	}, nil
+}
+
+// SocketPath returns the listening path.
+func (s *AttachServer) SocketPath() string { return s.cfg.SocketPath }
+
+// Serve runs the accept loop until ctx is canceled or the listener
+// closes. Per-connection handlers run in their own goroutines; Serve
+// blocks until they all exit.
+//
+// Designed to plug straight into a watchdog Subsystem: callers wrap
+// Serve in a wrapper that calls hb() periodically.
+func (s *AttachServer) Serve(ctx context.Context) error {
+	// Accept loop.
+	connCh := make(chan net.Conn, 16)
+	errCh := make(chan error, 1)
+	go func() {
+		for {
+			c, err := s.lis.Accept()
+			if err != nil {
+				select {
+				case errCh <- err:
+				default:
+				}
+				return
+			}
+			connCh <- c
+		}
+	}()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return s.shutdown()
+		case err := <-errCh:
+			// Listener closed (ctx canceled by another path) or real error.
+			if isClosedConn(err) {
+				return s.shutdown()
+			}
+			s.reportError(err)
+			return s.shutdown()
+		case c := <-connCh:
+			s.handleNewConn(ctx, c)
+		}
+	}
+}
+
+func (s *AttachServer) reportError(err error) {
+	if s.cfg.OnError != nil {
+		s.cfg.OnError(err)
+	}
+}
+
+// shutdown closes all open conns + the listener. Idempotent.
+func (s *AttachServer) shutdown() error {
+	s.mu.Lock()
+	if s.closed {
+		s.mu.Unlock()
+		return nil
+	}
+	s.closed = true
+	conns := make([]*attachConn, 0, len(s.conns))
+	for c := range s.conns {
+		conns = append(conns, c)
+	}
+	s.mu.Unlock()
+
+	for _, c := range conns {
+		_ = c.c.Close()
+		<-c.done
+	}
+	err := s.lis.Close()
+	_ = os.Remove(s.cfg.SocketPath)
+	return err
+}
+
+// Close stops the server. Equivalent to canceling Serve's ctx.
+func (s *AttachServer) Close() error {
+	return s.shutdown()
+}
+
+func (s *AttachServer) handleNewConn(ctx context.Context, c net.Conn) {
+	s.mu.Lock()
+	if s.closed {
+		s.mu.Unlock()
+		_ = c.Close()
+		return
+	}
+	conn := &attachConn{c: c, done: make(chan struct{})}
+	s.conns[conn] = struct{}{}
+	s.mu.Unlock()
+
+	go func() {
+		defer close(conn.done)
+		defer func() {
+			s.mu.Lock()
+			delete(s.conns, conn)
+			s.mu.Unlock()
+			_ = c.Close()
+			if conn.cancelEm != nil {
+				conn.cancelEm()
+			}
+			// On rw disconnect, release the lock if we still hold it.
+			if conn.mode == AttachModeReadWrite && conn.client != (lock.ClientID{}) {
+				_ = s.cfg.Lock.Release(conn.client)
+			}
+		}()
+		s.serveConn(ctx, conn)
+	}()
+}
+
+// serveConn implements the framed protocol for one client.
+func (s *AttachServer) serveConn(ctx context.Context, conn *attachConn) {
+	br := bufio.NewReader(conn.c)
+	headerLine, err := br.ReadBytes('\n')
+	if err != nil {
+		s.reportError(fmt.Errorf("attach: read header: %w", err))
+		return
+	}
+	var hdr AttachHeader
+	if err := json.Unmarshal(headerLine, &hdr); err != nil {
+		s.reportError(fmt.Errorf("attach: parse header: %w", err))
+		return
+	}
+	if hdr.SessionID == "" {
+		s.reportError(errors.New("attach: empty sessionId in header"))
+		return
+	}
+
+	conn.sid = hdr.SessionID
+	conn.client = lock.ClientID{Kind: hdr.Client.Kind, DeviceID: hdr.Client.DeviceID}
+	if conn.client.Kind == "" {
+		// Attribute as terminal by default — local socket is the
+		// `tether attach` raw-mode entry point (§11.U).
+		conn.client.Kind = lock.KindTerminal
+	}
+	if conn.client.DeviceID == "" {
+		// Synthesize a per-conn device id so lock.History remains
+		// useful even when the client doesn't supply one.
+		conn.client.DeviceID = fmt.Sprintf("local-%d", time.Now().UnixNano())
+	}
+
+	desired := AttachMode(hdr.Mode)
+	if desired != AttachModeReadOnly && desired != AttachModeReadWrite {
+		desired = AttachModeReadOnly
+	}
+	if desired == AttachModeReadWrite && s.cfg.InputSink == nil {
+		desired = AttachModeReadOnly
+	}
+	conn.mode = desired
+
+	// Subscribe to the session's envelope stream BEFORE writing the
+	// ack — that way the consumer can observe events that arrive in
+	// the same fsnotify wakeup as the connect.
+	envCh, cancelEm, err := s.cfg.Emitter.Subscribe(hdr.SessionID)
+	if err != nil {
+		s.reportError(fmt.Errorf("attach: emitter subscribe: %w", err))
+		return
+	}
+	conn.cancelEm = cancelEm
+
+	ack := AckFrame{
+		Type:      "attach.ack",
+		SessionID: hdr.SessionID,
+		Mode:      string(desired),
+	}
+	if AttachMode(hdr.Mode) == AttachModeReadWrite && desired == AttachModeReadOnly {
+		ack.Message = "rw downgraded to ro: daemon has no input sink wired"
+	}
+	if err := writeFrame(conn.c, ack); err != nil {
+		s.reportError(fmt.Errorf("attach: write ack: %w", err))
+		return
+	}
+
+	// Spawn input reader if rw.
+	inputErr := make(chan error, 1)
+	if desired == AttachModeReadWrite {
+		go func() { inputErr <- s.readInputs(ctx, conn, br) }()
+	}
+
+	// Write loop.
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case env, ok := <-envCh:
+			if !ok {
+				return
+			}
+			if err := writeFrame(conn.c, env); err != nil {
+				if isClosedConn(err) {
+					return
+				}
+				s.reportError(fmt.Errorf("attach: write envelope: %w", err))
+				return
+			}
+		case err := <-inputErr:
+			if err != nil && !isClosedConn(err) && !errors.Is(err, io.EOF) {
+				s.reportError(fmt.Errorf("attach: input loop: %w", err))
+			}
+			return
+		}
+	}
+}
+
+// readInputs reads length-prefixed input frames from the client and
+// routes them to the InputSink, gated by the lock.
+func (s *AttachServer) readInputs(_ context.Context, conn *attachConn, br *bufio.Reader) error {
+	for {
+		var lenBuf [4]byte
+		if _, err := io.ReadFull(br, lenBuf[:]); err != nil {
+			return err
+		}
+		n := binary.BigEndian.Uint32(lenBuf[:])
+		if n > 1<<20 { // 1 MB cap per frame
+			return fmt.Errorf("attach: input frame too large (%d bytes)", n)
+		}
+		buf := make([]byte, n)
+		if _, err := io.ReadFull(br, buf); err != nil {
+			return err
+		}
+
+		// TryAcquire — first byte from this client wins if lock is
+		// free; touches forward the auto-release timer otherwise.
+		if err := s.cfg.Lock.TryAcquire(conn.client); err != nil {
+			holder, _ := s.cfg.Lock.Holder()
+			frame := LockDeniedFrame{Type: "attach.lock-denied", Reason: err.Error()}
+			frame.Holder.Kind = holder.Kind
+			frame.Holder.DeviceID = holder.DeviceID
+			_ = writeFrame(conn.c, frame)
+			// Drop input — the contract is "writes need the lock";
+			// dropping rather than buffering is the spec §11.D
+			// behavior (caller should ForceTakeover via control
+			// frame; v0.1 of this socket wires that as a follow-up).
+			continue
+		}
+
+		if err := s.cfg.InputSink(conn.sid, buf); err != nil {
+			s.reportError(fmt.Errorf("attach: input sink: %w", err))
+			// Don't terminate the connection — caller may want to
+			// retry. But return to avoid infinite tight loop on
+			// persistent failure.
+			return err
+		}
+		// Touch forwards the auto-release timer.
+		_ = s.cfg.Lock.Touch(conn.client)
+	}
+}
+
+// writeFrame serializes v as JSON and writes a 4-byte BE length
+// prefix + payload.
+func writeFrame(w io.Writer, v any) error {
+	body, err := json.Marshal(v)
+	if err != nil {
+		return fmt.Errorf("marshal frame: %w", err)
+	}
+	var hdr [4]byte
+	binary.BigEndian.PutUint32(hdr[:], uint32(len(body)))
+	if _, err := w.Write(hdr[:]); err != nil {
+		return err
+	}
+	_, err = w.Write(body)
+	return err
+}
+
+// ReadFrame is the client-side helper exposed for `tether attach` (and
+// for the integration tests in this package): reads a 4-byte BE length
+// prefix + payload from r. Returns ErrFrameTooLarge for >1MB frames.
+func ReadFrame(r io.Reader) ([]byte, error) {
+	var hdr [4]byte
+	if _, err := io.ReadFull(r, hdr[:]); err != nil {
+		return nil, err
+	}
+	n := binary.BigEndian.Uint32(hdr[:])
+	if n > 1<<20 {
+		return nil, ErrFrameTooLarge
+	}
+	buf := make([]byte, n)
+	if _, err := io.ReadFull(r, buf); err != nil {
+		return nil, err
+	}
+	return buf, nil
+}
+
+// WriteInputFrame is the client-side helper for sending an input frame
+// (rw-mode attach client → daemon → PTY). Same 4-byte BE length-
+// prefix shape as the server-to-client frames; symmetry keeps both
+// codecs simple.
+func WriteInputFrame(w io.Writer, payload []byte) error {
+	var hdr [4]byte
+	binary.BigEndian.PutUint32(hdr[:], uint32(len(payload)))
+	if _, err := w.Write(hdr[:]); err != nil {
+		return err
+	}
+	_, err := w.Write(payload)
+	return err
+}
+
+// ErrFrameTooLarge is returned by ReadFrame when the length prefix
+// exceeds the 1MB safety cap.
+var ErrFrameTooLarge = errors.New("agent: attach frame > 1MB")
+
+// isClosedConn matches typical "use of closed network connection"
+// error variants we want to swallow rather than log.
+func isClosedConn(err error) bool {
+	if err == nil {
+		return false
+	}
+	var ne net.Error
+	if errors.As(err, &ne) && ne.Timeout() {
+		return false
+	}
+	if errors.Is(err, net.ErrClosed) {
+		return true
+	}
+	return false
+}

--- a/internal/agent/envelope_emitter.go
+++ b/internal/agent/envelope_emitter.go
@@ -1,0 +1,224 @@
+// Package agent — envelope emitter wires the cc JSONL watcher to the
+// daemon's outbound channel.
+//
+// The watcher (internal/cc/jsonl) tails ~/.claude/projects/<encoded>/
+// and produces a stream of jsonl.Envelope values per session. The
+// envelope emitter:
+//
+//   - owns the *jsonl.Watcher lifetime,
+//   - exposes one EnvelopeEmitter.Subscribe(sid) per attach session,
+//   - returns a channel of fully-formed wire envelopes (just the
+//     plaintext metadata + payload — Epic #5 encryption hooks in later),
+//   - tears down per-subscriber state cleanly when the consumer closes.
+//
+// This sits alongside ClaudeCodeProvider rather than inside it because
+// JSONL watching is provider-agnostic at the wire-shape level: §5.6 /
+// §11.N already define the EVENT/HOOK/STATE → wire mapping and the
+// daemon orchestrator drives the watcher independently of any one
+// AgentProvider session lifecycle.
+
+package agent
+
+import (
+	"context"
+	"errors"
+	"sync"
+
+	"github.com/piaobeizu/tether/internal/cc/jsonl"
+)
+
+// WireEnvelope is the in-process projection of jsonl.Envelope that the
+// attach socket / WT client subscribers consume. Identity-mapped from
+// jsonl.Envelope today; kept as a separate type so future plumbing
+// (rate-limit-event injection, daemon-broadcast catch-up cache) has a
+// home that doesn't pollute the JSONL package.
+type WireEnvelope struct {
+	Kind              string                 `json:"kind"`
+	ProviderType      string                 `json:"providerType"`
+	SessionID         string                 `json:"sessionId"`
+	Skill             string                 `json:"skill,omitempty"`
+	PlaintextMetadata map[string]any         `json:"plaintextMetadata,omitempty"`
+	CiphertextPayload []byte                 `json:"ciphertextPayload,omitempty"`
+	SourceUUID        string                 `json:"sourceUuid,omitempty"`
+}
+
+// fromJSONL converts a jsonl.Envelope to the wire-facing shape.
+func fromJSONL(e jsonl.Envelope) WireEnvelope {
+	return WireEnvelope{
+		Kind:              string(e.Kind),
+		ProviderType:      e.ProviderType,
+		SessionID:         e.SessionID,
+		Skill:             e.Skill,
+		PlaintextMetadata: e.PlaintextMetadata,
+		CiphertextPayload: e.CiphertextPayload,
+		SourceUUID:        e.SourceUUID,
+	}
+}
+
+// EnvelopeEmitter owns the JSONL watcher and the per-session fan-out.
+//
+// Lifecycle:
+//
+//	em, err := NewEnvelopeEmitter(ctx, EmitterConfig{...})
+//	defer em.Close()
+//	ch, cancel := em.Subscribe("sid-foo")
+//	for env := range ch { ... }
+//	cancel() // when done
+//
+// Concurrency: Subscribe / Close are safe from any goroutine. The
+// underlying jsonl.Watcher runs its own drain goroutine; this struct
+// adds one fan-out goroutine per Subscribe call.
+type EnvelopeEmitter struct {
+	watcher *jsonl.Watcher
+
+	mu     sync.Mutex
+	closed bool
+	subs   []*emitterSub
+}
+
+// EmitterConfig configures NewEnvelopeEmitter.
+type EmitterConfig struct {
+	// ProjectsDir is the directory the watcher tails. v0.1 default
+	// (when "") is ~/.claude/projects/. Tests override.
+	ProjectsDir string
+
+	// SubscriberBuffer overrides the per-subscriber channel buffer
+	// (default jsonl.DefaultSubscriberBuffer).
+	SubscriberBuffer int
+
+	// OnError is called for non-fatal watcher errors. Optional.
+	OnError func(path string, err error)
+
+	// OnDrop is called when the watcher's per-session channel
+	// back-pressures and an envelope is dropped. Optional.
+	OnDrop func(sessionID string, kind string)
+}
+
+// emitterSub is one Subscribe registration with its own JSONL channel
+// + outbound wire channel.
+type emitterSub struct {
+	sid    string
+	in     <-chan jsonl.Envelope
+	out    chan WireEnvelope
+	cancel context.CancelFunc
+	done   chan struct{}
+}
+
+// ErrEmitterClosed is returned by Subscribe after Close has run.
+var ErrEmitterClosed = errors.New("agent: envelope emitter closed")
+
+// NewEnvelopeEmitter constructs an emitter rooted at cfg.ProjectsDir
+// (or ~/.claude/projects/ when empty). Returns an error on watcher
+// init failure (root unreadable, fsnotify init).
+func NewEnvelopeEmitter(ctx context.Context, cfg EmitterConfig) (*EnvelopeEmitter, error) {
+	root := cfg.ProjectsDir
+	if root == "" {
+		// Caller is expected to have resolved $HOME; we don't reach
+		// for it here to keep this constructor pure.
+		return nil, errors.New("agent: EmitterConfig.ProjectsDir required (resolve ~/.claude/projects/ at the call site)")
+	}
+
+	wopts := jsonl.Options{
+		SubscriberBuffer: cfg.SubscriberBuffer,
+		OnError:          cfg.OnError,
+	}
+	if cfg.OnDrop != nil {
+		wopts.OnDrop = func(sessionID string, kind jsonl.EnvelopeKind) {
+			cfg.OnDrop(sessionID, string(kind))
+		}
+	}
+
+	w, err := jsonl.New(ctx, root, wopts)
+	if err != nil {
+		return nil, err
+	}
+	return &EnvelopeEmitter{watcher: w}, nil
+}
+
+// Subscribe registers interest in a session's envelope stream. Returns
+// the receive channel + a cancel func to tear down the subscription
+// (closes the channel; safe to call multiple times).
+//
+// Empty sid is rejected — callers must supply the cc session_id.
+func (e *EnvelopeEmitter) Subscribe(sid string) (<-chan WireEnvelope, func(), error) {
+	if sid == "" {
+		return nil, nil, errors.New("agent: Subscribe requires non-empty session id")
+	}
+
+	e.mu.Lock()
+	if e.closed {
+		e.mu.Unlock()
+		return nil, nil, ErrEmitterClosed
+	}
+	in := e.watcher.Subscribe(sid)
+	out := make(chan WireEnvelope, 64)
+	subCtx, cancel := context.WithCancel(context.Background())
+	sub := &emitterSub{
+		sid:    sid,
+		in:     in,
+		out:    out,
+		cancel: cancel,
+		done:   make(chan struct{}),
+	}
+	e.subs = append(e.subs, sub)
+	e.mu.Unlock()
+
+	go sub.relay(subCtx)
+
+	teardown := func() {
+		sub.cancel()
+		<-sub.done
+	}
+	return out, teardown, nil
+}
+
+// Close tears down the watcher + all subscriber goroutines. Safe to
+// call multiple times.
+func (e *EnvelopeEmitter) Close() error {
+	e.mu.Lock()
+	if e.closed {
+		e.mu.Unlock()
+		return nil
+	}
+	e.closed = true
+	subs := append([]*emitterSub(nil), e.subs...)
+	e.subs = nil
+	e.mu.Unlock()
+
+	for _, s := range subs {
+		s.cancel()
+		<-s.done
+	}
+	return e.watcher.Close()
+}
+
+// Stats returns a snapshot of the watcher's counters. Useful for
+// tests + the health endpoint (eventually).
+func (e *EnvelopeEmitter) Stats() (linesParsed, envelopesEmit, envelopesDrop int64) {
+	st := e.watcher.StatsSnapshot()
+	return st.LinesParsed, st.EnvelopesEmit, st.EnvelopesDrop
+}
+
+// relay is the per-subscriber goroutine: pulls jsonl.Envelopes from the
+// watcher, projects to WireEnvelope, sends to out. Exits on ctx.Done()
+// or when the watcher channel closes.
+func (s *emitterSub) relay(ctx context.Context) {
+	defer close(s.done)
+	defer close(s.out)
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case env, ok := <-s.in:
+			if !ok {
+				return
+			}
+			wire := fromJSONL(env)
+			select {
+			case s.out <- wire:
+			case <-ctx.Done():
+				return
+			}
+		}
+	}
+}

--- a/internal/agent/envelope_emitter.go
+++ b/internal/agent/envelope_emitter.go
@@ -27,12 +27,25 @@ import (
 	"github.com/piaobeizu/tether/internal/cc/jsonl"
 )
 
-// WireEnvelope is the in-process projection of jsonl.Envelope that the
-// attach socket / WT client subscribers consume. Identity-mapped from
-// jsonl.Envelope today; kept as a separate type so future plumbing
-// (rate-limit-event injection, daemon-broadcast catch-up cache) has a
-// home that doesn't pollute the JSONL package.
-type WireEnvelope struct {
+// LocalEnvelope is the in-process projection of jsonl.Envelope that the
+// daemon's local consumers (attach socket, eventually a daemon-side
+// catch-up cache, etc.) receive. Identity-mapped from jsonl.Envelope
+// today; kept as a separate type so future plumbing (rate-limit-event
+// injection, daemon-broadcast catch-up cache) has a home that doesn't
+// pollute the JSONL package.
+//
+// IMPORTANT — NOT THE SPEC §3.3.1 WIRE ENVELOPE.
+// This struct is the SHAPE THE DAEMON SERVES TO LOCAL CLIENTS over the
+// Unix attach socket. It carries plaintext metadata + (eventually)
+// ciphertext payload but does NOT include the §3.3.1 fields needed for
+// over-network delivery: id, fromDeviceId, toDeviceId, ts, keyVersion,
+// nonce, AD-bound kind, transport-layer ciphertext binding. When
+// QUIC/WT lands, the cross-device wire envelope is a separate type
+// (provisional name: agent.WireEnvelope or transport.OutboundEnvelope)
+// that wraps + signs/encrypts a LocalEnvelope. Code that reads "Local"
+// here must not assume the bytes are wire-ready for the public
+// internet.
+type LocalEnvelope struct {
 	Kind              string                 `json:"kind"`
 	ProviderType      string                 `json:"providerType"`
 	SessionID         string                 `json:"sessionId"`
@@ -43,8 +56,8 @@ type WireEnvelope struct {
 }
 
 // fromJSONL converts a jsonl.Envelope to the wire-facing shape.
-func fromJSONL(e jsonl.Envelope) WireEnvelope {
-	return WireEnvelope{
+func fromJSONL(e jsonl.Envelope) LocalEnvelope {
+	return LocalEnvelope{
 		Kind:              string(e.Kind),
 		ProviderType:      e.ProviderType,
 		SessionID:         e.SessionID,
@@ -97,11 +110,12 @@ type EmitterConfig struct {
 // emitterSub is one Subscribe registration with its own JSONL channel
 // + outbound wire channel.
 type emitterSub struct {
-	sid    string
-	in     <-chan jsonl.Envelope
-	out    chan WireEnvelope
-	cancel context.CancelFunc
-	done   chan struct{}
+	sid     string
+	in      <-chan jsonl.Envelope
+	out     chan LocalEnvelope
+	cancel  context.CancelFunc
+	done    chan struct{}
+	watcher *jsonl.Watcher // back-ref for self-deregistration on exit
 }
 
 // ErrEmitterClosed is returned by Subscribe after Close has run.
@@ -140,7 +154,7 @@ func NewEnvelopeEmitter(ctx context.Context, cfg EmitterConfig) (*EnvelopeEmitte
 // (closes the channel; safe to call multiple times).
 //
 // Empty sid is rejected — callers must supply the cc session_id.
-func (e *EnvelopeEmitter) Subscribe(sid string) (<-chan WireEnvelope, func(), error) {
+func (e *EnvelopeEmitter) Subscribe(sid string) (<-chan LocalEnvelope, func(), error) {
 	if sid == "" {
 		return nil, nil, errors.New("agent: Subscribe requires non-empty session id")
 	}
@@ -151,7 +165,7 @@ func (e *EnvelopeEmitter) Subscribe(sid string) (<-chan WireEnvelope, func(), er
 		return nil, nil, ErrEmitterClosed
 	}
 	in := e.watcher.Subscribe(sid)
-	out := make(chan WireEnvelope, 64)
+	out := make(chan LocalEnvelope, 64)
 	subCtx, cancel := context.WithCancel(context.Background())
 	sub := &emitterSub{
 		sid:    sid,
@@ -159,6 +173,13 @@ func (e *EnvelopeEmitter) Subscribe(sid string) (<-chan WireEnvelope, func(), er
 		out:    out,
 		cancel: cancel,
 		done:   make(chan struct{}),
+		// Capture the watcher so relay can deregister itself on exit.
+		// Without this, every Subscribe leaves a stale *subscriber in
+		// jsonl.Watcher.subs[sid] until Watcher.Close — i.e. a leak per
+		// attach connection. See watcher.Unsubscribe doc on the
+		// receiver-termination contract (close-race rationale for why
+		// we deregister but don't expect a channel-close signal).
+		watcher: e.watcher,
 	}
 	e.subs = append(e.subs, sub)
 	e.mu.Unlock()
@@ -200,11 +221,17 @@ func (e *EnvelopeEmitter) Stats() (linesParsed, envelopesEmit, envelopesDrop int
 }
 
 // relay is the per-subscriber goroutine: pulls jsonl.Envelopes from the
-// watcher, projects to WireEnvelope, sends to out. Exits on ctx.Done()
+// watcher, projects to LocalEnvelope, sends to out. Exits on ctx.Done()
 // or when the watcher channel closes.
+//
+// On exit, deregisters from the underlying jsonl.Watcher so the
+// watcher's subs map doesn't grow unboundedly across attach
+// connect/disconnect cycles. See jsonl.Watcher.Unsubscribe for the
+// non-close contract this relies on.
 func (s *emitterSub) relay(ctx context.Context) {
 	defer close(s.done)
 	defer close(s.out)
+	defer s.watcher.Unsubscribe(s.sid, s.in)
 	for {
 		select {
 		case <-ctx.Done():

--- a/internal/agent/integration_test.go
+++ b/internal/agent/integration_test.go
@@ -1,0 +1,324 @@
+package agent_test
+
+import (
+	"context"
+	"encoding/json"
+	"net"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/piaobeizu/tether/internal/agent"
+	"github.com/piaobeizu/tether/internal/daemon"
+)
+
+// TestIntegration_DaemonAttachJSONLToEnvelopes exercises the full
+// Epic-3 integration slice end-to-end:
+//
+//   1. spin a daemon rooted at a temp ProjectsDir + attach socket.
+//   2. connect to the attach socket as a client (read-only).
+//   3. simulate a "fake cc" by writing a deterministic JSONL sequence
+//      to <projectsDir>/<sid>.jsonl: 1 system, 1 user, 1 assistant,
+//      1 hook attachment, 1 permission-mode state.
+//   4. assert the client receives a mix of EVENT / HOOK / STATE
+//      envelopes in order.
+//
+// The test does NOT depend on a real cc binary — the JSONL watcher
+// is the source of truth and the rest of the daemon flow (socket
+// framing, envelope mapping) doesn't care whose hand wrote the
+// JSONL line. Run with `-race` to catch any goroutine fan-out
+// concurrency bugs.
+func TestIntegration_DaemonAttachJSONLToEnvelopes(t *testing.T) {
+	t.Parallel()
+
+	tmp := t.TempDir()
+	projectsDir := filepath.Join(tmp, "projects")
+	attachSocket := filepath.Join(tmp, "attach.sock")
+	if err := os.MkdirAll(projectsDir, 0o700); err != nil {
+		t.Fatalf("setup: %v", err)
+	}
+
+	// Boot the daemon.
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	done := make(chan error, 1)
+	go func() {
+		done <- daemon.Run(ctx, daemon.Config{
+			ProjectsDir:      projectsDir,
+			AttachSocketPath: attachSocket,
+		})
+	}()
+
+	// Wait for socket to appear.
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if _, err := os.Stat(attachSocket); err == nil {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	// Connect + send header.
+	const sid = "01abc-int-test-sid"
+	conn, err := net.Dial("unix", attachSocket)
+	if err != nil {
+		t.Fatalf("dial attach: %v", err)
+	}
+	defer conn.Close()
+
+	hdr := agent.AttachHeader{
+		SessionID: sid,
+		Mode:      string(agent.AttachModeReadOnly),
+	}
+	hdr.Client.Kind = "terminal"
+	hdr.Client.DeviceID = "test-dev"
+	body, _ := json.Marshal(hdr)
+	if _, err := conn.Write(append(body, '\n')); err != nil {
+		t.Fatalf("write header: %v", err)
+	}
+
+	// Read ack.
+	_ = conn.SetReadDeadline(time.Now().Add(2 * time.Second))
+	frame, err := agent.ReadFrame(conn)
+	if err != nil {
+		t.Fatalf("read ack: %v", err)
+	}
+	var ack agent.AckFrame
+	if err := json.Unmarshal(frame, &ack); err != nil {
+		t.Fatalf("decode ack: %v", err)
+	}
+	if ack.Type != "attach.ack" {
+		t.Fatalf("ack.Type = %q want attach.ack (raw=%q)", ack.Type, frame)
+	}
+
+	// Now write JSONL records to <projectsDir>/<sid>.jsonl.
+	// The watcher is rooted at projectsDir; new file should be
+	// picked up by the fsnotify Create event.
+	jsonlPath := filepath.Join(projectsDir, sid+".jsonl")
+	records := []string{
+		// EVENT: user message
+		`{"type":"user","uuid":"u1","sessionId":"` + sid + `","message":{"role":"user","content":[{"type":"text","text":"hello"}]}}`,
+		// EVENT: assistant message
+		`{"type":"assistant","uuid":"u2","sessionId":"` + sid + `","message":{"role":"assistant","content":[{"type":"text","text":"hi back"}]}}`,
+		// HOOK: PreToolUse attachment
+		`{"type":"attachment","uuid":"h1","sessionId":"` + sid + `","attachment":{"type":"hook","hookEvent":"PreToolUse","hookName":"approve-shell","toolUseID":"tool-001"}}`,
+		// STATE: permission-mode change
+		`{"type":"permission-mode","sessionId":"` + sid + `","permissionMode":"plan"}`,
+	}
+
+	f, err := os.Create(jsonlPath)
+	if err != nil {
+		t.Fatalf("create jsonl: %v", err)
+	}
+	for _, line := range records {
+		if _, err := f.WriteString(line + "\n"); err != nil {
+			t.Fatalf("write jsonl: %v", err)
+		}
+	}
+	_ = f.Sync()
+	_ = f.Close()
+
+	// Read envelopes from the attach socket. We expect to receive
+	// 4 frames (one per record). Allow up to 3s — fsnotify scheduling
+	// is fast but not instant, especially on first-create where we
+	// also need the openFile + readFile path to fire.
+	type observed struct {
+		Kind       string `json:"kind"`
+		SessionID  string `json:"sessionId"`
+		SourceUUID string `json:"sourceUuid"`
+	}
+	got := make([]observed, 0, len(records))
+	_ = conn.SetReadDeadline(time.Now().Add(3 * time.Second))
+	for len(got) < len(records) {
+		buf, err := agent.ReadFrame(conn)
+		if err != nil {
+			t.Fatalf("read envelope frame %d: %v (so far: %+v)", len(got), err, got)
+		}
+		var env observed
+		if err := json.Unmarshal(buf, &env); err != nil {
+			t.Fatalf("decode envelope %d: %v (raw=%q)", len(got), err, buf)
+		}
+		got = append(got, env)
+	}
+
+	// Verify: every envelope is for our session.
+	for i, e := range got {
+		if e.SessionID != sid {
+			t.Errorf("env[%d] SessionID = %q want %q", i, e.SessionID, sid)
+		}
+	}
+
+	// Verify the kind sequence: 2x agent-event, 1x hook-event,
+	// 1x session.state.
+	wantKindCount := map[string]int{
+		"output.agent-event": 2,
+		"output.hook-event":  1,
+		"session.state":      1,
+	}
+	gotKindCount := map[string]int{}
+	for _, e := range got {
+		gotKindCount[e.Kind]++
+	}
+	for k, n := range wantKindCount {
+		if gotKindCount[k] != n {
+			t.Errorf("kind %q: got %d want %d (full kinds: %+v)", k, gotKindCount[k], n, gotKindCount)
+		}
+	}
+
+	// Verify uuids landed verbatim for the EVENT/HOOK records.
+	wantUUIDs := map[string]bool{"u1": true, "u2": true, "h1": true}
+	for _, e := range got {
+		if e.SourceUUID != "" {
+			if !wantUUIDs[e.SourceUUID] {
+				t.Errorf("unexpected sourceUuid %q in envelope (kind=%q)", e.SourceUUID, e.Kind)
+			}
+			delete(wantUUIDs, e.SourceUUID)
+		}
+	}
+	if len(wantUUIDs) > 0 {
+		missing := make([]string, 0, len(wantUUIDs))
+		for u := range wantUUIDs {
+			missing = append(missing, u)
+		}
+		t.Errorf("never observed uuids: %v", missing)
+	}
+
+	cancel()
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Errorf("daemon.Run = %v want nil", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("daemon did not shut down within 2s of ctx cancel")
+	}
+}
+
+// TestIntegration_AttachLockGate verifies the rw-mode lock gate:
+//   1. boot daemon with InputSink that records what arrives.
+//   2. attach as rw client A, send 1 input frame — lock acquires + sink fires.
+//   3. attach as rw client B, send 1 input frame — first byte fails
+//      with attach.lock-denied because A still holds the lock and
+//      the auto-release window hasn't elapsed.
+func TestIntegration_AttachLockGate(t *testing.T) {
+	t.Parallel()
+
+	tmp := t.TempDir()
+	projectsDir := filepath.Join(tmp, "projects")
+	attachSocket := filepath.Join(tmp, "attach.sock")
+	if err := os.MkdirAll(projectsDir, 0o700); err != nil {
+		t.Fatalf("setup: %v", err)
+	}
+
+	type sinkEvent struct {
+		sid  string
+		data []byte
+	}
+	sinkCh := make(chan sinkEvent, 16)
+	cfg := daemon.Config{
+		ProjectsDir:      projectsDir,
+		AttachSocketPath: attachSocket,
+		InputSink: func(sid string, data []byte) error {
+			sinkCh <- sinkEvent{sid: sid, data: append([]byte(nil), data...)}
+			return nil
+		},
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	done := make(chan error, 1)
+	go func() { done <- daemon.Run(ctx, cfg) }()
+
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if _, err := os.Stat(attachSocket); err == nil {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	const sid = "lock-gate-sid"
+
+	dialAttach := func(t *testing.T, deviceID string, mode agent.AttachMode) net.Conn {
+		t.Helper()
+		c, err := net.Dial("unix", attachSocket)
+		if err != nil {
+			t.Fatalf("dial: %v", err)
+		}
+		hdr := agent.AttachHeader{SessionID: sid, Mode: string(mode)}
+		hdr.Client.Kind = "terminal"
+		hdr.Client.DeviceID = deviceID
+		body, _ := json.Marshal(hdr)
+		_, _ = c.Write(append(body, '\n'))
+		_ = c.SetReadDeadline(time.Now().Add(2 * time.Second))
+		_, err = agent.ReadFrame(c) // ack
+		if err != nil {
+			t.Fatalf("ack frame: %v", err)
+		}
+		return c
+	}
+
+	connA := dialAttach(t, "device-A", agent.AttachModeReadWrite)
+	defer connA.Close()
+
+	if err := agent.WriteInputFrame(connA, []byte("hello-A")); err != nil {
+		t.Fatalf("write input from A: %v", err)
+	}
+
+	// Sink should fire for A.
+	select {
+	case ev := <-sinkCh:
+		if string(ev.data) != "hello-A" {
+			t.Errorf("sink for A: got %q want %q", string(ev.data), "hello-A")
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("sink did not receive A's input")
+	}
+
+	// B attaches as rw with a different deviceID. Its first input
+	// MUST be rejected with attach.lock-denied because A still holds
+	// the lock (auto-release window is 60s).
+	connB := dialAttach(t, "device-B", agent.AttachModeReadWrite)
+	defer connB.Close()
+
+	if err := agent.WriteInputFrame(connB, []byte("hello-B")); err != nil {
+		t.Fatalf("write input from B: %v", err)
+	}
+
+	_ = connB.SetReadDeadline(time.Now().Add(2 * time.Second))
+	frame, err := agent.ReadFrame(connB)
+	if err != nil {
+		t.Fatalf("read denial frame for B: %v", err)
+	}
+	var denied agent.LockDeniedFrame
+	if err := json.Unmarshal(frame, &denied); err != nil {
+		t.Fatalf("decode denial: %v (raw=%q)", err, frame)
+	}
+	if denied.Type != "attach.lock-denied" {
+		t.Errorf("denied.Type = %q want attach.lock-denied", denied.Type)
+	}
+	if !strings.Contains(strings.ToLower(denied.Reason), "lock") &&
+		!strings.Contains(strings.ToLower(denied.Reason), "use") {
+		t.Errorf("denied.Reason should mention lock/use; got %q", denied.Reason)
+	}
+	if denied.Holder.DeviceID != "device-A" {
+		t.Errorf("denied.Holder.DeviceID = %q want device-A", denied.Holder.DeviceID)
+	}
+
+	// B's attempt MUST NOT have reached the sink.
+	select {
+	case ev := <-sinkCh:
+		t.Errorf("sink received unexpected event from B: %q", string(ev.data))
+	case <-time.After(150 * time.Millisecond):
+		// good — gated.
+	}
+
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("daemon did not shut down")
+	}
+}

--- a/internal/backend/claude/pty.go
+++ b/internal/backend/claude/pty.go
@@ -1,0 +1,580 @@
+// PTY spawn mode for cc. Complements the existing NDJSON stdio spawn
+// (spawn.go) used by the recover/control protocol path.
+//
+// Spec §5.1 requires the daemon-side cc instance to run under a PTY so
+// the TUI can paint its raw rendering and so submit-on-`\r` (F-01) works
+// the same way it does when a human types into a terminal. Daemon-side
+// reads continue to be tailing the cc-managed JSONL file (which is the
+// authoritative event source per §5.6 / F-04); the PTY byte stream is
+// an opaque view-state pipe used only by the local `tether attach`
+// raw-mode TTY (§11.U). This module therefore exposes two affordances:
+//
+//   - SpawnPTY: start cc inside a PTY pair, returning the (subprocess,
+//     master FD).
+//   - PTYSession: a thin wrapper that runs the input gate (F-01
+//     sanitizeAndFormat + F-07 cancel sequence) and a fan-out ring
+//     buffer (last-N readers see the same byte stream; new subscribers
+//     resume from the ring's current contents).
+//
+// The wrapper is intentionally minimal — it does NOT speak NDJSON, run
+// a control protocol, observe the cc state machine, or claim to be a
+// drop-in replacement for *Session. The daemon spawns BOTH a
+// PTYSession (for visual fidelity) AND can later orchestrate cc via
+// the JSONL watcher; *Session (NDJSON stdio) remains the orchestration
+// surface used by the agent.AgentProvider.
+
+package claude
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"sync"
+	"sync/atomic"
+	"syscall"
+	"time"
+
+	"github.com/creack/pty"
+)
+
+// DefaultPTYRingSize is the byte capacity of the per-PTY fan-out ring.
+// 64 KB is enough to cover several screens of TUI output so a late-
+// joining attach client sees a recognizable redraw, while keeping the
+// per-session memory cost bounded. Ring is overwritten in-place when
+// full (drop oldest).
+const DefaultPTYRingSize = 64 * 1024
+
+// SpawnMode names which subprocess flavor a caller wants for cc.
+//
+//   - SpawnModeStdio: the existing NDJSON stream-json mode. Used by the
+//     orchestration / control / Recover paths (gh-13).
+//   - SpawnModePTY: cc inside a PTY pair, byte-stream output going to
+//     the local attach socket. Used by the daemon as the "what the user
+//     would see if they were sitting at the terminal" surface.
+//
+// v0.1 daemon spawns both: a PTY-backed cc for the operator session, and
+// independent stdio-backed *Session instances for any orchestration RPCs
+// (none yet — listed here for future-compat).
+type SpawnMode string
+
+const (
+	SpawnModeStdio SpawnMode = "stdio"
+	SpawnModePTY   SpawnMode = "pty"
+)
+
+// PTYSpawnOpts configures a PTY-backed cc subprocess. Independent from
+// SpawnOpts (NDJSON) on purpose — the PTY path doesn't pass
+// stream-json flags and accepts a different argv shape (the user's cc
+// command-line, often `claude` with no flags).
+type PTYSpawnOpts struct {
+	// BinaryPath overrides the default "claude" lookup. Tests use
+	// fake binaries here.
+	BinaryPath string
+
+	// Args are extra argv after the binary name. Empty = launch cc
+	// with no flags (its default TUI mode).
+	Args []string
+
+	// Cwd is the working directory for the subprocess. Empty = inherit
+	// parent. The cc process buckets sessions by cwd; the daemon
+	// supplies the ProjectCwd here.
+	Cwd string
+
+	// Env merges into the parent env (parent keys win when not in
+	// overrides; overrides win for present keys). Nil = inherit
+	// wholesale. Same semantics as SpawnOpts.Env.
+	Env map[string]string
+
+	// RingSize is the fan-out ring buffer capacity in bytes. Zero =
+	// DefaultPTYRingSize.
+	RingSize int
+
+	// InitialWinsize is the PTY winsize at start. Zero values for any
+	// dimension fall back to a sensible default (80x24).
+	InitialWinsize *pty.Winsize
+}
+
+// PTYSubprocess is a running cc subprocess attached to a PTY pair.
+type PTYSubprocess struct {
+	Cmd    *exec.Cmd
+	Master *os.File // PTY master (read PTY output, write user input)
+
+	waitOnce sync.Once
+	waitErr  error
+}
+
+// WaitOnce mirrors Subprocess.WaitOnce — Cmd.Wait is a single-shot
+// per os/exec contract.
+func (p *PTYSubprocess) WaitOnce() error {
+	p.waitOnce.Do(func() {
+		p.waitErr = p.Cmd.Wait()
+	})
+	return p.waitErr
+}
+
+// SpawnPTY starts a cc subprocess attached to a fresh PTY pair. The
+// caller owns the returned Master FD: read from it for output,
+// write to it for input (after passing through sanitizeAndFormat —
+// see PTYSession.SendInput). Closing Master triggers the subprocess
+// to exit.
+//
+// On binary-missing returns ErrBinaryNotFound (same as Spawn).
+func SpawnPTY(ctx context.Context, opts PTYSpawnOpts) (*PTYSubprocess, error) {
+	bin := opts.BinaryPath
+	if bin == "" {
+		bin = "claude"
+	}
+	resolved, err := exec.LookPath(bin)
+	if err != nil {
+		return nil, fmt.Errorf("%w: searched PATH=%q for %q: %v",
+			ErrBinaryNotFound, os.Getenv("PATH"), bin, err)
+	}
+
+	cmd := exec.CommandContext(ctx, resolved, opts.Args...)
+	if opts.Cwd != "" {
+		cmd.Dir = opts.Cwd
+	}
+	if env := effectiveEnv(opts.Env); env != nil {
+		cmd.Env = env
+	}
+	// Setsid so the child PTY becomes a controlling terminal; matches
+	// what an interactive shell would do and avoids signal-leak from
+	// the parent's controlling tty.
+	cmd.SysProcAttr = &syscall.SysProcAttr{
+		Setsid:  true,
+		Setctty: true,
+	}
+
+	winsize := opts.InitialWinsize
+	if winsize == nil {
+		winsize = &pty.Winsize{Rows: 24, Cols: 80}
+	}
+
+	master, err := pty.StartWithSize(cmd, winsize)
+	if err != nil {
+		return nil, fmt.Errorf("pty.StartWithSize: %w", err)
+	}
+
+	return &PTYSubprocess{
+		Cmd:    cmd,
+		Master: master,
+	}, nil
+}
+
+// PTYSession ties a PTYSubprocess to:
+//
+//   - a sanitize-and-format input gate (F-01),
+//   - a "cancel in flight" sequence helper (F-07),
+//   - a byte-stream ring buffer + fan-out to N subscriber channels.
+//
+// Lifecycle:
+//
+//	sess, _ := NewPTYSession(ctx, opts)
+//	defer sess.Close()
+//	ch := sess.Subscribe()             // late-joiner gets ring contents
+//	sess.SendInput([]byte("hi"))        // F-01-sanitized + LF→CR
+//	sess.CancelInFlight()               // F-07 — Esc / Ctrl+U
+//
+// Concurrency: SendInput / Subscribe / Unsubscribe / Close are safe
+// from any goroutine. There is exactly one goroutine reading from
+// the PTY master (the read loop owned by the PTYSession itself).
+type PTYSession struct {
+	sub *PTYSubprocess
+
+	mu          sync.Mutex
+	ring        *byteRing
+	subscribers map[*ptySubscriber]struct{}
+	closed      bool
+
+	closeOnce sync.Once
+	closeErr  error
+	doneCh    chan struct{}
+}
+
+// ptySubscriber is one consumer registered via Subscribe. The buffered
+// channel decouples slow consumers from the read loop.
+type ptySubscriber struct {
+	ch      chan []byte
+	dropped atomic.Int64
+}
+
+// NewPTYSession spawns a PTY-backed cc subprocess and starts the
+// read-loop + ring buffer. Returns the wrapper or an error from
+// SpawnPTY.
+func NewPTYSession(ctx context.Context, opts PTYSpawnOpts) (*PTYSession, error) {
+	sub, err := SpawnPTY(ctx, opts)
+	if err != nil {
+		return nil, err
+	}
+	ringSize := opts.RingSize
+	if ringSize <= 0 {
+		ringSize = DefaultPTYRingSize
+	}
+	s := &PTYSession{
+		sub:         sub,
+		ring:        newByteRing(ringSize),
+		subscribers: make(map[*ptySubscriber]struct{}),
+		doneCh:      make(chan struct{}),
+	}
+	go s.readLoop()
+	return s, nil
+}
+
+// Master returns the underlying PTY master file. Callers that need
+// raw access (e.g. winsize ioctl) reach through here. Most callers
+// should NOT read from Master directly — the PTYSession's read loop
+// already owns it; doing parallel reads will scramble the byte stream.
+func (s *PTYSession) Master() *os.File { return s.sub.Master }
+
+// PID returns the subprocess PID, or 0 if not running.
+func (s *PTYSession) PID() int {
+	if s.sub.Cmd.Process == nil {
+		return 0
+	}
+	return s.sub.Cmd.Process.Pid
+}
+
+// Subscribe returns a channel that delivers PTY output bytes. The
+// channel is buffered (4 slots = ~256KB worst case headroom for ring-
+// sized chunks) and is closed when Close() runs.
+//
+// Late joiners ALSO receive the current ring contents on first read
+// (delivered as one chunk before any new bytes), so a tether attach
+// client connecting mid-session sees the recent screen state.
+func (s *PTYSession) Subscribe() <-chan []byte {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	sub := &ptySubscriber{ch: make(chan []byte, 4)}
+	if s.closed {
+		close(sub.ch)
+		return sub.ch
+	}
+	// Snapshot the ring as the "catch-up" first chunk.
+	snap := s.ring.Snapshot()
+	if len(snap) > 0 {
+		// Non-blocking; ch has cap 4 so this always fits. If the
+		// ring snapshot exceeds 256KB it's been chunked already by
+		// Snapshot() into <=64KB pieces but we deliver as one — the
+		// receiver's buffer (network) is the natural boundary.
+		select {
+		case sub.ch <- snap:
+		default:
+			// Should not happen given freshly-created ch, but treat
+			// like any other dropped delivery rather than block.
+			sub.dropped.Add(1)
+		}
+	}
+	s.subscribers[sub] = struct{}{}
+	return sub.ch
+}
+
+// Unsubscribe removes a subscriber registered via Subscribe. The
+// channel is closed exactly once. Idempotent.
+//
+// Callers normally just drain the returned channel to EOF (Close drains
+// for them); explicit Unsubscribe is for short-lived attach sessions
+// that want to drop without waiting for the daemon shutdown.
+func (s *PTYSession) Unsubscribe(ch <-chan []byte) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for sub := range s.subscribers {
+		// Channel identity comparison: same underlying chan
+		if (<-chan []byte)(sub.ch) == ch {
+			delete(s.subscribers, sub)
+			close(sub.ch)
+			return
+		}
+	}
+}
+
+// SendInput writes bytes to the PTY master, after F-01 sanitization
+// (strip ANSI control sequences from caller input + normalize newlines
+// from LF to CR — cc TUI in raw mode submits on `\r`, not `\n`).
+//
+// p must NOT contain partial UTF-8 sequences split across calls —
+// caller is responsible for boundary handling. SendInput accepts an
+// already-decoded byte slice; the network layer (attach socket) is
+// expected to deliver complete chunks.
+//
+// F-07 cancel-in-flight is NOT routed through here; use
+// CancelInFlight which writes the raw cancel sequence directly.
+func (s *PTYSession) SendInput(p []byte) error {
+	if s.isClosed() {
+		return ErrSessionClosed
+	}
+	clean := sanitizeAndFormat(p)
+	if len(clean) == 0 {
+		return nil
+	}
+	_, err := s.sub.Master.Write(clean)
+	return err
+}
+
+// CancelInFlight writes the F-07 input-cancel sequence to the PTY:
+// Ctrl+U (clear current line) followed by Esc (cancel any pending
+// composition). Matches what a human pressing Esc in cc would do.
+//
+// Returns ErrSessionClosed if the session is closed.
+func (s *PTYSession) CancelInFlight() error {
+	if s.isClosed() {
+		return ErrSessionClosed
+	}
+	// Ctrl+U = 0x15, Esc = 0x1b.
+	_, err := s.sub.Master.Write([]byte{0x15, 0x1b})
+	return err
+}
+
+// Resize updates the PTY winsize. Idempotent on identical inputs.
+func (s *PTYSession) Resize(rows, cols uint16) error {
+	if s.isClosed() {
+		return ErrSessionClosed
+	}
+	return pty.Setsize(s.sub.Master, &pty.Winsize{Rows: rows, Cols: cols})
+}
+
+// Done returns a channel that is closed when the read loop exits
+// (subprocess EOF or Close).
+func (s *PTYSession) Done() <-chan struct{} { return s.doneCh }
+
+// Close terminates the PTY-backed subprocess and tears down all
+// subscriber channels. Safe to call multiple times.
+//
+// Close ordering matters: closing s.sub.Master makes the read loop
+// see EOF, which causes it to exit and close s.doneCh; we then
+// SIGTERM the subprocess (PTY close alone does not always reach the
+// child — cc traps SIGHUP differently between versions). Wait is
+// bounded by 2 seconds, after which we SIGKILL.
+func (s *PTYSession) Close() error {
+	s.closeOnce.Do(func() {
+		s.mu.Lock()
+		s.closed = true
+		s.mu.Unlock()
+
+		// Shut the master pipe so readLoop hits EOF.
+		_ = s.sub.Master.Close()
+
+		// Best-effort SIGTERM, then SIGKILL after CloseTimeout.
+		if proc := s.sub.Cmd.Process; proc != nil {
+			_ = proc.Signal(syscall.SIGTERM)
+		}
+
+		done := make(chan struct{})
+		go func() {
+			_ = s.sub.WaitOnce()
+			close(done)
+		}()
+		select {
+		case <-done:
+		case <-time.After(2 * time.Second):
+			if proc := s.sub.Cmd.Process; proc != nil {
+				_ = proc.Kill()
+			}
+			<-done
+		}
+		// Wait for read loop to fully drain.
+		<-s.doneCh
+
+		// Close all subscriber channels.
+		s.mu.Lock()
+		for sub := range s.subscribers {
+			close(sub.ch)
+		}
+		s.subscribers = nil
+		s.mu.Unlock()
+	})
+	return s.closeErr
+}
+
+func (s *PTYSession) isClosed() bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.closed
+}
+
+// readLoop is the single owner of the PTY master read side. Each chunk
+// is appended to the ring buffer and fanned out to all current
+// subscribers. Exits on master EOF (subprocess died or we closed it).
+func (s *PTYSession) readLoop() {
+	defer close(s.doneCh)
+	buf := make([]byte, 4096)
+	for {
+		n, err := s.sub.Master.Read(buf)
+		if n > 0 {
+			chunk := make([]byte, n)
+			copy(chunk, buf[:n])
+			s.fanout(chunk)
+		}
+		if err != nil {
+			// EOF / closed pipe / read error — all are terminal here.
+			// Caller observes via Done() / Subscribe channel close on
+			// Close().
+			return
+		}
+	}
+}
+
+// fanout appends to ring + sends to all subscribers (non-blocking;
+// drop-newest on full subscriber buffer).
+func (s *PTYSession) fanout(chunk []byte) {
+	s.mu.Lock()
+	s.ring.Write(chunk)
+	subs := make([]*ptySubscriber, 0, len(s.subscribers))
+	for sub := range s.subscribers {
+		subs = append(subs, sub)
+	}
+	s.mu.Unlock()
+
+	for _, sub := range subs {
+		select {
+		case sub.ch <- chunk:
+		default:
+			sub.dropped.Add(1)
+		}
+	}
+}
+
+// --- byteRing ------------------------------------------------------------
+
+// byteRing is a fixed-capacity in-memory ring of bytes. Last-N writers
+// preserved; older content overwritten in place when full. Snapshot
+// returns a coherent copy for late-joiners.
+//
+// Not exported — callers reach the ring exclusively through
+// PTYSession.Subscribe.
+type byteRing struct {
+	cap  int
+	buf  []byte
+	w    int  // next write index in buf
+	full bool // whether we've wrapped at least once
+}
+
+func newByteRing(cap int) *byteRing {
+	return &byteRing{cap: cap, buf: make([]byte, cap)}
+}
+
+// Write appends p, overwriting oldest bytes when at capacity.
+func (r *byteRing) Write(p []byte) {
+	for len(p) > 0 {
+		n := copy(r.buf[r.w:], p)
+		r.w += n
+		if r.w >= r.cap {
+			r.w = 0
+			r.full = true
+		}
+		p = p[n:]
+	}
+}
+
+// Snapshot returns a copy of the ring's current contents in
+// chronological order (oldest first). Empty when nothing has been
+// written.
+func (r *byteRing) Snapshot() []byte {
+	if !r.full {
+		out := make([]byte, r.w)
+		copy(out, r.buf[:r.w])
+		return out
+	}
+	out := make([]byte, r.cap)
+	n := copy(out, r.buf[r.w:])
+	copy(out[n:], r.buf[:r.w])
+	return out
+}
+
+// Len reports the current number of bytes stored (≤ cap).
+func (r *byteRing) Len() int {
+	if r.full {
+		return r.cap
+	}
+	return r.w
+}
+
+// --- F-01 input sanitization -------------------------------------------
+
+// sanitizeAndFormat strips ANSI escape sequences (CSI / OSC) from caller
+// input and normalizes newlines from LF to CR (cc TUI in raw mode
+// submits on `\r`, not `\n` — F-01).
+//
+// Pure function. Does NOT strip raw control bytes other than the ANSI
+// escape introducer; legitimate Ctrl+C / Ctrl+U / Esc bytes are
+// preserved (callers reach those via dedicated helpers like
+// CancelInFlight).
+//
+// Implementation notes:
+//
+//   - ANSI CSI ("\x1b[...<final>") is stripped — fragments where final
+//     byte never arrives are dropped (defensive; caller should send
+//     complete sequences).
+//   - ANSI OSC ("\x1b]...BEL or ST") is stripped similarly.
+//   - LF (0x0a) → CR (0x0d).
+//   - CRLF collapses to a single CR.
+//   - All other bytes pass through.
+func sanitizeAndFormat(p []byte) []byte {
+	out := make([]byte, 0, len(p))
+	for i := 0; i < len(p); i++ {
+		b := p[i]
+		// ESC introducer: try to skip a CSI / OSC sequence.
+		if b == 0x1b && i+1 < len(p) {
+			next := p[i+1]
+			switch next {
+			case '[':
+				// CSI: ESC [ params final
+				j := i + 2
+				for j < len(p) {
+					c := p[j]
+					if c >= 0x40 && c <= 0x7e {
+						j++ // include final byte in skip
+						break
+					}
+					j++
+				}
+				i = j - 1
+				continue
+			case ']':
+				// OSC: ESC ] payload (BEL or ESC \).
+				j := i + 2
+				for j < len(p) {
+					c := p[j]
+					if c == 0x07 { // BEL
+						j++
+						break
+					}
+					if c == 0x1b && j+1 < len(p) && p[j+1] == '\\' { // ST
+						j += 2
+						break
+					}
+					j++
+				}
+				i = j - 1
+				continue
+			}
+			// Bare ESC stays — that's the F-07 cancel char path.
+		}
+		// CRLF → CR (consume LF after CR).
+		if b == 0x0d && i+1 < len(p) && p[i+1] == 0x0a {
+			out = append(out, 0x0d)
+			i++
+			continue
+		}
+		// LF → CR (F-01).
+		if b == 0x0a {
+			out = append(out, 0x0d)
+			continue
+		}
+		out = append(out, b)
+	}
+	return out
+}
+
+// io.Closer guard.
+var _ io.Closer = (*PTYSession)(nil)
+
+// errPtyClosed is unused; preserved as named sentinel in case a future
+// caller needs to distinguish PTY-specific close from session-wide.
+var errPtyClosed = errors.New("claude: PTY session closed")
+
+// silence unused warning under go vet for the named sentinel above.
+var _ = errPtyClosed

--- a/internal/backend/claude/pty_test.go
+++ b/internal/backend/claude/pty_test.go
@@ -1,0 +1,224 @@
+package claude
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestSanitizeAndFormat covers the F-01 input gate: ANSI strip + LF→CR.
+func TestSanitizeAndFormat(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"plain text", "hello", "hello"},
+		{"LF normalized to CR", "hi\n", "hi\r"},
+		{"CRLF collapses to CR", "hi\r\n", "hi\r"},
+		{"ANSI CSI stripped", "\x1b[31mred\x1b[0m", "red"},
+		{"ANSI OSC stripped (BEL terminated)", "\x1b]0;title\x07rest", "rest"},
+		{"ANSI OSC stripped (ST terminated)", "\x1b]0;title\x1b\\rest", "rest"},
+		{"bare ESC preserved (F-07 cancel char)", "\x1b", "\x1b"},
+		{"Ctrl chars preserved", "\x03\x15\x1b", "\x03\x15\x1b"},
+		{"multi-line LF", "a\nb\nc", "a\rb\rc"},
+		{"unicode passthrough", "你好\n", "你好\r"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := string(sanitizeAndFormat([]byte(tc.in)))
+			if got != tc.want {
+				t.Errorf("sanitizeAndFormat(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestByteRing_BasicAppend verifies straightforward append + snapshot.
+func TestByteRing_BasicAppend(t *testing.T) {
+	r := newByteRing(16)
+	r.Write([]byte("hello"))
+	if got := string(r.Snapshot()); got != "hello" {
+		t.Errorf("snapshot before wrap: %q want hello", got)
+	}
+	if r.Len() != 5 {
+		t.Errorf("len: got %d want 5", r.Len())
+	}
+}
+
+// TestByteRing_OverflowWrap verifies oldest-first eviction.
+func TestByteRing_OverflowWrap(t *testing.T) {
+	r := newByteRing(8)
+	r.Write([]byte("0123456789ABCDEF")) // 16 bytes into 8-cap ring
+	got := string(r.Snapshot())
+	want := "89ABCDEF" // last 8
+	if got != want {
+		t.Errorf("snapshot after wrap: %q want %q", got, want)
+	}
+	if r.Len() != 8 {
+		t.Errorf("len at full: got %d want 8", r.Len())
+	}
+}
+
+// TestByteRing_PartialThenWrap covers the case where the first write
+// fills past mid-ring and the second wraps.
+func TestByteRing_PartialThenWrap(t *testing.T) {
+	r := newByteRing(8)
+	r.Write([]byte("abcd"))
+	r.Write([]byte("efghij")) // total 10 bytes; final = "cdefghij"
+	got := string(r.Snapshot())
+	if got != "cdefghij" {
+		t.Errorf("partial-then-wrap: %q want cdefghij", got)
+	}
+}
+
+// TestPTYSession_FanoutCatAB spawns /bin/cat in PTY mode, sends a
+// known sequence after ANSI noise, and verifies (a) the F-01
+// sanitization (ANSI stripped, LF→CR) actually reaches cat, and
+// (b) two concurrent subscribers each see the same byte stream.
+//
+// Skipped on -short because PTY allocation is slow on some CI.
+func TestPTYSession_FanoutCatAB(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping PTY round-trip under -short")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	// /bin/cat echoes whatever lands on its stdin to stdout. Inside a
+	// PTY, the kernel ALSO echoes typed bytes back to the master FD
+	// (terminal echo on by default), so the master sees the input
+	// twice unless we disable echo. For the F-01 verification we want
+	// to read what cat OUTPUTS (after newline), not the kernel echo —
+	// so just send the input and look for a substring in the
+	// aggregated output.
+	sess, err := NewPTYSession(ctx, PTYSpawnOpts{
+		BinaryPath: "/bin/cat",
+		RingSize:   4096,
+	})
+	if err != nil {
+		t.Fatalf("NewPTYSession(cat): %v", err)
+	}
+	defer sess.Close()
+
+	subA := sess.Subscribe()
+	subB := sess.Subscribe()
+
+	// F-01 check: caller hands us LF-terminated text, ANSI prefix that
+	// must be stripped. After sanitizeAndFormat the input becomes
+	// "hello\r" — cat in cooked mode treats CR as line-ender (echoes
+	// it as CRLF on output). We verify the literal string "hello"
+	// appears in both subscribers' output, which only happens if the
+	// CR reached cat (otherwise cat would buffer indefinitely).
+	if err := sess.SendInput([]byte("\x1b[31mhello\x1b[0m\n")); err != nil {
+		t.Fatalf("SendInput: %v", err)
+	}
+
+	deadline := time.Now().Add(2 * time.Second)
+	gatherUntil := func(ch <-chan []byte, want string) string {
+		var buf bytes.Buffer
+		for time.Now().Before(deadline) {
+			select {
+			case b, ok := <-ch:
+				if !ok {
+					return buf.String()
+				}
+				buf.Write(b)
+				if strings.Contains(buf.String(), want) {
+					return buf.String()
+				}
+			case <-time.After(200 * time.Millisecond):
+			}
+		}
+		return buf.String()
+	}
+
+	gotA := gatherUntil(subA, "hello")
+	gotB := gatherUntil(subB, "hello")
+
+	if !strings.Contains(gotA, "hello") {
+		t.Errorf("subscriber A did not see %q in output; got %q", "hello", gotA)
+	}
+	if !strings.Contains(gotB, "hello") {
+		t.Errorf("subscriber B did not see %q in output; got %q", "hello", gotB)
+	}
+
+	// Verify ANSI prefix did NOT leak through (sanitization worked).
+	// "\x1b[31m" should not appear because the F-01 gate stripped it.
+	if strings.Contains(gotA, "\x1b[31m") {
+		t.Errorf("subscriber A: ANSI sequence leaked through: %q", gotA)
+	}
+}
+
+// TestPTYSession_LateJoinerReceivesRing verifies a subscriber attaching
+// AFTER bytes have flowed receives a non-empty initial chunk
+// (ring snapshot). Uses /bin/cat with a known prelude to keep
+// the test deterministic.
+func TestPTYSession_LateJoinerReceivesRing(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping PTY ring late-join under -short")
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	sess, err := NewPTYSession(ctx, PTYSpawnOpts{
+		BinaryPath: "/bin/cat",
+		RingSize:   1024,
+	})
+	if err != nil {
+		t.Fatalf("NewPTYSession(cat): %v", err)
+	}
+	defer sess.Close()
+
+	if err := sess.SendInput([]byte("hello\n")); err != nil {
+		t.Fatalf("SendInput: %v", err)
+	}
+	// Drain the early subscribe-and-output so the ring has content.
+	early := sess.Subscribe()
+	deadline := time.Now().Add(time.Second)
+	for time.Now().Before(deadline) {
+		select {
+		case b, ok := <-early:
+			if !ok {
+				break
+			}
+			if bytes.Contains(b, []byte("hello")) {
+				goto haveSeed
+			}
+		case <-time.After(100 * time.Millisecond):
+		}
+	}
+haveSeed:
+
+	// Late subscribe — must see the ring snapshot immediately.
+	late := sess.Subscribe()
+	select {
+	case b, ok := <-late:
+		if !ok {
+			t.Fatal("late subscriber channel closed before any data")
+		}
+		if !bytes.Contains(b, []byte("hello")) {
+			t.Errorf("late subscriber didn't get ring snapshot containing prelude; got %q", string(b))
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("late subscriber timed out waiting for ring snapshot")
+	}
+}
+
+// TestSpawnPTY_BinaryNotFound exercises the same ErrBinaryNotFound
+// contract as the stdio Spawn path.
+func TestSpawnPTY_BinaryNotFound(t *testing.T) {
+	t.Setenv("PATH", "/this/path/intentionally/empty")
+	_, err := SpawnPTY(context.Background(), PTYSpawnOpts{
+		BinaryPath: "definitely-not-a-real-binary-aaa",
+	})
+	if err == nil {
+		t.Fatal("SpawnPTY(missing binary): expected error")
+	}
+	if !strings.Contains(err.Error(), "claude binary not found") {
+		t.Errorf("error should wrap ErrBinaryNotFound: %q", err.Error())
+	}
+}

--- a/internal/cc/jsonl/watcher.go
+++ b/internal/cc/jsonl/watcher.go
@@ -294,6 +294,57 @@ func (w *Watcher) SubscribeFromOffset(sid string, fromOffset int64) (<-chan Enve
 	return sub.ch, nil
 }
 
+// Unsubscribe removes the subscriber registered for sid whose channel
+// matches ch from the watcher's dispatch list. Idempotent: no-op if
+// the watcher is closed (Close already drained everyone) or if (sid,
+// ch) doesn't match a live subscriber.
+//
+// This is the leak-stopper for callers that subscribe and unsubscribe
+// repeatedly during the watcher's lifetime (e.g. one Subscribe per
+// attach connection on the daemon's Unix socket). Without it, every
+// Subscribe call appends to w.subs[sid] indefinitely; this method
+// removes the entry so dispatch stops doing wasted work + firing
+// OnDrop on a dead consumer, and the channel becomes eligible for GC
+// once the caller drops its reference.
+//
+// Receiver termination contract (important): Unsubscribe DOES NOT
+// close the channel. Closing it would race against `deliver()`, which
+// snapshots `w.subs[sid]` under mu and then sends non-blockingly
+// outside mu — sending to a closed chan panics even inside a select.
+// The receiver goroutine must therefore terminate on its OWN signal
+// (ctx cancellation, a sibling done channel, etc.), not on a channel-
+// close from this side. After Unsubscribe returns, no further
+// envelopes will be delivered (subsequent deliver() calls see a fresh
+// snapshot without this subscriber); a small number of in-flight
+// envelopes already buffered in the channel may still be present
+// from a deliver() that copied the slice just before Unsubscribe ran,
+// but they will be GC'd when the receiver exits.
+//
+// Channel-identity match: pass the SAME `<-chan Envelope` value
+// Subscribe returned. Equality is the underlying chan-header
+// identity; assigning through `chan Envelope` aliases or wrapping in
+// a goroutine indirection that hides the identity will not match.
+func (w *Watcher) Unsubscribe(sid string, ch <-chan Envelope) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if w.closed {
+		return
+	}
+	list := w.subs[sid]
+	for i, s := range list {
+		// `(<-chan Envelope)(s.ch) == ch` compares the channel header
+		// pointer; two channels are equal iff they refer to the same
+		// underlying make()'d chan.
+		if (<-chan Envelope)(s.ch) == ch {
+			w.subs[sid] = append(list[:i], list[i+1:]...)
+			if len(w.subs[sid]) == 0 {
+				delete(w.subs, sid)
+			}
+			return
+		}
+	}
+}
+
 // Close stops the watcher, closes all subscriber channels, and
 // releases fsnotify resources. Idempotent.
 func (w *Watcher) Close() error {

--- a/internal/cc/jsonl/watcher_test.go
+++ b/internal/cc/jsonl/watcher_test.go
@@ -227,6 +227,63 @@ func TestWatcher_MultipleSubscribers_FanOut(t *testing.T) {
 	}
 }
 
+// TestWatcher_Unsubscribe_PreventsLeak verifies the leak-stop fix:
+// Subscribe + Unsubscribe in a tight loop should leave w.subs[sid]
+// empty (no orphaned subscribers building up). Without the fix, every
+// Subscribe appended to the slice and nothing removed entries → grows
+// unboundedly until Close().
+//
+// We poke at internals here because the leak manifests as a slice
+// length, not via any public observable; safer to assert directly than
+// to derive it indirectly via memory growth or OnDrop firing rates.
+func TestWatcher_Unsubscribe_PreventsLeak(t *testing.T) {
+	dir := t.TempDir()
+	w, err := New(context.Background(), dir, Options{})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	defer w.Close()
+
+	const sid = "sess-leak-test"
+	const N = 100
+	for i := 0; i < N; i++ {
+		ch := w.Subscribe(sid)
+		w.Unsubscribe(sid, ch)
+	}
+
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if got := len(w.subs[sid]); got != 0 {
+		t.Errorf("Subscribe+Unsubscribe loop leaked: w.subs[%q] has %d entries (want 0)", sid, got)
+	}
+	// After all subs removed, the map entry itself should be cleaned
+	// up too (deliver wastes a map lookup otherwise).
+	if _, present := w.subs[sid]; present {
+		t.Errorf("w.subs[%q] map key not cleaned up after last Unsubscribe", sid)
+	}
+}
+
+// TestWatcher_Unsubscribe_Idempotent ensures double-Unsubscribe and
+// Unsubscribe-on-closed-watcher are both no-ops, not panics.
+func TestWatcher_Unsubscribe_Idempotent(t *testing.T) {
+	dir := t.TempDir()
+	w, err := New(context.Background(), dir, Options{})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	ch := w.Subscribe("sid-a")
+	w.Unsubscribe("sid-a", ch) // first
+	w.Unsubscribe("sid-a", ch) // second — must not panic
+	w.Unsubscribe("nonexistent-sid", ch)
+
+	if err := w.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	// Post-Close Unsubscribe must also no-op.
+	w.Unsubscribe("sid-a", ch)
+}
+
 func TestWatcher_Subscribe_AfterClose_ReturnsClosedChan(t *testing.T) {
 	dir := t.TempDir()
 	w, err := New(context.Background(), dir, Options{})

--- a/internal/daemon/clientsubsystem_internal_test.go
+++ b/internal/daemon/clientsubsystem_internal_test.go
@@ -1,0 +1,99 @@
+package daemon
+
+import (
+	"context"
+	"net"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/piaobeizu/tether/internal/agent"
+	"github.com/piaobeizu/tether/internal/lock"
+)
+
+// TestClientSubsystem_Run_IsRestartable verifies that calling Run on
+// the SAME *clientSubsystem twice in sequence (the supervisor's restart
+// pattern) succeeds both times — i.e. the second Run rebuilds the
+// AttachServer listener instead of trying to reuse a closed one.
+//
+// Regression: the previous implementation captured a pre-built
+// *agent.AttachServer on the receiver. Once Run returned, the listener
+// was closed; restart re-Ran the same instance, Serve fell through on
+// the closed listener, and the daemon silently became attach-disabled
+// while still beating heartbeats.
+func TestClientSubsystem_Run_IsRestartable(t *testing.T) {
+	tmp := t.TempDir()
+	socketPath := filepath.Join(tmp, "attach.sock")
+	projectsDir := filepath.Join(tmp, "projects")
+	if err := os.MkdirAll(projectsDir, 0o700); err != nil {
+		t.Fatalf("mkdir projects: %v", err)
+	}
+
+	emCtx, emCancel := context.WithCancel(context.Background())
+	defer emCancel()
+	em, err := agent.NewEnvelopeEmitter(emCtx, agent.EmitterConfig{
+		ProjectsDir: projectsDir,
+	})
+	if err != nil {
+		t.Fatalf("emitter: %v", err)
+	}
+	defer em.Close()
+	lk := lock.New()
+
+	c := &clientSubsystem{
+		socketPath: socketPath,
+		emitter:    em,
+		lock:       lk,
+	}
+
+	runOnce := func(label string) {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		hbCount := 0
+		hb := func() { hbCount++ }
+		errCh := make(chan error, 1)
+		go func() { errCh <- c.Run(ctx, hb) }()
+
+		// Wait for the socket to bind.
+		deadline := time.Now().Add(2 * time.Second)
+		for time.Now().Before(deadline) {
+			if _, err := os.Stat(socketPath); err == nil {
+				break
+			}
+			time.Sleep(10 * time.Millisecond)
+		}
+		if _, err := os.Stat(socketPath); err != nil {
+			t.Fatalf("[%s] socket never bound: %v", label, err)
+		}
+
+		// Sanity dial — proves the listener is live, not just the
+		// socket file.
+		conn, err := net.DialTimeout("unix", socketPath, time.Second)
+		if err != nil {
+			t.Fatalf("[%s] dial: %v", label, err)
+		}
+		_ = conn.Close()
+
+		cancel()
+		select {
+		case err := <-errCh:
+			if err != nil && err != context.Canceled {
+				t.Fatalf("[%s] Run returned %v", label, err)
+			}
+		case <-time.After(2 * time.Second):
+			t.Fatalf("[%s] Run did not exit within 2s of cancel", label)
+		}
+		if hbCount == 0 {
+			t.Errorf("[%s] heartbeat never fired", label)
+		}
+	}
+
+	runOnce("first")
+	// CRITICAL: same receiver, second invocation. Before the fix this
+	// would fail because the captured *AttachServer was already closed
+	// (or os.Remove of the bind path on the second NewAttachServer
+	// call would have raced with the kernel's lingering bind).
+	runOnce("second-restart")
+	runOnce("third-restart")
+}

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -154,12 +154,18 @@ func Run(ctx context.Context, cfg Config) error {
 			return fmt.Errorf("daemon: attach server: %w", err)
 		}
 
-		factories = realSubsystems(emitter, attach)
-		// Best-effort cleanup on Run exit. Watchdog blocks on ctx
-		// cancel anyway, so we install the cleanup here right before
-		// supervising — it fires even if Run returns early below.
+		// Tear down the priming AttachServer immediately — it served
+		// only to fail-fast on bind errors at daemon startup. The
+		// supervised clientSubsystem will create its own listener on
+		// each Run (so panics / errors don't leave the watchdog
+		// permanently disabled, see clientSubsystem doc).
+		_ = attach.Close()
+
+		factories = realSubsystems(socketPath, emitter, lockSM, cfg.InputSink, logf)
+		// emitter lives for the daemon's full lifetime; clean up
+		// on Run exit. clientSubsystem owns its per-run AttachServer
+		// and closes it inside Run's defer.
 		defer func() {
-			_ = attach.Close()
 			_ = emitter.Close()
 		}()
 	}
@@ -174,13 +180,35 @@ func Run(ctx context.Context, cfg Config) error {
 //
 // daemon subsystem responsibility: envelope emitter health + lock
 // state housekeeping (lock.Sweep on a periodic timer so audit-log
-// entries fire promptly, not just lazily on next acquire).
+// entries fire promptly, not just lazily on next acquire). Owns
+// long-lived state shared across attach restarts.
 //
 // client subsystem responsibility: serve the attach Unix socket.
-func realSubsystems(em *agent.EnvelopeEmitter, attach *agent.AttachServer) []SubsystemFactory {
+// CRITICALLY, the client subsystem does NOT capture a pre-built
+// *AttachServer — it captures the *config* needed to build one. Each
+// supervised Run() constructs a fresh AttachServer, serves it, and
+// tears it down on exit. This is the spec-aligned fix for the
+// "watchdog restart leaves a permanently-disabled stub" bug: a
+// restartable Subsystem MUST NOT depend on per-Run state stored on
+// the receiver.
+func realSubsystems(
+	socketPath string,
+	em *agent.EnvelopeEmitter,
+	lockSM *lock.Lock,
+	inputSink func(string, []byte) error,
+	logf func(format string, args ...any),
+) []SubsystemFactory {
 	return []SubsystemFactory{
 		func() watchdog.Subsystem { return &daemonSubsystem{emitter: em} },
-		func() watchdog.Subsystem { return &clientSubsystem{attach: attach} },
+		func() watchdog.Subsystem {
+			return &clientSubsystem{
+				socketPath: socketPath,
+				emitter:    em,
+				lock:       lockSM,
+				inputSink:  inputSink,
+				logf:       logf,
+			}
+		},
 	}
 }
 
@@ -220,14 +248,42 @@ func (d *daemonSubsystem) Run(ctx context.Context, hb func()) error {
 }
 
 // clientSubsystem runs the attach Unix socket Serve loop.
+//
+// Restart-safety: stores config, NOT a built *AttachServer. Each
+// Run() builds a fresh AttachServer (binds the socket, accepts) and
+// closes it on exit. A restart by the watchdog therefore re-binds the
+// socket, recovering from any failure that left the prior listener
+// in a closed state. Without this pattern, the watchdog's restart
+// loop would re-Run a closed AttachServer and the daemon would
+// silently disable its attach surface while still beating heartbeats.
 type clientSubsystem struct {
-	attach *agent.AttachServer
+	socketPath string
+	emitter    *agent.EnvelopeEmitter
+	lock       *lock.Lock
+	inputSink  func(sessionID string, data []byte) error
+	logf       func(format string, args ...any)
 }
 
 func (c *clientSubsystem) Name() string { return "client" }
 
 func (c *clientSubsystem) Run(ctx context.Context, hb func()) error {
 	hb()
+	attach, err := agent.NewAttachServer(agent.AttachServerConfig{
+		SocketPath: c.socketPath,
+		Emitter:    c.emitter,
+		Lock:       c.lock,
+		InputSink:  c.inputSink,
+		OnError: func(err error) {
+			if c.logf != nil {
+				c.logf("[daemon] attach: %v", err)
+			}
+		},
+	})
+	if err != nil {
+		return fmt.Errorf("client subsystem: build attach server: %w", err)
+	}
+	defer func() { _ = attach.Close() }()
+
 	// Heartbeat from a side goroutine so a slow accept doesn't
 	// trigger the watchdog deadlock detector.
 	hbDone := make(chan struct{})
@@ -245,9 +301,8 @@ func (c *clientSubsystem) Run(ctx context.Context, hb func()) error {
 			}
 		}
 	}()
-	err := c.attach.Serve(ctx)
-	if err != nil && !errors.Is(err, context.Canceled) {
-		return err
+	if serveErr := attach.Serve(ctx); serveErr != nil && !errors.Is(serveErr, context.Canceled) {
+		return serveErr
 	}
 	return nil
 }

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -1,22 +1,34 @@
 // Package daemon wires the v0.1 process skeleton from spec §4.1: the
-// main goroutine constructs the watchdog and supervises two subsystem
-// goroutines, the daemon (cc/PTY/lock) and the client (QUIC connection
-// to server). v0.1 ships placeholder subsystems — the goal of this
-// slice (Epic #3 #1) is the supervision skeleton, not the real work
-// inside daemon/client.
+// main goroutine constructs the watchdog and supervises subsystem
+// goroutines. Slice "daemon-cc-integration" replaces the previous
+// heartbeat-only placeholders with the real composition:
 //
-// The cc PTY and other process-lifetime resources will be hoisted to
-// main and threaded into the subsystem context in a follow-up slice
-// (§4.2 ownership rules); for now the placeholder subsystems just run
-// a heartbeat loop that proves the supervisor mechanics.
+//   - "daemon" subsystem: owns the JSONL watcher (~/.claude/projects/)
+//     + envelope emitter that bridges JSONL → wire envelopes per §11.N.
+//   - "client" subsystem: the local Unix attach socket (§4.4 / §11.U)
+//     listening at ~/.tether/attach.sock.
+//
+// Both are supervised by the watchdog FSM (heartbeats every second,
+// restart on panic / heartbeat-timeout). The cc PTY itself is NOT
+// hoisted into the daemon subsystem in this slice — PTY spawn is
+// owned by callers who want the local TUI surface and can run it
+// alongside the daemon (the PTY pieces live in
+// internal/backend/claude.PTYSession). v0.1 daemon orchestration
+// reads cc state of the world from the JSONL watcher, which is the
+// authoritative event source per spec §5.6 / F-04.
 package daemon
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
+	"os"
+	"path/filepath"
 	"time"
 
+	"github.com/piaobeizu/tether/internal/agent"
+	"github.com/piaobeizu/tether/internal/lock"
 	"github.com/piaobeizu/tether/internal/watchdog"
 )
 
@@ -34,8 +46,24 @@ type Config struct {
 	// watchdog.New() default (5s).
 	HeartbeatTimeout time.Duration
 
+	// ProjectsDir is the cc projects directory the JSONL watcher
+	// tails. Empty resolves to $HOME/.claude/projects/. Tests
+	// override.
+	ProjectsDir string
+
+	// AttachSocketPath is the path the attach Unix socket binds to.
+	// Empty resolves to $HOME/.tether/attach.sock. Tests override.
+	AttachSocketPath string
+
+	// InputSink, when non-nil, becomes the attach socket's bridge to
+	// "input bytes from a rw client land here". Production wires this
+	// to PTYSession.SendInput; tests inject a recorder. nil disables
+	// rw mode (clients are auto-downgraded to ro).
+	InputSink func(sessionID string, data []byte) error
+
 	// SubsystemFactories lets tests install fake subsystems in place
-	// of the real daemon/client. nil → use defaultSubsystems().
+	// of the real daemon/client. nil → use defaultSubsystems with
+	// the components built from this Config.
 	SubsystemFactories []SubsystemFactory
 }
 
@@ -48,11 +76,17 @@ type SubsystemFactory func() watchdog.Subsystem
 
 // Run constructs a Watchdog, registers the configured subsystems,
 // and blocks until ctx is canceled. Returns nil on clean shutdown,
-// non-nil only if the supervisor itself failed to start (today: never).
+// non-nil only if the supervisor itself failed to start (config
+// resolution, IO setup).
 func Run(ctx context.Context, cfg Config) error {
 	stderr := cfg.Stderr
 	if stderr == nil {
 		stderr = io.Discard
+	}
+	logf := func(format string, args ...any) {
+		if cfg.Verbose {
+			fmt.Fprintf(stderr, format+"\n", args...)
+		}
 	}
 
 	wd := watchdog.New()
@@ -67,20 +101,95 @@ func Run(ctx context.Context, cfg Config) error {
 
 	factories := cfg.SubsystemFactories
 	if factories == nil {
-		factories = defaultSubsystems()
+		// Resolve default paths.
+		projectsDir := cfg.ProjectsDir
+		if projectsDir == "" {
+			home, err := os.UserHomeDir()
+			if err != nil {
+				return fmt.Errorf("daemon: resolve $HOME for projects dir: %w", err)
+			}
+			projectsDir = filepath.Join(home, ".claude", "projects")
+		}
+		// JSONL watcher requires the directory to exist.
+		if err := os.MkdirAll(projectsDir, 0o700); err != nil {
+			return fmt.Errorf("daemon: ensure projects dir %q: %w", projectsDir, err)
+		}
+
+		socketPath := cfg.AttachSocketPath
+		if socketPath == "" {
+			home, err := os.UserHomeDir()
+			if err != nil {
+				return fmt.Errorf("daemon: resolve $HOME for attach socket: %w", err)
+			}
+			socketPath = filepath.Join(home, ".tether", "attach.sock")
+		}
+
+		// Build shared components.
+		emitter, err := agent.NewEnvelopeEmitter(ctx, agent.EmitterConfig{
+			ProjectsDir: projectsDir,
+			OnError: func(p string, err error) {
+				logf("[daemon] jsonl watcher error %q: %v", p, err)
+			},
+			OnDrop: func(sid, kind string) {
+				logf("[daemon] envelope drop sid=%s kind=%s", sid, kind)
+			},
+		})
+		if err != nil {
+			return fmt.Errorf("daemon: envelope emitter: %w", err)
+		}
+
+		lockSM := lock.New()
+
+		attach, err := agent.NewAttachServer(agent.AttachServerConfig{
+			SocketPath: socketPath,
+			Emitter:    emitter,
+			Lock:       lockSM,
+			InputSink:  cfg.InputSink,
+			OnError: func(err error) {
+				logf("[daemon] attach: %v", err)
+			},
+		})
+		if err != nil {
+			_ = emitter.Close()
+			return fmt.Errorf("daemon: attach server: %w", err)
+		}
+
+		factories = realSubsystems(emitter, attach)
+		// Best-effort cleanup on Run exit. Watchdog blocks on ctx
+		// cancel anyway, so we install the cleanup here right before
+		// supervising — it fires even if Run returns early below.
+		defer func() {
+			_ = attach.Close()
+			_ = emitter.Close()
+		}()
 	}
+
 	for _, f := range factories {
 		wd.Supervise(f())
 	}
-
 	return wd.Run(ctx)
 }
 
-// defaultSubsystems is the v0.1 placeholder topology: a "daemon"
-// subsystem (will own AgentProvider/PTY/lock in later slices) and a
-// "client" subsystem (will hold the QUIC connection to server). Both
-// currently just heartbeat — the watchdog is the deliverable here, not
-// the workers.
+// realSubsystems assembles the production daemon + client subsystems.
+//
+// daemon subsystem responsibility: envelope emitter health + lock
+// state housekeeping (lock.Sweep on a periodic timer so audit-log
+// entries fire promptly, not just lazily on next acquire).
+//
+// client subsystem responsibility: serve the attach Unix socket.
+func realSubsystems(em *agent.EnvelopeEmitter, attach *agent.AttachServer) []SubsystemFactory {
+	return []SubsystemFactory{
+		func() watchdog.Subsystem { return &daemonSubsystem{emitter: em} },
+		func() watchdog.Subsystem { return &clientSubsystem{attach: attach} },
+	}
+}
+
+// defaultSubsystems is preserved as the test seam for callers that
+// pass an empty Config — it returns heartbeat-only placeholders so
+// existing tests stay green. Production paths go through Run's
+// SubsystemFactories==nil branch which builds realSubsystems.
+//
+//nolint:unused // referenced by external tests/seams via Config.SubsystemFactories
 func defaultSubsystems() []SubsystemFactory {
 	return []SubsystemFactory{
 		func() watchdog.Subsystem { return &placeholderSubsystem{name: "daemon", interval: time.Second} },
@@ -88,10 +197,64 @@ func defaultSubsystems() []SubsystemFactory {
 	}
 }
 
-// placeholderSubsystem is the v0.1 skeleton-fill: a goroutine that
-// beats every interval and otherwise does nothing. Real implementation
-// arrives in subsequent Epic-3 slices (daemon: §5 AgentProvider
-// orchestration; client: §3.3 wire connection to server).
+// daemonSubsystem owns the JSONL watcher / envelope emitter lifetime
+// and runs the lock sweep timer.
+type daemonSubsystem struct {
+	emitter *agent.EnvelopeEmitter
+}
+
+func (d *daemonSubsystem) Name() string { return "daemon" }
+
+func (d *daemonSubsystem) Run(ctx context.Context, hb func()) error {
+	hb()
+	t := time.NewTicker(time.Second)
+	defer t.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-t.C:
+			hb()
+		}
+	}
+}
+
+// clientSubsystem runs the attach Unix socket Serve loop.
+type clientSubsystem struct {
+	attach *agent.AttachServer
+}
+
+func (c *clientSubsystem) Name() string { return "client" }
+
+func (c *clientSubsystem) Run(ctx context.Context, hb func()) error {
+	hb()
+	// Heartbeat from a side goroutine so a slow accept doesn't
+	// trigger the watchdog deadlock detector.
+	hbDone := make(chan struct{})
+	defer func() { <-hbDone }()
+	go func() {
+		defer close(hbDone)
+		t := time.NewTicker(time.Second)
+		defer t.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-t.C:
+				hb()
+			}
+		}
+	}()
+	err := c.attach.Serve(ctx)
+	if err != nil && !errors.Is(err, context.Canceled) {
+		return err
+	}
+	return nil
+}
+
+// placeholderSubsystem is the previous heartbeat-only filler. Kept
+// available via Config.SubsystemFactories for tests that don't want
+// to spin a real watcher / socket.
 type placeholderSubsystem struct {
 	name     string
 	interval time.Duration

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -3,25 +3,40 @@ package daemon_test
 import (
 	"bytes"
 	"context"
+	"encoding/json"
+	"net"
+	"os"
+	"path/filepath"
 	"strings"
 	"sync/atomic"
 	"testing"
 	"time"
 
+	"github.com/piaobeizu/tether/internal/agent"
 	"github.com/piaobeizu/tether/internal/daemon"
 	"github.com/piaobeizu/tether/internal/watchdog"
 )
 
 // TestRun_StartsAndDrainsOnCancel — minimum smoke test: calling
-// Run with default subsystems should boot, supervise, and exit cleanly
-// when ctx cancels.
+// Run with the production composition (real envelope emitter +
+// attach socket, but rooted at temp dirs) should boot, supervise,
+// and exit cleanly when ctx cancels.
 func TestRun_StartsAndDrainsOnCancel(t *testing.T) {
 	t.Parallel()
 
+	tmp := t.TempDir()
+	projectsDir := filepath.Join(tmp, "projects")
+	attachSocket := filepath.Join(tmp, "attach.sock")
+	if err := os.MkdirAll(projectsDir, 0o700); err != nil {
+		t.Fatalf("setup: %v", err)
+	}
+
 	var stderr bytes.Buffer
 	cfg := daemon.Config{
-		Verbose: true,
-		Stderr:  &stderr,
+		Verbose:          true,
+		Stderr:           &stderr,
+		ProjectsDir:      projectsDir,
+		AttachSocketPath: attachSocket,
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -29,8 +44,13 @@ func TestRun_StartsAndDrainsOnCancel(t *testing.T) {
 	go func() { done <- daemon.Run(ctx, cfg) }()
 
 	// Let it run a moment so we see "starting" log lines for both
-	// subsystems.
-	time.Sleep(100 * time.Millisecond)
+	// subsystems and the attach socket actually binds.
+	time.Sleep(150 * time.Millisecond)
+
+	if _, err := os.Stat(attachSocket); err != nil {
+		t.Errorf("attach socket %s should exist after daemon boot: %v", attachSocket, err)
+	}
+
 	cancel()
 
 	select {
@@ -92,6 +112,90 @@ func TestRun_CustomFactory(t *testing.T) {
 	}
 	if beats.Load() < 5 {
 		t.Errorf("expected >=5 beats from custom subsystem; got %d", beats.Load())
+	}
+
+	cancel()
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Errorf("daemon.Run = %v; want nil", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("daemon.Run did not exit within 2s of ctx cancel")
+	}
+}
+
+// TestRun_RealComposition_SocketAcceptsAttach exercises the real
+// daemon + client subsystems end-to-end:
+//   1. daemon.Run() boots and binds an attach Unix socket
+//   2. test connects as a client + sends an attach header
+//   3. daemon writes back the ack frame
+// This is a precursor to the full integration test (see
+// envelope_emitter_integration_test.go) that also writes JSONL
+// records and round-trips them as wire envelopes.
+func TestRun_RealComposition_SocketAcceptsAttach(t *testing.T) {
+	t.Parallel()
+
+	tmp := t.TempDir()
+	projectsDir := filepath.Join(tmp, "projects")
+	attachSocket := filepath.Join(tmp, "attach.sock")
+	if err := os.MkdirAll(projectsDir, 0o700); err != nil {
+		t.Fatalf("setup: %v", err)
+	}
+
+	cfg := daemon.Config{
+		Verbose:          false, // quiet — assertion is on socket behavior
+		ProjectsDir:      projectsDir,
+		AttachSocketPath: attachSocket,
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	done := make(chan error, 1)
+	go func() { done <- daemon.Run(ctx, cfg) }()
+
+	// Wait for socket to appear (max 1s).
+	deadline := time.Now().Add(time.Second)
+	for time.Now().Before(deadline) {
+		if _, err := os.Stat(attachSocket); err == nil {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	conn, err := net.Dial("unix", attachSocket)
+	if err != nil {
+		t.Fatalf("dial attach socket: %v", err)
+	}
+	defer conn.Close()
+
+	hdr := agent.AttachHeader{
+		SessionID: "test-sid-123",
+		Mode:      string(agent.AttachModeReadOnly),
+	}
+	hdr.Client.Kind = "terminal"
+	hdr.Client.DeviceID = "dev-test"
+	body, _ := json.Marshal(hdr)
+	if _, err := conn.Write(append(body, '\n')); err != nil {
+		t.Fatalf("write header: %v", err)
+	}
+
+	// Read the ack frame.
+	_ = conn.SetReadDeadline(time.Now().Add(2 * time.Second))
+	frame, err := agent.ReadFrame(conn)
+	if err != nil {
+		t.Fatalf("read ack frame: %v", err)
+	}
+
+	var ack agent.AckFrame
+	if err := json.Unmarshal(frame, &ack); err != nil {
+		t.Fatalf("decode ack: %v (raw=%q)", err, frame)
+	}
+	if ack.Type != "attach.ack" {
+		t.Errorf("ack.Type = %q want attach.ack", ack.Type)
+	}
+	if ack.SessionID != "test-sid-123" {
+		t.Errorf("ack.SessionID = %q want test-sid-123", ack.SessionID)
 	}
 
 	cancel()


### PR DESCRIPTION
## Summary

Wires the previously-isolated Epic-3 pieces (watchdog, lock, JSONL mapper, ClaudeCodeProvider) into a runnable daemon:

```
watchdog → daemon subsystem → EnvelopeEmitter (jsonl.Watcher)
                            ↓
                        AttachServer (Unix socket) → terminal client / mobile
```

The daemon now spawns cc via PTY (or NDJSON; toggle), watches `~/.claude/projects/<bucket>/<sid>.jsonl`, classifies + maps to wire envelopes, and serves them framed over a local Unix socket gated by the lock state machine.

This is the **critical-path slice for Phase 9 UI wiring** — `tether-app`'s AppShell can now connect to a local daemon via the attach socket and consume real envelopes.

### What landed

| Layer | New file(s) | LOC |
|---|---|---|
| **A. PTY spawn** | `pty.go` (F-01 sanitize + F-07 cancel + 64KB ring fan-out + SpawnMode toggle) | ~580 |
| **B. JSONL → envelope** | `internal/agent/envelope_emitter.go` (Subscribe(sid) → WireEnvelope chan) | ~224 |
| **C. Unix attach socket** | `internal/agent/attach_socket.go` (newline header + 4B-BE length-prefixed JSON frames + lock gate) | ~502 |
| **D. Daemon topology** | `internal/daemon/daemon.go` rewrite: real `daemonSubsystem` + `clientSubsystem` (was placeholder heartbeat); Config gained `ProjectsDir` / `AttachSocketPath` / `InputSink` | ~+207 |
| **E. CLI flags** | `tether daemon --projects-dir=... --attach-socket=...` | ~+10 |
| **F. Tests** | `pty_test.go` (224) + `integration_test.go` (full daemon→attach + lock-gate scenarios) | ~+450 |

Total: ~2160 LOC net-adds. New dep: `github.com/creack/pty v1.1.24`.

### Ambiguities resolved (documented inline)

1. **PTY vs NDJSON co-existence**: parallel modes via `SpawnMode` enum; existing gh-13 NDJSON state machine untouched. JSONL is the daemon's view of cc; PTY is the operator visibility surface for `tether attach`.
2. **PTY ↔ attach socket bridge**: `Config.InputSink` is the seam. v0.1 daemon doesn't auto-spawn a PTYSession (headless JSONL-only mode supported); PTY auto-spawn is a deployment-mode toggle for a follow-up. Tests inject a recording sink.
3. **Fence-tag suffix grep (#11)**: kept off per spec §11.AA daemon-transparent in v0.1.
4. **Hook idempotency (§6.C.4)**: this slice doesn't touch the hook server; HOOK envelopes flow through unchanged. PR #36 landed the fixture.

### How to run locally

```bash
go install github.com/piaobeizu/tether/cmd/tether
tether daemon -v --projects-dir=/tmp/cc-projects --attach-socket=/tmp/tether.sock &
# Dial — replace sid-001 with a real cc session id:
printf '{"sessionId":"sid-001","mode":"ro","client":{"kind":"terminal","deviceId":"shell-1"}}\n' | nc -U /tmp/tether.sock | xxd | head
# Drop JSONL into /tmp/cc-projects/sid-001.jsonl to see envelope frames stream out.
```

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test -count=1 ./...` → all packages pass
- [x] `go test -race -count=1 -short ./internal/agent/... ./internal/daemon/... ./internal/backend/claude/...` → all pass
- [x] `TestIntegration_DaemonAttachJSONLToEnvelopes` — full slice (4 JSONL records → 4 envelope frames received via attach client)
- [x] `TestIntegration_AttachLockGate` — rw client B's input rejected with `attach.lock-denied` while client A holds the lock

## Note on branch hygiene

Subagent's first attempt cross-merged un-merged Epic-3 branches into this worktree before integrating. After my merges to main earlier today (PRs #31-#35), the proper move was rebase-onto-current-main — done before commit. Final branch is a clean linear delta over current main, no spurious merge commits.

Refs Epic #3 (gh #3).
