### PR TITLE
docs(agent): cross-link LockDeniedFrame to spec §11.D.1

### DIFF
--- a/internal/agent/attach_socket.go
+++ b/internal/agent/attach_socket.go
@@ -84,6 +84,10 @@ type AckFrame struct {
 
 // LockDeniedFrame is sent in response to a write that the server can't
 // authorize because the lock is held.
+//
+// Wire shape pinned in spec §11.D.1 "attach.lock-denied frame shape".
+// Field changes here MUST be mirrored there (and vice versa) — this is
+// the stable contract third-party / mobile attach clients code against.
 type LockDeniedFrame struct {
 	Type   string `json:"type"`
 	Reason string `json:"reason"`


### PR DESCRIPTION
## Summary
- Adds a doc comment on `LockDeniedFrame` in `internal/agent/attach_socket.go` pointing to **spec §11.D.1 "attach.lock-denied frame shape"** so future authors know the wire contract is pinned externally and any field change must be mirrored there.
- Comment-only — no behavioral / wire change.
- Companion to tether-doc PR #9 which adds the §11.D.1 subsection.

## Test plan
- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [ ] Reviewer: cross-link in spec PR resolves once tether-doc PR #9 lands

🤖 Generated with [Claude Code](https://claude.com/claude-code)