### PR TITLE
Phase-9 bridge: `tether skill list --json` + attach protocol lock-in

### DIFF
--- a/cmd/tether/main.go
+++ b/cmd/tether/main.go
@@ -166,7 +166,7 @@ func usage(w *os.File) {
 	fmt.Fprintln(w, "Subcommands:")
 	fmt.Fprintln(w, "  daemon                         start the supervised daemon (watchdog + daemon + client)")
 	fmt.Fprintln(w, "  skill install <name|git-url>   install a skill into the global pool")
-	fmt.Fprintln(w, "  skill list                     list installed skills")
+	fmt.Fprintln(w, "  skill list [--json]            list installed skills (--json: machine-readable, consumed by tether-app UI)")
 	fmt.Fprintln(w, "  skill remove <name>            uninstall a skill")
 	fmt.Fprintln(w, "  skill info <name>              print manifest details for an installed skill")
 	fmt.Fprintln(w, "  resume <sid>                   resume a claude session by id (spec §10.4 strategy c)")

--- a/cmd/tether/skill.go
+++ b/cmd/tether/skill.go
@@ -90,12 +90,20 @@ func skillInstall(args []string) int {
 // (Phase 9): mapped to {name, v, on, desc, update} in
 // tether-app/src/store/loadSkills.ts. DO NOT rename without updating
 // the TS-side translator.
+//
+// Note for the Rust bridge: `json.NewEncoder(...).Encode(rows)` appends
+// a trailing '\n'. Use `serde_json::from_slice` or `from_str`, both of
+// which tolerate trailing whitespace; do not byte-equality-check raw
+// stdout.
 type skillListJSONRow struct {
 	Name        string `json:"name"`
 	Version     string `json:"version"`
 	Description string `json:"description"`
-	// Optional — omitted when the skill ships no tether.toml or no
-	// enablement field. The TS side defaults `on=true` for omitted.
+	// Optional. v0.1: never set — `internal/skill.SkillSection` has no
+	// `Enabled` field, so `pool.Info(n)` cannot populate it. Reserved
+	// for the workspace-level resolver follow-up (when tether.toml
+	// learns to express per-workspace enablement). The TS side
+	// defaults `on=true` when omitted.
 	Enabled *bool `json:"enabled,omitempty"`
 	// Optional — populated when an update channel reports a newer
 	// release. v0.1: never set (no registry probe).

--- a/cmd/tether/skill.go
+++ b/cmd/tether/skill.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"encoding/json"
 	"flag"
 	"fmt"
 	"os"
@@ -84,11 +85,35 @@ func skillInstall(args []string) int {
 	return 0
 }
 
+// skillListJSONRow is the shape emitted when `--json` is passed.
+// Field names are the wire contract for the tether-app Tauri bridge
+// (Phase 9): mapped to {name, v, on, desc, update} in
+// tether-app/src/store/loadSkills.ts. DO NOT rename without updating
+// the TS-side translator.
+type skillListJSONRow struct {
+	Name        string `json:"name"`
+	Version     string `json:"version"`
+	Description string `json:"description"`
+	// Optional — omitted when the skill ships no tether.toml or no
+	// enablement field. The TS side defaults `on=true` for omitted.
+	Enabled *bool `json:"enabled,omitempty"`
+	// Optional — populated when an update channel reports a newer
+	// release. v0.1: never set (no registry probe).
+	UpdateAvailable string `json:"updateAvailable,omitempty"`
+}
+
 func skillList(args []string) int {
-	if len(args) > 0 {
-		fmt.Fprintln(os.Stderr, "usage: tether skill list")
+	fs := flag.NewFlagSet("tether skill list", flag.ContinueOnError)
+	fs.SetOutput(os.Stderr)
+	asJSON := fs.Bool("json", false, "emit a JSON array (machine-readable; consumed by the tether-app UI)")
+	if err := fs.Parse(args); err != nil {
 		return 2
 	}
+	if fs.NArg() != 0 {
+		fmt.Fprintln(os.Stderr, "usage: tether skill list [--json]")
+		return 2
+	}
+
 	pool, err := skill.DefaultPool()
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)
@@ -99,6 +124,28 @@ func skillList(args []string) int {
 		fmt.Fprintln(os.Stderr, err)
 		return 1
 	}
+
+	if *asJSON {
+		rows := make([]skillListJSONRow, 0, len(names))
+		for _, n := range names {
+			m, _ := pool.Info(n)
+			row := skillListJSONRow{Name: n}
+			if m != nil {
+				row.Version = m.Skill.Version
+				row.Description = m.Skill.Description
+			}
+			rows = append(rows, row)
+		}
+		// Always emit a JSON array even when empty — callers parse
+		// stdout as JSON without looking at exit code or stderr.
+		enc := json.NewEncoder(os.Stdout)
+		if err := enc.Encode(rows); err != nil {
+			fmt.Fprintln(os.Stderr, err)
+			return 1
+		}
+		return 0
+	}
+
 	if len(names) == 0 {
 		fmt.Printf("(no skills installed in %s)\n", pool.Root)
 		return 0

--- a/cmd/tether/skill_test.go
+++ b/cmd/tether/skill_test.go
@@ -1,0 +1,102 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestSkillListJSON_EmptyPool — exercises the `--json` path against
+// an empty pool. The contract for tether-app's Tauri bridge is that
+// stdout is ALWAYS valid JSON (even when the pool is empty), so the
+// frontend can parse without sniffing the exit code.
+func TestSkillListJSON_EmptyPool(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	// pool root = $HOME/.tether/skills — left empty / nonexistent.
+
+	read, restore := captureStdout(t)
+	rc := skillList([]string{"--json"})
+	stdout := read()
+	restore()
+	if rc != 0 {
+		t.Fatalf("skillList(--json) returned %d, want 0", rc)
+	}
+
+	var rows []skillListJSONRow
+	if err := json.Unmarshal([]byte(stdout), &rows); err != nil {
+		t.Fatalf("output is not valid JSON: %v (raw=%q)", err, stdout)
+	}
+	if len(rows) != 0 {
+		t.Errorf("expected empty array, got %+v", rows)
+	}
+}
+
+// TestSkillListJSON_PopulatedPool — drops two skill directories into
+// the pool (one with a tether.toml, one without) and asserts the JSON
+// shape. The tether-app TS-side `loadSkills.mapSkill` translation is
+// independently unit-tested in src/store/loadSkills.test.ts.
+func TestSkillListJSON_PopulatedPool(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	pool := filepath.Join(tmp, ".tether", "skills")
+	if err := os.MkdirAll(filepath.Join(pool, "refactor-code"), 0o755); err != nil {
+		t.Fatalf("setup pool dir: %v", err)
+	}
+	manifest := `[skill]
+name = "refactor-code"
+version = "0.4.2"
+description = "DAG-driven code restructuring"
+
+[skill.agents]
+primary = "cc"
+`
+	if err := os.WriteFile(filepath.Join(pool, "refactor-code", "tether.toml"),
+		[]byte(manifest), 0o644); err != nil {
+		t.Fatalf("write manifest: %v", err)
+	}
+	// Plain plugin (no tether.toml) — should still appear in the
+	// listing with an empty version.
+	if err := os.MkdirAll(filepath.Join(pool, "plain-plugin"), 0o755); err != nil {
+		t.Fatalf("setup plain plugin: %v", err)
+	}
+
+	read, restore := captureStdout(t)
+	rc := skillList([]string{"--json"})
+	stdout := read()
+	restore()
+	if rc != 0 {
+		t.Fatalf("skillList(--json) returned %d, want 0", rc)
+	}
+
+	var rows []skillListJSONRow
+	if err := json.Unmarshal([]byte(stdout), &rows); err != nil {
+		t.Fatalf("output is not valid JSON: %v (raw=%q)", err, stdout)
+	}
+	byName := map[string]skillListJSONRow{}
+	for _, r := range rows {
+		byName[r.Name] = r
+	}
+	if got := byName["refactor-code"]; got.Version != "0.4.2" ||
+		got.Description != "DAG-driven code restructuring" {
+		t.Errorf("refactor-code row mismatch: %+v", got)
+	}
+	if got, ok := byName["plain-plugin"]; !ok {
+		t.Errorf("plain-plugin missing from listing")
+	} else if got.Version != "" {
+		t.Errorf("plain-plugin should have empty version, got %q", got.Version)
+	}
+}
+
+// TestSkillListJSON_RejectsExtraArgs — flag parsing should reject
+// positional args after `--json` (matches the non-JSON path's strict
+// arity check).
+func TestSkillListJSON_RejectsExtraArgs(t *testing.T) {
+	if rc := skillList([]string{"--json", "extra"}); rc != 2 {
+		t.Errorf("skillList(--json extra) = %d, want 2", rc)
+	}
+}
+
+// captureStdout helper lives in resume_test.go (returns read+restore
+// closures). We reuse it here.

--- a/internal/agent/attach_protocol_test.go
+++ b/internal/agent/attach_protocol_test.go
@@ -15,9 +15,12 @@ import (
 	"context"
 	"encoding/binary"
 	"encoding/json"
+	"errors"
+	"io"
 	"net"
 	"os"
 	"path/filepath"
+	"sync"
 	"testing"
 	"time"
 
@@ -127,7 +130,7 @@ func TestAttachProtocol_FrameSizePrefix(t *testing.T) {
 
 	_ = conn.SetReadDeadline(time.Now().Add(2 * time.Second))
 	var lenBuf [4]byte
-	if _, err := readFull(conn, lenBuf[:]); err != nil {
+	if _, err := io.ReadFull(conn, lenBuf[:]); err != nil {
 		t.Fatalf("read length prefix: %v", err)
 	}
 	n := binary.BigEndian.Uint32(lenBuf[:])
@@ -138,7 +141,7 @@ func TestAttachProtocol_FrameSizePrefix(t *testing.T) {
 		t.Errorf("ack length prefix = %d, want 0 < n <= 65536", n)
 	}
 	payload := make([]byte, n)
-	if _, err := readFull(conn, payload); err != nil {
+	if _, err := io.ReadFull(conn, payload); err != nil {
 		t.Fatalf("read payload: %v", err)
 	}
 	var v map[string]any
@@ -161,7 +164,23 @@ func TestAttachProtocol_FrameSizePrefix(t *testing.T) {
 func TestAttachProtocol_HeaderTooLargeIsRejected(t *testing.T) {
 	t.Parallel()
 
-	srv, sockPath := newTestAttachServer(t)
+	// Capture daemon-side errors so we can assert the daemon rejected
+	// for the SPECIFIC reason we expect (ErrHeaderTooLarge), not just
+	// "conn dropped for any reason" — a buggy daemon panic would also
+	// drop the conn.
+	var (
+		errMu     sync.Mutex
+		caughtErr error
+	)
+	srv, sockPath := newTestAttachServerWithOpts(t, func(err error) {
+		errMu.Lock()
+		defer errMu.Unlock()
+		// First error wins — subsequent close-related errors get
+		// folded so we keep the root cause.
+		if caughtErr == nil {
+			caughtErr = err
+		}
+	})
 	ctx, cancel := context.WithCancel(context.Background())
 	srvDone := make(chan error, 1)
 	go func() { srvDone <- srv.Serve(ctx) }()
@@ -184,8 +203,8 @@ func TestAttachProtocol_HeaderTooLargeIsRejected(t *testing.T) {
 	}
 	defer conn.Close()
 
-	// Send 65KB of garbage with no newline. The daemon should bail
-	// somewhere around byte 65536 and close the conn.
+	// Send 65KB+1024 of garbage with no newline. The daemon should bail
+	// at byte MaxHeaderBytes and close the conn.
 	junk := make([]byte, agent.MaxHeaderBytes+1024)
 	for i := range junk {
 		junk[i] = 'x'
@@ -203,11 +222,37 @@ func TestAttachProtocol_HeaderTooLargeIsRejected(t *testing.T) {
 	if err == nil && n > 0 {
 		t.Errorf("daemon kept conn open after oversized header (got %d bytes: %q)", n, buf[:n])
 	}
+
+	// Hard assertion: the OnError callback fired with ErrHeaderTooLarge.
+	// Conn-level close events arrive before serveConn's reportError on
+	// some kernels — wait briefly for the error to land.
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		errMu.Lock()
+		got := caughtErr
+		errMu.Unlock()
+		if got != nil {
+			if !errors.Is(got, agent.ErrHeaderTooLarge) {
+				t.Errorf("expected ErrHeaderTooLarge, got %v", got)
+			}
+			return
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	t.Error("OnError never fired — daemon dropped the conn for some other reason")
 }
 
 // --- helpers ---
 
 func newTestAttachServer(t *testing.T) (*agent.AttachServer, string) {
+	return newTestAttachServerWithOpts(t, nil)
+}
+
+// newTestAttachServerWithOpts is the variant for tests that need to
+// observe daemon-side errors (e.g. asserting ErrHeaderTooLarge fires
+// for the right reason, not just "conn dropped"). Pass nil for
+// onError to get the bare-bones server.
+func newTestAttachServerWithOpts(t *testing.T, onError func(error)) (*agent.AttachServer, string) {
 	t.Helper()
 	tmp := t.TempDir()
 	sockPath := filepath.Join(tmp, "attach.sock")
@@ -229,6 +274,7 @@ func newTestAttachServer(t *testing.T) (*agent.AttachServer, string) {
 		Emitter:    em,
 		Lock:       lk,
 		SocketPerm: 0o600,
+		OnError:    onError,
 	})
 	if err != nil {
 		_ = em.Close()
@@ -240,18 +286,4 @@ func newTestAttachServer(t *testing.T) (*agent.AttachServer, string) {
 		_ = os.Remove(sockPath)
 	})
 	return srv, sockPath
-}
-
-// readFull is io.ReadFull inlined (avoids an io import-cycle warning
-// from the linter when we have only one consumer).
-func readFull(c net.Conn, buf []byte) (int, error) {
-	total := 0
-	for total < len(buf) {
-		n, err := c.Read(buf[total:])
-		total += n
-		if err != nil {
-			return total, err
-		}
-	}
-	return total, nil
 }

--- a/internal/agent/attach_protocol_test.go
+++ b/internal/agent/attach_protocol_test.go
@@ -1,0 +1,257 @@
+// Phase 9 protocol lock-in: explicit wire-shape tests for the attach
+// socket. These complement integration_test.go (which exercises the
+// full daemon → JSONL watcher → envelope path) by isolating the
+// AttachServer + a hand-rolled "Rust-shaped" client that just speaks
+// the wire bytes — same shape the tether-app Tauri command issues
+// from src-tauri/src/attach/mod.rs.
+//
+// The point: if the wire format ever drifts (header newline contract,
+// 4-BE length prefix, ack frame shape), these tests fail BEFORE the
+// integration test does, so the breakage is localized.
+
+package agent_test
+
+import (
+	"context"
+	"encoding/binary"
+	"encoding/json"
+	"net"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/piaobeizu/tether/internal/agent"
+	"github.com/piaobeizu/tether/internal/lock"
+)
+
+// TestAttachProtocol_HeaderAckDrop simulates the minimum wire dance the
+// tether-app Rust bridge issues:
+//
+//   1. dial Unix socket
+//   2. write JSON header line + '\n'
+//   3. read 4-byte BE length-prefixed JSON ack frame
+//   4. close — daemon must clean up without error
+//
+// The test does NOT push any envelopes through; it locks in just the
+// connect-time handshake.
+func TestAttachProtocol_HeaderAckDrop(t *testing.T) {
+	t.Parallel()
+
+	srv, sockPath := newTestAttachServer(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	srvDone := make(chan error, 1)
+	go func() { srvDone <- srv.Serve(ctx) }()
+	// Cleanup order: cancel ctx FIRST so serveConn's select unblocks,
+	// then Close (idempotent) so the listener tears down + waits for
+	// per-conn goroutines, then drain srvDone.
+	defer func() {
+		cancel()
+		_ = srv.Close()
+		select {
+		case <-srvDone:
+		case <-time.After(2 * time.Second):
+			t.Errorf("server did not shut down within 2s of ctx cancel")
+		}
+	}()
+
+	conn, err := net.Dial("unix", sockPath)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	defer conn.Close()
+
+	hdr := agent.AttachHeader{SessionID: "sid-rust-123", Mode: string(agent.AttachModeReadOnly)}
+	hdr.Client.Kind = "terminal"
+	hdr.Client.DeviceID = "rust-bridge-test"
+	body, _ := json.Marshal(hdr)
+	if _, err := conn.Write(append(body, '\n')); err != nil {
+		t.Fatalf("write header: %v", err)
+	}
+
+	_ = conn.SetReadDeadline(time.Now().Add(2 * time.Second))
+	frame, err := agent.ReadFrame(conn)
+	if err != nil {
+		t.Fatalf("read ack: %v", err)
+	}
+
+	var ack agent.AckFrame
+	if err := json.Unmarshal(frame, &ack); err != nil {
+		t.Fatalf("ack JSON parse: %v (raw=%q)", err, frame)
+	}
+	if ack.Type != "attach.ack" {
+		t.Errorf("ack.Type = %q want attach.ack", ack.Type)
+	}
+	if ack.SessionID != "sid-rust-123" {
+		t.Errorf("ack.SessionID = %q want sid-rust-123", ack.SessionID)
+	}
+	if ack.Mode != string(agent.AttachModeReadOnly) {
+		t.Errorf("ack.Mode = %q want ro", ack.Mode)
+	}
+}
+
+// TestAttachProtocol_FrameSizePrefix sanity-checks the 4-byte BE length
+// prefix the Rust bridge depends on. We pull the raw bytes (NOT through
+// ReadFrame) so a regression in the helper itself is also caught.
+func TestAttachProtocol_FrameSizePrefix(t *testing.T) {
+	t.Parallel()
+
+	srv, sockPath := newTestAttachServer(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	srvDone := make(chan error, 1)
+	go func() { srvDone <- srv.Serve(ctx) }()
+	// Cleanup order: cancel ctx FIRST so serveConn's select unblocks,
+	// then Close (idempotent) so the listener tears down + waits for
+	// per-conn goroutines, then drain srvDone.
+	defer func() {
+		cancel()
+		_ = srv.Close()
+		select {
+		case <-srvDone:
+		case <-time.After(2 * time.Second):
+			t.Errorf("server did not shut down within 2s of ctx cancel")
+		}
+	}()
+
+	conn, err := net.Dial("unix", sockPath)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	defer conn.Close()
+
+	hdr := agent.AttachHeader{SessionID: "sid-frame-prefix", Mode: "ro"}
+	hdr.Client.Kind = "terminal"
+	hdr.Client.DeviceID = "rust-bridge-test"
+	body, _ := json.Marshal(hdr)
+	_, _ = conn.Write(append(body, '\n'))
+
+	_ = conn.SetReadDeadline(time.Now().Add(2 * time.Second))
+	var lenBuf [4]byte
+	if _, err := readFull(conn, lenBuf[:]); err != nil {
+		t.Fatalf("read length prefix: %v", err)
+	}
+	n := binary.BigEndian.Uint32(lenBuf[:])
+	if n == 0 || n > 64*1024 {
+		// 64K is a sanity ceiling for the ack frame; the real cap is
+		// 1MB but the ack body is well under 200B so anything > 64K
+		// here is a wire-shape regression.
+		t.Errorf("ack length prefix = %d, want 0 < n <= 65536", n)
+	}
+	payload := make([]byte, n)
+	if _, err := readFull(conn, payload); err != nil {
+		t.Fatalf("read payload: %v", err)
+	}
+	var v map[string]any
+	if err := json.Unmarshal(payload, &v); err != nil {
+		t.Fatalf("payload not JSON: %v (raw=%q)", err, payload)
+	}
+	if v["type"] != "attach.ack" {
+		t.Errorf("payload.type = %v want attach.ack", v["type"])
+	}
+}
+
+// TestAttachProtocol_HeaderTooLargeIsRejected — the daemon caps the
+// newline-terminated header read at MaxHeaderBytes (64KB). A buggy
+// client that streams without ever sending '\n' must NOT be able to
+// OOM the daemon. This test floods the socket with junk under the cap
+// + verifies the daemon drops the conn instead of panicking. The Rust
+// bridge sends well under 1KB so this is a guardrail, not a behavior
+// the bridge itself depends on — but locking it in keeps the daemon
+// safe regardless of who connects.
+func TestAttachProtocol_HeaderTooLargeIsRejected(t *testing.T) {
+	t.Parallel()
+
+	srv, sockPath := newTestAttachServer(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	srvDone := make(chan error, 1)
+	go func() { srvDone <- srv.Serve(ctx) }()
+	// Cleanup order: cancel ctx FIRST so serveConn's select unblocks,
+	// then Close (idempotent) so the listener tears down + waits for
+	// per-conn goroutines, then drain srvDone.
+	defer func() {
+		cancel()
+		_ = srv.Close()
+		select {
+		case <-srvDone:
+		case <-time.After(2 * time.Second):
+			t.Errorf("server did not shut down within 2s of ctx cancel")
+		}
+	}()
+
+	conn, err := net.Dial("unix", sockPath)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	defer conn.Close()
+
+	// Send 65KB of garbage with no newline. The daemon should bail
+	// somewhere around byte 65536 and close the conn.
+	junk := make([]byte, agent.MaxHeaderBytes+1024)
+	for i := range junk {
+		junk[i] = 'x'
+	}
+	_ = conn.SetWriteDeadline(time.Now().Add(2 * time.Second))
+	// Best-effort write; the conn may close mid-write once the daemon
+	// hits the cap. Ignore the error.
+	_, _ = conn.Write(junk)
+
+	// Reading should now hit EOF / closed-conn since the daemon
+	// rejected our oversized header.
+	_ = conn.SetReadDeadline(time.Now().Add(2 * time.Second))
+	buf := make([]byte, 16)
+	n, err := conn.Read(buf)
+	if err == nil && n > 0 {
+		t.Errorf("daemon kept conn open after oversized header (got %d bytes: %q)", n, buf[:n])
+	}
+}
+
+// --- helpers ---
+
+func newTestAttachServer(t *testing.T) (*agent.AttachServer, string) {
+	t.Helper()
+	tmp := t.TempDir()
+	sockPath := filepath.Join(tmp, "attach.sock")
+	projDir := filepath.Join(tmp, "projects")
+	if err := os.MkdirAll(projDir, 0o700); err != nil {
+		t.Fatalf("mkdir projects: %v", err)
+	}
+
+	em, err := agent.NewEnvelopeEmitter(context.Background(), agent.EmitterConfig{
+		ProjectsDir: projDir,
+	})
+	if err != nil {
+		t.Fatalf("NewEnvelopeEmitter: %v", err)
+	}
+	lk := lock.New()
+
+	srv, err := agent.NewAttachServer(agent.AttachServerConfig{
+		SocketPath: sockPath,
+		Emitter:    em,
+		Lock:       lk,
+		SocketPerm: 0o600,
+	})
+	if err != nil {
+		_ = em.Close()
+		t.Fatalf("NewAttachServer: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = srv.Close()
+		_ = em.Close()
+		_ = os.Remove(sockPath)
+	})
+	return srv, sockPath
+}
+
+// readFull is io.ReadFull inlined (avoids an io import-cycle warning
+// from the linter when we have only one consumer).
+func readFull(c net.Conn, buf []byte) (int, error) {
+	total := 0
+	for total < len(buf) {
+		n, err := c.Read(buf[total:])
+		total += n
+		if err != nil {
+			return total, err
+		}
+	}
+	return total, nil
+}


### PR DESCRIPTION
## Summary

Daemon-side surface for the tether-app Phase-9 attach bridge:

- **`tether skill list --json`** — machine-readable JSON array (always emits valid JSON, even when the pool is empty). Field names are the wire contract: `name / version / description / enabled? / updateAvailable?`. The TS-side translator (`tether-app/src/store/loadSkills.ts::mapSkill`) handles the Go→TS shape mapping in one pass.
- **`internal/agent/attach_protocol_test.go`** — explicit wire-shape lock-in for the attach socket (header line → 4B-BE length-prefixed ack frame → drop). Complements the existing end-to-end `TestIntegration_DaemonAttachJSONLToEnvelopes` by isolating the handshake. Also asserts the `MaxHeaderBytes` cap rejects oversized garbage cleanly.

### What landed

| Surface | File | Notes |
|---|---|---|
| CLI flag | `cmd/tether/skill.go` | `--json`; human path unchanged |
| CLI usage | `cmd/tether/main.go` | one-liner doc update |
| CLI tests | `cmd/tether/skill_test.go` | empty-pool / populated-pool / arity rejection |
| Protocol tests | `internal/agent/attach_protocol_test.go` | header+ack+drop, length-prefix shape, oversized header rejection |

### Pairs with

`piaobeizu/tether-app#<TBD>` — that PR's `src-tauri/src/skills.rs` is the consumer of `--json`. The two PRs are independent (different repos), but landing this one first is harmless (`--json` is additive).

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test -race -count=1 ./...` → all packages pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)