### PR TITLE
fix(pty): align CancelInFlight with spec §5.3 — Esc + sleep + Ctrl+U

### DIFF
--- a/internal/backend/claude/pty.go
+++ b/internal/backend/claude/pty.go
@@ -47,6 +47,36 @@ import (
 // full (drop oldest).
 const DefaultPTYRingSize = 64 * 1024
 
+// F-07 cancel-in-flight pacing. Spec §5.3 + Appendix B/F-07 require the
+// daemon to space the two cancel keystrokes so cc can react to each one
+// before the next arrives:
+//
+//  1. Esc (0x1b)              — tells cc to abort the in-flight turn;
+//     cc then re-renders the input box with
+//     the original prompt restored.
+//  2. sleep CancelEscToCtrlUDelay (500–800 ms per spec)
+//  3. Ctrl+U (0x15)           — clears whatever cc put back into the
+//     input line.
+//  4. sleep CancelCtrlUSettleDelay (200–500 ms per spec) before the
+//     caller is allowed to write a new prompt.
+//
+// We pick the lower bound of each range as the default — long enough to
+// be safe per PoC-1, short enough that the user sees a snappy "stop"
+// button. Exported so callers / tests can override if cc upstream
+// changes timing.
+const (
+	CancelEscToCtrlUDelay  = 500 * time.Millisecond
+	CancelCtrlUSettleDelay = 200 * time.Millisecond
+)
+
+// Cancel byte literals — kept as named constants so the byte-order
+// requirement (Esc THEN Ctrl+U, never the other way) is grep-able and
+// not buried in a magic-number slice. See §5.3 / F-07.
+const (
+	cancelByteEsc   byte = 0x1b // Esc — cancels cc's in-flight generation.
+	cancelByteCtrlU byte = 0x15 // Ctrl+U — clears the input line cc restores.
+)
+
 // SpawnMode names which subprocess flavor a caller wants for cc.
 //
 //   - SpawnModeStdio: the existing NDJSON stream-json mode. Used by the
@@ -192,6 +222,13 @@ type PTYSession struct {
 	closeOnce sync.Once
 	closeErr  error
 	doneCh    chan struct{}
+
+	// cancelWriter / cancelSleep are test seams for verifying the F-07
+	// cancel sequence (byte order + sleep durations) without spawning a
+	// real cc PTY. Production code leaves both nil — CancelInFlight
+	// then writes through s.sub.Master and calls time.Sleep directly.
+	cancelWriter io.Writer
+	cancelSleep  func(time.Duration)
 }
 
 // ptySubscriber is one consumer registered via Subscribe. The buffered
@@ -314,18 +351,53 @@ func (s *PTYSession) SendInput(p []byte) error {
 	return err
 }
 
-// CancelInFlight writes the F-07 input-cancel sequence to the PTY:
-// Ctrl+U (clear current line) followed by Esc (cancel any pending
-// composition). Matches what a human pressing Esc in cc would do.
+// CancelInFlight writes the F-07 input-cancel sequence to the PTY in
+// the order spec §5.3 mandates:
 //
-// Returns ErrSessionClosed if the session is closed.
+//	Esc (0x1b)  →  sleep CancelEscToCtrlUDelay  →  Ctrl+U (0x15)  →  sleep CancelCtrlUSettleDelay
+//
+// Esc MUST go first: it tells cc to abort the in-flight turn, after
+// which cc restores the original prompt into the input box. Ctrl+U
+// then clears that restored line so the caller can compose a new
+// prompt on a clean buffer. Sending them back-to-back (or in reverse
+// order) sometimes wins the race but loses it under load — cc may not
+// have processed the Esc before the line-clear arrives, leaving the
+// turn still generating.
+//
+// The two sleeps are blocking on purpose: a `tether stop` UX is OK
+// taking ~700ms, and the alternative (kicking the timing into the
+// caller) just relocates the same bug. Total wall time ≤ ~1s with
+// the lower-bound defaults.
+//
+// Returns ErrSessionClosed if the session is closed. A short-write or
+// I/O error from either keystroke is returned; the second keystroke is
+// skipped if the first fails.
 func (s *PTYSession) CancelInFlight() error {
 	if s.isClosed() {
 		return ErrSessionClosed
 	}
-	// Ctrl+U = 0x15, Esc = 0x1b.
-	_, err := s.sub.Master.Write([]byte{0x15, 0x1b})
-	return err
+	w := s.cancelWriter
+	if w == nil {
+		w = s.sub.Master
+	}
+	sleep := s.cancelSleep
+	if sleep == nil {
+		sleep = time.Sleep
+	}
+
+	// 1. Esc — cancel cc's in-flight generation.
+	if _, err := w.Write([]byte{cancelByteEsc}); err != nil {
+		return err
+	}
+	// 2. Wait for cc to process Esc and restore the prompt.
+	sleep(CancelEscToCtrlUDelay)
+	// 3. Ctrl+U — clear the restored input line.
+	if _, err := w.Write([]byte{cancelByteCtrlU}); err != nil {
+		return err
+	}
+	// 4. Settle delay before the caller may write a new prompt.
+	sleep(CancelCtrlUSettleDelay)
+	return nil
 }
 
 // Resize updates the PTY winsize. Idempotent on identical inputs.

--- a/internal/backend/claude/pty_cancel_test.go
+++ b/internal/backend/claude/pty_cancel_test.go
@@ -1,0 +1,192 @@
+package claude
+
+// Tests for the F-07 cancel-in-flight sequence (spec §5.3 + Appendix B).
+// Verifies both the byte order (Esc THEN Ctrl+U, never reversed) and
+// the inter-keystroke pacing (cc needs ~500ms to process Esc before
+// Ctrl+U is safe). PoC-1 documented this empirically; we just lock it
+// in as code so a future drive-by edit can't silently regress.
+
+import (
+	"errors"
+	"sync"
+	"testing"
+	"time"
+)
+
+// timestampedWriter records every Write call with a monotonic
+// timestamp, so a test can assert "byte X arrived before byte Y" AND
+// "the gap between the two writes was at least D".
+type timestampedWriter struct {
+	mu     sync.Mutex
+	start  time.Time
+	writes []timestampedWrite
+	// failOn, if non-nil, returns its value as the Write error when the
+	// invocation count matches its index. Used to test the "skip the
+	// second keystroke when the first fails" branch.
+	failOn map[int]error
+	calls  int
+}
+
+type timestampedWrite struct {
+	atOffset time.Duration // since the writer was created
+	bytes    []byte
+}
+
+func newTimestampedWriter() *timestampedWriter {
+	return &timestampedWriter{start: time.Now()}
+}
+
+func (w *timestampedWriter) Write(p []byte) (int, error) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	w.calls++
+	if err, ok := w.failOn[w.calls-1]; ok && err != nil {
+		return 0, err
+	}
+	cp := make([]byte, len(p))
+	copy(cp, p)
+	w.writes = append(w.writes, timestampedWrite{
+		atOffset: time.Since(w.start),
+		bytes:    cp,
+	})
+	return len(p), nil
+}
+
+// recordedSleeper captures the durations passed to time.Sleep so the
+// test can assert "we asked for at least Esc→CtrlU then settle". Using
+// a recorded fake instead of real sleeps keeps the test fast (-race
+// -count=10 should still finish in well under a second).
+type recordedSleeper struct {
+	mu        sync.Mutex
+	durations []time.Duration
+	// realDelay, if >0, makes the sleeper actually sleep this long
+	// each call so the timestampedWriter's offset measurements
+	// reflect ordering, not just declared intent. We keep it small
+	// (a few ms) to stay test-fast.
+	realDelay time.Duration
+}
+
+func (s *recordedSleeper) Sleep(d time.Duration) {
+	s.mu.Lock()
+	s.durations = append(s.durations, d)
+	delay := s.realDelay
+	s.mu.Unlock()
+	if delay > 0 {
+		time.Sleep(delay)
+	}
+}
+
+// newPTYSessionForCancelTest builds a PTYSession with NO subprocess
+// and NO read loop — only the fields CancelInFlight touches. This is
+// the lightest possible harness; spawning real cc here would make the
+// test depend on a binary on PATH and obscure the byte-level assertions.
+func newPTYSessionForCancelTest(w *timestampedWriter, sleep func(time.Duration)) *PTYSession {
+	return &PTYSession{
+		subscribers:  make(map[*ptySubscriber]struct{}),
+		doneCh:       make(chan struct{}),
+		cancelWriter: w,
+		cancelSleep:  sleep,
+	}
+}
+
+// TestCancelInFlight_ByteOrderAndSleeps is the spec-§5.3 lock-in:
+// Esc (0x1b) MUST be the first byte written, Ctrl+U (0x15) MUST be the
+// second, and there MUST be a real sleep gap between them.
+func TestCancelInFlight_ByteOrderAndSleeps(t *testing.T) {
+	w := newTimestampedWriter()
+	sleeper := &recordedSleeper{realDelay: 5 * time.Millisecond}
+	sess := newPTYSessionForCancelTest(w, sleeper.Sleep)
+
+	if err := sess.CancelInFlight(); err != nil {
+		t.Fatalf("CancelInFlight: %v", err)
+	}
+
+	// --- Byte order ---
+	if len(w.writes) != 2 {
+		t.Fatalf("got %d writes, want 2; writes=%+v", len(w.writes), w.writes)
+	}
+	if len(w.writes[0].bytes) != 1 || w.writes[0].bytes[0] != 0x1b {
+		t.Errorf("first write = %v, want [0x1b] (Esc)", w.writes[0].bytes)
+	}
+	if len(w.writes[1].bytes) != 1 || w.writes[1].bytes[0] != 0x15 {
+		t.Errorf("second write = %v, want [0x15] (Ctrl+U)", w.writes[1].bytes)
+	}
+
+	// --- Sleep durations: we expect the spec-mandated pair, in order. ---
+	if got, want := len(sleeper.durations), 2; got != want {
+		t.Fatalf("got %d sleeps, want %d; durations=%v", got, want, sleeper.durations)
+	}
+	if sleeper.durations[0] != CancelEscToCtrlUDelay {
+		t.Errorf("first sleep = %v, want CancelEscToCtrlUDelay=%v",
+			sleeper.durations[0], CancelEscToCtrlUDelay)
+	}
+	if sleeper.durations[1] != CancelCtrlUSettleDelay {
+		t.Errorf("second sleep = %v, want CancelCtrlUSettleDelay=%v",
+			sleeper.durations[1], CancelCtrlUSettleDelay)
+	}
+
+	// --- Sleep actually elapsed between writes. ---
+	// realDelay above is 5ms per Sleep call, so the gap from write[0]
+	// to write[1] should be ≥ 5ms (the first sleep). Use a generous
+	// floor (3ms) to absorb scheduler jitter on -race builds.
+	gap := w.writes[1].atOffset - w.writes[0].atOffset
+	if gap < 3*time.Millisecond {
+		t.Errorf("gap between Esc and Ctrl+U = %v, want ≥3ms (sleeper should have blocked)", gap)
+	}
+
+	// --- Spec sanity: the named delays land inside the spec windows
+	// from §5.3 / F-07 (500–800ms, 200–500ms). Pin the upper bound too
+	// so a future "let's just bump these to 5s" PR fails review here. ---
+	if CancelEscToCtrlUDelay < 500*time.Millisecond || CancelEscToCtrlUDelay > 800*time.Millisecond {
+		t.Errorf("CancelEscToCtrlUDelay=%v outside spec §5.3 window 500–800ms",
+			CancelEscToCtrlUDelay)
+	}
+	if CancelCtrlUSettleDelay < 200*time.Millisecond || CancelCtrlUSettleDelay > 500*time.Millisecond {
+		t.Errorf("CancelCtrlUSettleDelay=%v outside spec §5.3 window 200–500ms",
+			CancelCtrlUSettleDelay)
+	}
+}
+
+// TestCancelInFlight_FirstWriteFailsSkipsSecond locks in the safety
+// behavior: if the Esc write fails, we MUST NOT push Ctrl+U onto the
+// PTY (a stray Ctrl+U with no preceding Esc would clear whatever the
+// user is currently typing).
+func TestCancelInFlight_FirstWriteFailsSkipsSecond(t *testing.T) {
+	wantErr := errors.New("simulated PTY write fail")
+	w := newTimestampedWriter()
+	w.failOn = map[int]error{0: wantErr}
+	sleeper := &recordedSleeper{}
+	sess := newPTYSessionForCancelTest(w, sleeper.Sleep)
+
+	err := sess.CancelInFlight()
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("CancelInFlight err = %v, want %v", err, wantErr)
+	}
+	if len(w.writes) != 0 {
+		t.Errorf("got %d successful writes, want 0; writes=%+v", len(w.writes), w.writes)
+	}
+	if len(sleeper.durations) != 0 {
+		t.Errorf("got %d sleeps after failed first write, want 0", len(sleeper.durations))
+	}
+}
+
+// TestCancelInFlight_ClosedSession returns ErrSessionClosed without
+// touching the writer or the sleeper — so a "stop" pressed against a
+// torn-down session is a cheap no-op, not a panic.
+func TestCancelInFlight_ClosedSession(t *testing.T) {
+	w := newTimestampedWriter()
+	sleeper := &recordedSleeper{}
+	sess := newPTYSessionForCancelTest(w, sleeper.Sleep)
+	sess.closed = true
+
+	err := sess.CancelInFlight()
+	if !errors.Is(err, ErrSessionClosed) {
+		t.Fatalf("CancelInFlight on closed session: got %v, want ErrSessionClosed", err)
+	}
+	if len(w.writes) != 0 {
+		t.Errorf("closed session still wrote %d times", len(w.writes))
+	}
+	if len(sleeper.durations) != 0 {
+		t.Errorf("closed session still slept %d times", len(sleeper.durations))
+	}
+}


### PR DESCRIPTION
## Summary

PR #37 review flagged a deferred follow-up: `internal/backend/claude/pty.go::CancelInFlight` was writing `[0x15, 0x1b]` (Ctrl+U then Esc) back-to-back with no inter-keystroke sleep. Spec §5.3 + Appendix B / F-07 — both informed by PoC-1 — mandate the opposite order **and** explicit pacing: `Esc (0x1b)` → 500–800ms → `Ctrl+U (0x15)` → 200–500ms → optional new prompt + `\r`. Esc has to go first so cc actually aborts the in-flight turn; cc then re-renders the input box with the original prompt restored, which is what Ctrl+U clears. Reversed-and-tight, the line-clear races a still-running generation and we end up with neither a clean cancel nor a clean input buffer.

I treated the spec as canonical: nothing in `poc/go-pty-cc/` documents a reason for the back-to-back form, so the most plausible read is that PR #37's CancelInFlight was hand-coded from memory and never re-checked against §5.3. The fix lifts the two delays into named constants (`CancelEscToCtrlUDelay = 500ms`, `CancelCtrlUSettleDelay = 200ms`) sitting at the top of `pty.go` with a §5.3 doc-comment so a future drive-by edit can't silently regress, picks the lower bound of each spec window for snappier UX, and adds a `pty_cancel_test.go` with a timestamped fake `io.Writer` + recorded sleeper to lock in (a) byte order, (b) sleep durations land inside the spec windows, (c) actual elapsed time between writes is non-zero, (d) failed Esc skips Ctrl+U so we never strand a stray line-clear on the user's PTY, (e) closed-session early-out doesn't touch the writer or sleeper.

### What changed

| File | Δ |
|---|---|
| `internal/backend/claude/pty.go` | named delay/byte constants + rewritten `CancelInFlight` (Esc → sleep → Ctrl+U → sleep) + test seam fields (`cancelWriter`, `cancelSleep`) |
| `internal/backend/claude/pty_cancel_test.go` | new — 3 cases via `timestampedWriter` + `recordedSleeper` |

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `gofmt -l internal/backend/claude/pty.go internal/backend/claude/pty_cancel_test.go` clean
- [x] `go test -race -count=10 -short ./internal/backend/claude/...` → `ok 8.633s`
- [x] `go test -race -count=1 ./internal/backend/claude/...` (full, includes `TestSession_Recover_RealClaude_Scenario5`) → `ok 56.829s`
- [x] `go test -race -count=10 -run TestCancelInFlight ./internal/backend/claude/...` → all 3 cases pass
- [x] Spec windows pinned in test (500–800ms / 200–500ms) — bumping the constants outside the F-07 range will fail review here.

## Branch hygiene

Branch `pf2.cancel-seq-spec` is rebased onto current `origin/main` (`caf287f`); single linear commit on top, no merges from sibling branches. No dependency on unmerged work.

Refs Epic #3 follow-up from PR #37 review.