### PR TITLE
feat(lock): persist TakeoverEvents to JSONL audit log per §11.D

### DIFF
--- a/cmd/tether/main.go
+++ b/cmd/tether/main.go
@@ -66,6 +66,11 @@ func runDaemon(args []string) int {
 		"cc projects directory to tail (default $HOME/.claude/projects)")
 	attachSocket := fs.String("attach-socket", "",
 		"path for the local attach Unix socket (default $HOME/.tether/attach.sock)")
+	lockAuditLog := fs.String("lock-audit-log", "",
+		"override path for the lock audit log JSONL "+
+			"(default $HOME/.tether/users/default/sessions/default/lock.log; spec §11.D)")
+	noAudit := fs.Bool("no-audit", false,
+		"disable persistent lock audit log (in-memory History only)")
 	if err := fs.Parse(args); err != nil {
 		return 2
 	}
@@ -88,6 +93,8 @@ func runDaemon(args []string) int {
 		Stderr:           os.Stderr,
 		ProjectsDir:      *projectsDir,
 		AttachSocketPath: *attachSocket,
+		LockAuditLogPath: *lockAuditLog,
+		DisableLockAudit: *noAudit,
 	}
 	if err := daemon.Run(ctx, cfg); err != nil {
 		fmt.Fprintf(os.Stderr, "tether daemon: %v\n", err)

--- a/internal/agent/integration_test.go
+++ b/internal/agent/integration_test.go
@@ -48,6 +48,7 @@ func TestIntegration_DaemonAttachJSONLToEnvelopes(t *testing.T) {
 		done <- daemon.Run(ctx, daemon.Config{
 			ProjectsDir:      projectsDir,
 			AttachSocketPath: attachSocket,
+			LockAuditLogPath: filepath.Join(tmp, "lock.log"),
 		})
 	}()
 
@@ -220,6 +221,7 @@ func TestIntegration_AttachLockGate(t *testing.T) {
 	cfg := daemon.Config{
 		ProjectsDir:      projectsDir,
 		AttachSocketPath: attachSocket,
+		LockAuditLogPath: filepath.Join(tmp, "lock.log"),
 		InputSink: func(sid string, data []byte) error {
 			sinkCh <- sinkEvent{sid: sid, data: append([]byte(nil), data...)}
 			return nil
@@ -313,6 +315,19 @@ func TestIntegration_AttachLockGate(t *testing.T) {
 		t.Errorf("sink received unexpected event from B: %q", string(ev.data))
 	case <-time.After(150 * time.Millisecond):
 		// good — gated.
+	}
+
+	// Spec §11.D audit log: A's implicit acquire MUST have persisted to
+	// the configured lock.log. We don't assert exact line content (the
+	// JSONL schema is covered in lock package tests); just that the
+	// file exists and is non-empty by the time B is denied.
+	auditPath := filepath.Join(tmp, "lock.log")
+	if st, statErr := os.Stat(auditPath); statErr != nil {
+		t.Errorf("expected lock audit log at %q after acquire: %v", auditPath, statErr)
+	} else if st.Size() == 0 {
+		t.Errorf("lock audit log %q is empty after acquire", auditPath)
+	} else if mode := st.Mode().Perm(); mode != 0o600 {
+		t.Errorf("lock audit log mode: got %o want 0600", mode)
 	}
 
 	cancel()

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -65,6 +65,35 @@ type Config struct {
 	// of the real daemon/client. nil → use defaultSubsystems with
 	// the components built from this Config.
 	SubsystemFactories []SubsystemFactory
+
+	// LockAuditLogPath is the path the lock state-machine's JSONL
+	// audit log is written to (spec §11.D "audit log" row). Empty
+	// resolves to
+	// `$HOME/.tether/users/default/sessions/<sid>/lock.log`, where
+	// `<sid>` is derived from LockSessionID (or "default" if also
+	// empty — v0.1 has no real per-session lock yet).
+	//
+	// Tests override to keep filesystem state hermetic.
+	LockAuditLogPath string
+
+	// LockSessionID names the session bucket the lock audit log
+	// lives under. v0.1 has a single process-wide lock (the daemon
+	// hasn't been split per-session yet — see follow-up §11.D), so
+	// this is effectively a stable label. Empty → "default".
+	LockSessionID string
+
+	// LockUser names the user bucket. Empty → "default" — v0.1 is
+	// single-user (xiaokang.w@gmicloud.ai per env), and the spec
+	// path under `~/.tether/users/default/...` is the documented
+	// placeholder. Multi-user is a follow-up tracked in §11.D.
+	LockUser string
+
+	// DisableLockAudit disables persistent audit-log writing even
+	// when LockAuditLogPath could be resolved. Useful for `tether
+	// daemon --no-audit` scenarios + tests that don't want the
+	// fixture filesystem touched. Default false (audit log is on
+	// for production).
+	DisableLockAudit bool
 }
 
 // SubsystemFactory is a deferred constructor for a Subsystem. The
@@ -138,7 +167,33 @@ func Run(ctx context.Context, cfg Config) error {
 			return fmt.Errorf("daemon: envelope emitter: %w", err)
 		}
 
-		lockSM := lock.New()
+		// Resolve audit-log path per §11.D and wire the JSONL sink.
+		// On any resolution / open error we degrade to in-memory-
+		// only History and surface a verbose log line — the daemon
+		// MUST stay up even if the audit-log path is unwritable.
+		lockOpts := []lock.Option{}
+		var lockSink *lock.JSONLLogSink
+		if !cfg.DisableLockAudit {
+			auditPath, perr := resolveLockAuditPath(cfg)
+			if perr != nil {
+				logf("[daemon] lock audit log: resolve path: %v (continuing in-memory only)", perr)
+			} else {
+				sink, serr := lock.NewJSONLLogSink(auditPath)
+				if serr != nil {
+					logf("[daemon] lock audit log: open %q: %v (continuing in-memory only)", auditPath, serr)
+				} else {
+					lockSink = sink
+					lockOpts = append(lockOpts,
+						lock.WithLogSink(sink),
+						lock.WithSinkErrorHandler(func(err error) {
+							logf("[daemon] lock audit log: append: %v", err)
+						}),
+					)
+					logf("[daemon] lock audit log → %s", auditPath)
+				}
+			}
+		}
+		lockSM := lock.New(lockOpts...)
 
 		attach, err := agent.NewAttachServer(agent.AttachServerConfig{
 			SocketPath: socketPath,
@@ -164,9 +219,13 @@ func Run(ctx context.Context, cfg Config) error {
 		factories = realSubsystems(socketPath, emitter, lockSM, cfg.InputSink, logf)
 		// emitter lives for the daemon's full lifetime; clean up
 		// on Run exit. clientSubsystem owns its per-run AttachServer
-		// and closes it inside Run's defer.
+		// and closes it inside Run's defer. lockSink (if any) flushes
+		// + releases its file handle here.
 		defer func() {
 			_ = emitter.Close()
+			if lockSink != nil {
+				_ = lockSink.Close()
+			}
 		}()
 	}
 
@@ -174,6 +233,33 @@ func Run(ctx context.Context, cfg Config) error {
 		wd.Supervise(f())
 	}
 	return wd.Run(ctx)
+}
+
+// resolveLockAuditPath maps daemon Config to the spec §11.D audit log
+// path:
+//
+//	~/.tether/users/<user>/sessions/<sid>/lock.log
+//
+// Empty `LockAuditLogPath` → resolves $HOME and uses the default
+// layout. Empty user/sid default to "default" (v0.1 is single-user,
+// single-session-bucket; multi-tenant is a §11.D follow-up).
+func resolveLockAuditPath(cfg Config) (string, error) {
+	if cfg.LockAuditLogPath != "" {
+		return cfg.LockAuditLogPath, nil
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("resolve $HOME: %w", err)
+	}
+	user := cfg.LockUser
+	if user == "" {
+		user = "default"
+	}
+	sid := cfg.LockSessionID
+	if sid == "" {
+		sid = "default"
+	}
+	return filepath.Join(home, ".tether", "users", user, "sessions", sid, "lock.log"), nil
 }
 
 // realSubsystems assembles the production daemon + client subsystems.

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -37,6 +37,7 @@ func TestRun_StartsAndDrainsOnCancel(t *testing.T) {
 		Stderr:           &stderr,
 		ProjectsDir:      projectsDir,
 		AttachSocketPath: attachSocket,
+		LockAuditLogPath: filepath.Join(tmp, "lock.log"),
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -147,6 +148,7 @@ func TestRun_RealComposition_SocketAcceptsAttach(t *testing.T) {
 		Verbose:          false, // quiet — assertion is on socket behavior
 		ProjectsDir:      projectsDir,
 		AttachSocketPath: attachSocket,
+		LockAuditLogPath: filepath.Join(tmp, "lock.log"),
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())

--- a/internal/lock/doc.go
+++ b/internal/lock/doc.go
@@ -31,11 +31,21 @@
 // Concurrency: Lock is safe for concurrent use. All mutating methods take
 // an internal mutex; History returns a defensive copy.
 //
+// Persistence (spec §11.D "audit log" row): callers wire a LogSink via
+// WithLogSink to persist every TakeoverEvent past process lifetime.
+// The package ships NewJSONLLogSink which implements the on-disk JSONL
+// format at `~/.tether/users/<user>/sessions/<sid>/lock.log` (path
+// resolution is the caller's responsibility). Sink Append errors are
+// best-effort — the in-memory state machine never blocks or rolls back
+// on a sink failure; callers can route the error via
+// WithSinkErrorHandler. v0.1 has no rotation (write forever); rotation
+// is a §11.D follow-up (operator-managed for now).
+//
 // Out-of-scope (deferred):
-//   - persisting the audit log to ~/.tether/.../lock.log (daemon's job)
 //   - mode switching RPC (separate from lock; only the current holder is
 //     allowed but that policy lives at the daemon RPC handler — this
 //     package exposes IsHolder so the handler can enforce it cleanly)
 //   - view-only attach / multi-holder fan-out (v0.1 not in scope per
 //     §11.D)
+//   - audit-log rotation/retention (none in v0.1; operator-managed)
 package lock

--- a/internal/lock/lock.go
+++ b/internal/lock/lock.go
@@ -91,6 +91,27 @@ var ErrNotHolder = errors.New("lock: caller is not current holder")
 // uses time.Now.
 type nowFunc func() time.Time
 
+// LogSink is the durable-audit-log seam. Lock calls Append on every
+// state change (acquire / release / takeover) so the caller can
+// persist the event past process lifetime. Production wires this to
+// NewJSONLLogSink; tests may use a recording fake; nil sink (default
+// constructor with no WithLogSink) means in-memory History only,
+// matching pre-§11.D-persistence behavior.
+//
+// Implementations MUST be safe for concurrent Append. Append is called
+// under the Lock's internal mutex, so a slow sink will serialize
+// state-machine progress — keep it cheap; spec §11.D anticipates low
+// volume (a handful of events per session).
+//
+// An Append error is logged via the sink-error callback (if any, see
+// JSONLLogSinkConfig) but does NOT roll back the state-machine
+// transition: the in-memory state is the source of truth for the
+// current session; the on-disk log is best-effort durability for
+// post-mortem audit.
+type LogSink interface {
+	Append(ev TakeoverEvent) error
+}
+
 // Lock is the per-session writer-lock state machine. It's safe for
 // concurrent use. Construct via New.
 //
@@ -106,6 +127,8 @@ type Lock struct {
 	autoReleaseWindow time.Duration
 	now               nowFunc
 	history           []TakeoverEvent
+	sink              LogSink
+	onSinkErr         func(error)
 }
 
 // Option configures Lock at construction time.
@@ -128,6 +151,33 @@ func WithClock(now func() time.Time) Option {
 		if now != nil {
 			l.now = now
 		}
+	}
+}
+
+// WithLogSink installs a durable LogSink. nil sink is silently ignored
+// (back-compat with tests + the in-memory-only constructor). The sink
+// receives one Append call per emitted TakeoverEvent, in event order.
+//
+// Append is called while the Lock's internal mutex is held — the sink
+// MUST NOT call back into the same Lock or it will deadlock. JSONL
+// file sinks (NewJSONLLogSink) only touch their own file lock, so
+// they're safe.
+func WithLogSink(sink LogSink) Option {
+	return func(l *Lock) {
+		if sink != nil {
+			l.sink = sink
+		}
+	}
+}
+
+// WithSinkErrorHandler installs a callback invoked when LogSink.Append
+// returns an error. Passing nil disables the callback (errors are
+// silently dropped). Production wires this to a logger; the lock state
+// machine never blocks or rolls back on sink errors — durability is
+// best-effort, the in-memory state is authoritative.
+func WithSinkErrorHandler(fn func(error)) Option {
+	return func(l *Lock) {
+		l.onSinkErr = fn
 	}
 }
 
@@ -297,12 +347,14 @@ func (l *Lock) Release(c ClientID) error {
 	prev := l.holder
 	l.holder = ClientID{}
 	l.lastWriteAt = time.Time{}
-	l.history = append(l.history, TakeoverEvent{
+	ev := TakeoverEvent{
 		At:         l.now(),
 		Reason:     ReleaseExplicit,
 		PrevHolder: prev,
 		NewHolder:  ClientID{},
-	})
+	}
+	l.history = append(l.history, ev)
+	l.emitLocked(ev)
 	return nil
 }
 
@@ -348,12 +400,14 @@ func (l *Lock) grantLocked(c ClientID, at time.Time, reason AcquireReason) {
 	prev := l.holder
 	l.holder = c
 	l.lastWriteAt = at
-	l.history = append(l.history, TakeoverEvent{
+	ev := TakeoverEvent{
 		At:         at,
 		Reason:     reason,
 		PrevHolder: prev,
 		NewHolder:  c,
-	})
+	}
+	l.history = append(l.history, ev)
+	l.emitLocked(ev)
 }
 
 // reapStaleLocked checks staleness of the current holder and releases if
@@ -368,11 +422,30 @@ func (l *Lock) reapStaleLocked() bool {
 	prev := l.holder
 	l.holder = ClientID{}
 	l.lastWriteAt = time.Time{}
-	l.history = append(l.history, TakeoverEvent{
+	ev := TakeoverEvent{
 		At:         l.now(),
 		Reason:     ReleaseAuto,
 		PrevHolder: prev,
 		NewHolder:  ClientID{},
-	})
+	}
+	l.history = append(l.history, ev)
+	l.emitLocked(ev)
 	return true
+}
+
+// emitLocked dispatches a freshly-recorded event to the configured
+// LogSink (if any). Caller MUST already hold l.mu. Errors are routed
+// to the sink-error handler (or dropped) — never bubble up.
+//
+// Synchronous on purpose: §11.D audit log is meant to be durable, so a
+// crash immediately after the in-memory transition should still find
+// the event on disk. The throughput cost is negligible (a few events
+// per session). If profiling later shows otherwise we can buffer.
+func (l *Lock) emitLocked(ev TakeoverEvent) {
+	if l.sink == nil {
+		return
+	}
+	if err := l.sink.Append(ev); err != nil && l.onSinkErr != nil {
+		l.onSinkErr(err)
+	}
 }

--- a/internal/lock/sink_jsonl.go
+++ b/internal/lock/sink_jsonl.go
@@ -1,0 +1,200 @@
+package lock
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+	"time"
+)
+
+// jsonlEvent is the on-disk shape of a TakeoverEvent. Decoupled from
+// TakeoverEvent struct so the wire schema is stable even if the Go
+// struct grows fields. RFC3339Nano timestamps so the lines are easy to
+// `jq -r '.at'`-grep without losing nanosecond ordering.
+//
+// Schema (one event per line):
+//
+//	{
+//	  "at":  "2026-05-06T01:23:45.678901234Z",
+//	  "reason": "first-byte" | "stale-takeover" | "force-takeover" |
+//	            "auto-release" | "release",
+//	  "prev_holder": {"kind": "...", "device_id": "..."} | null,
+//	  "new_holder":  {"kind": "...", "device_id": "..."} | null
+//	}
+//
+// Zero ClientID serializes as JSON null (matches in-memory "no
+// holder"). Schema is part of the §11.D audit-log contract — change
+// only with a coordinated reader bump.
+type jsonlEvent struct {
+	At         string         `json:"at"`
+	Reason     string         `json:"reason"`
+	PrevHolder *jsonlClientID `json:"prev_holder"`
+	NewHolder  *jsonlClientID `json:"new_holder"`
+}
+
+type jsonlClientID struct {
+	Kind     string `json:"kind"`
+	DeviceID string `json:"device_id"`
+}
+
+func toJSONLClient(c ClientID) *jsonlClientID {
+	if c.Kind == "" && c.DeviceID == "" {
+		return nil
+	}
+	return &jsonlClientID{Kind: c.Kind, DeviceID: c.DeviceID}
+}
+
+func fromJSONLClient(p *jsonlClientID) ClientID {
+	if p == nil {
+		return ClientID{}
+	}
+	return ClientID{Kind: p.Kind, DeviceID: p.DeviceID}
+}
+
+// EncodeTakeoverEvent renders ev as the canonical JSONL form (no
+// trailing newline). Exposed primarily for tests / external readers
+// that want to reproduce the on-disk shape without re-implementing
+// the schema.
+func EncodeTakeoverEvent(ev TakeoverEvent) ([]byte, error) {
+	row := jsonlEvent{
+		At:         ev.At.UTC().Format(time.RFC3339Nano),
+		Reason:     string(ev.Reason),
+		PrevHolder: toJSONLClient(ev.PrevHolder),
+		NewHolder:  toJSONLClient(ev.NewHolder),
+	}
+	return json.Marshal(row)
+}
+
+// DecodeTakeoverEvent parses a single JSONL line back into a
+// TakeoverEvent. The reverse of EncodeTakeoverEvent; used by tests
+// and any future audit-log reader.
+func DecodeTakeoverEvent(line []byte) (TakeoverEvent, error) {
+	var row jsonlEvent
+	if err := json.Unmarshal(line, &row); err != nil {
+		return TakeoverEvent{}, err
+	}
+	at, err := time.Parse(time.RFC3339Nano, row.At)
+	if err != nil {
+		return TakeoverEvent{}, fmt.Errorf("lock: parse 'at': %w", err)
+	}
+	return TakeoverEvent{
+		At:         at,
+		Reason:     AcquireReason(row.Reason),
+		PrevHolder: fromJSONLClient(row.PrevHolder),
+		NewHolder:  fromJSONLClient(row.NewHolder),
+	}, nil
+}
+
+// JSONLLogSink persists TakeoverEvents to an append-only JSONL file
+// per spec §11.D ("audit log" row): one JSON object per line, file
+// mode 0600, parent dirs 0700, fsync on every Append (small volume —
+// safety > throughput). Append is mutex-serialized so concurrent
+// goroutines won't tear each other's writes. Close releases the file
+// handle and is idempotent.
+//
+// Retention/rotation: v0.1 writes forever — no size cap, no rolling.
+// Operator concern (logrotate, manual prune) until spec §11.D adds a
+// rotation row. Tracked as a follow-up in the §11.D table.
+type JSONLLogSink struct {
+	path string
+
+	mu     sync.Mutex
+	f      *os.File
+	closed bool
+}
+
+// JSONLLogSinkConfig is reserved for future knobs (rotation, fsync
+// strategy). v0.1 takes only the path, but the constructor accepts a
+// config struct so growing it doesn't break callers.
+type JSONLLogSinkConfig struct {
+	// Path is the destination JSONL file. Parent dirs are created at
+	// 0700 if missing. Required; empty path returns an error.
+	Path string
+}
+
+// NewJSONLLogSink opens (or creates) a JSONL audit log at path. Parent
+// directories are created at 0700 if missing; the file itself is
+// O_APPEND|O_CREATE|O_WRONLY at 0600. Returns the live sink — caller
+// is responsible for Close on shutdown.
+//
+// Path is checked for emptiness only; the caller is expected to have
+// already resolved the §11.D layout
+// `~/.tether/users/<user>/sessions/<sid>/lock.log`.
+func NewJSONLLogSink(path string) (*JSONLLogSink, error) {
+	return NewJSONLLogSinkWithConfig(JSONLLogSinkConfig{Path: path})
+}
+
+// NewJSONLLogSinkWithConfig is the explicit-config form.
+func NewJSONLLogSinkWithConfig(cfg JSONLLogSinkConfig) (*JSONLLogSink, error) {
+	if cfg.Path == "" {
+		return nil, errors.New("lock: JSONLLogSink: empty path")
+	}
+	dir := filepath.Dir(cfg.Path)
+	if dir != "" {
+		if err := os.MkdirAll(dir, 0o700); err != nil {
+			return nil, fmt.Errorf("lock: mkdir %q: %w", dir, err)
+		}
+	}
+	f, err := os.OpenFile(cfg.Path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o600)
+	if err != nil {
+		return nil, fmt.Errorf("lock: open audit log %q: %w", cfg.Path, err)
+	}
+	// Tighten mode in case the file pre-existed with looser perms.
+	// Best-effort — a Chmod failure on Windows-style FS shouldn't
+	// kill the daemon.
+	_ = os.Chmod(cfg.Path, 0o600)
+	return &JSONLLogSink{path: cfg.Path, f: f}, nil
+}
+
+// Path returns the file path the sink writes to. Stable for the
+// lifetime of the sink.
+func (s *JSONLLogSink) Path() string { return s.path }
+
+// Append serializes ev as a single JSON line and fsyncs. Safe for
+// concurrent callers — internal mutex serializes writes so lines
+// never tear.
+func (s *JSONLLogSink) Append(ev TakeoverEvent) error {
+	row, err := EncodeTakeoverEvent(ev)
+	if err != nil {
+		return fmt.Errorf("lock: encode event: %w", err)
+	}
+	row = append(row, '\n')
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.closed || s.f == nil {
+		return errors.New("lock: JSONLLogSink already closed")
+	}
+	// Single write call — kernel-level append is atomic for writes
+	// smaller than PIPE_BUF on POSIX; our rows are well under that
+	// (<512 bytes). The mutex above is belt-and-braces for hosts
+	// with quirkier append semantics (NFS, Windows).
+	if _, err := s.f.Write(row); err != nil {
+		return fmt.Errorf("lock: append %q: %w", s.path, err)
+	}
+	if err := s.f.Sync(); err != nil {
+		return fmt.Errorf("lock: fsync %q: %w", s.path, err)
+	}
+	return nil
+}
+
+// Close releases the underlying file handle. Idempotent — calling
+// Close on an already-closed sink returns nil. Subsequent Append
+// calls return an error (no silent data loss).
+func (s *JSONLLogSink) Close() error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.closed {
+		return nil
+	}
+	s.closed = true
+	if s.f == nil {
+		return nil
+	}
+	err := s.f.Close()
+	s.f = nil
+	return err
+}

--- a/internal/lock/sink_jsonl_test.go
+++ b/internal/lock/sink_jsonl_test.go
@@ -1,0 +1,368 @@
+package lock
+
+import (
+	"bufio"
+	"errors"
+	"os"
+	"path/filepath"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// helper: read all JSONL lines from path.
+func readJSONL(t *testing.T, path string) []TakeoverEvent {
+	t.Helper()
+	f, err := os.Open(path)
+	if err != nil {
+		t.Fatalf("open audit log %q: %v", path, err)
+	}
+	defer func() { _ = f.Close() }()
+	var out []TakeoverEvent
+	sc := bufio.NewScanner(f)
+	// Each row is well under default 64 KB but pre-grow to be safe.
+	sc.Buffer(make([]byte, 0, 4096), 1<<20)
+	for sc.Scan() {
+		line := sc.Bytes()
+		if len(line) == 0 {
+			t.Fatalf("blank line in JSONL audit log — torn write?")
+		}
+		ev, err := DecodeTakeoverEvent(line)
+		if err != nil {
+			t.Fatalf("decode JSONL line %q: %v", line, err)
+		}
+		out = append(out, ev)
+	}
+	if err := sc.Err(); err != nil {
+		t.Fatalf("scan: %v", err)
+	}
+	return out
+}
+
+func TestJSONLLogSink_AppendBasic(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "users", "default", "sessions", "sess-x", "lock.log")
+	sink, err := NewJSONLLogSink(path)
+	if err != nil {
+		t.Fatalf("NewJSONLLogSink: %v", err)
+	}
+	t.Cleanup(func() { _ = sink.Close() })
+
+	const N = 10
+	base := time.Date(2026, 5, 6, 1, 2, 3, 0, time.UTC)
+	for i := 0; i < N; i++ {
+		ev := TakeoverEvent{
+			At:         base.Add(time.Duration(i) * time.Millisecond),
+			Reason:     AcquireFirstByte,
+			PrevHolder: ClientID{},
+			NewHolder:  ClientID{Kind: KindMobile, DeviceID: "d-" + string(rune('a'+i))},
+		}
+		if err := sink.Append(ev); err != nil {
+			t.Fatalf("Append #%d: %v", i, err)
+		}
+	}
+	got := readJSONL(t, path)
+	if len(got) != N {
+		t.Fatalf("audit log line count: got %d want %d", len(got), N)
+	}
+	// Timestamps monotonic (non-decreasing).
+	for i := 1; i < len(got); i++ {
+		if got[i].At.Before(got[i-1].At) {
+			t.Errorf("non-monotonic timestamps at %d: %v < %v", i, got[i].At, got[i-1].At)
+		}
+	}
+	// Round-trip: parsed events should decode to the same shape.
+	for i, ev := range got {
+		if ev.Reason != AcquireFirstByte {
+			t.Errorf("ev[%d].Reason: got %s want %s", i, ev.Reason, AcquireFirstByte)
+		}
+		if ev.NewHolder.Kind != KindMobile {
+			t.Errorf("ev[%d].NewHolder.Kind: got %q want %q", i, ev.NewHolder.Kind, KindMobile)
+		}
+		if !ev.PrevHolder.Equal(ClientID{}) && (ev.PrevHolder.Kind != "" || ev.PrevHolder.DeviceID != "") {
+			t.Errorf("ev[%d].PrevHolder should be zero ClientID: %v", i, ev.PrevHolder)
+		}
+	}
+}
+
+func TestJSONLLogSink_FileModeAndDirs(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "users", "default", "sessions", "sess-y", "lock.log")
+	sink, err := NewJSONLLogSink(path)
+	if err != nil {
+		t.Fatalf("NewJSONLLogSink: %v", err)
+	}
+	t.Cleanup(func() { _ = sink.Close() })
+
+	// File mode 0600.
+	st, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat %q: %v", path, err)
+	}
+	if mode := st.Mode().Perm(); mode != 0o600 {
+		t.Errorf("file mode: got %o want 0600", mode)
+	}
+	// Parent dirs 0700.
+	for _, d := range []string{
+		filepath.Dir(path),                  // sessions/sess-y
+		filepath.Dir(filepath.Dir(path)),    // sessions
+		filepath.Dir(filepath.Dir(filepath.Dir(path))), // users/default
+	} {
+		ds, err := os.Stat(d)
+		if err != nil {
+			t.Fatalf("stat dir %q: %v", d, err)
+		}
+		if mode := ds.Mode().Perm(); mode != 0o700 {
+			t.Errorf("dir %q mode: got %o want 0700", d, mode)
+		}
+	}
+}
+
+func TestJSONLLogSink_AppendOnly(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "lock.log")
+	// Pre-seed file with a "previous run" line.
+	if err := os.WriteFile(path, []byte(`{"prev":"line"}`+"\n"), 0o600); err != nil {
+		t.Fatalf("seed file: %v", err)
+	}
+	sink, err := NewJSONLLogSink(path)
+	if err != nil {
+		t.Fatalf("NewJSONLLogSink: %v", err)
+	}
+	t.Cleanup(func() { _ = sink.Close() })
+	if err := sink.Append(TakeoverEvent{
+		At:        time.Now().UTC(),
+		Reason:    ReleaseExplicit,
+		NewHolder: ClientID{},
+	}); err != nil {
+		t.Fatalf("Append: %v", err)
+	}
+	// First line must be the seed (no truncation).
+	b, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("readfile: %v", err)
+	}
+	if want := `{"prev":"line"}`; string(b[:len(want)]) != want {
+		t.Errorf("seed line truncated; got prefix %q want %q", string(b[:len(want)]), want)
+	}
+}
+
+func TestJSONLLogSink_ConcurrentAppendNoTearing(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "lock.log")
+	sink, err := NewJSONLLogSink(path)
+	if err != nil {
+		t.Fatalf("NewJSONLLogSink: %v", err)
+	}
+	t.Cleanup(func() { _ = sink.Close() })
+
+	const Workers = 16
+	const PerWorker = 32
+	var wg sync.WaitGroup
+	wg.Add(Workers)
+	var failures atomic.Int64
+	base := time.Date(2026, 5, 6, 0, 0, 0, 0, time.UTC)
+	for w := 0; w < Workers; w++ {
+		w := w
+		go func() {
+			defer wg.Done()
+			for i := 0; i < PerWorker; i++ {
+				ev := TakeoverEvent{
+					At:         base.Add(time.Duration(w*PerWorker+i) * time.Microsecond),
+					Reason:     AcquireForce,
+					PrevHolder: ClientID{},
+					NewHolder:  ClientID{Kind: KindTerminal, DeviceID: "w-" + idForN(w)},
+				}
+				if err := sink.Append(ev); err != nil {
+					failures.Add(1)
+					t.Errorf("Append: %v", err)
+				}
+			}
+		}()
+	}
+	wg.Wait()
+	if failures.Load() != 0 {
+		t.Fatalf("had %d Append failures", failures.Load())
+	}
+	got := readJSONL(t, path)
+	if want := Workers * PerWorker; len(got) != want {
+		t.Fatalf("line count: got %d want %d (concurrent torn writes?)", len(got), want)
+	}
+}
+
+func TestJSONLLogSink_CloseRejectsAppend(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "lock.log")
+	sink, err := NewJSONLLogSink(path)
+	if err != nil {
+		t.Fatalf("NewJSONLLogSink: %v", err)
+	}
+	if err := sink.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	if err := sink.Close(); err != nil {
+		t.Errorf("second Close should be idempotent, got %v", err)
+	}
+	err = sink.Append(TakeoverEvent{At: time.Now()})
+	if err == nil {
+		t.Errorf("Append on closed sink: got nil want error")
+	}
+}
+
+func TestJSONLLogSink_EmptyPathRejected(t *testing.T) {
+	if _, err := NewJSONLLogSink(""); err == nil {
+		t.Errorf("empty path: got nil want error")
+	}
+}
+
+// recordingSink is a test fake LogSink implementation — used to drive
+// the Lock-side wiring tests without touching the filesystem.
+type recordingSink struct {
+	mu      sync.Mutex
+	events  []TakeoverEvent
+	failOn  int // index >=0 → return ErrSink on the Nth (0-based) Append
+	calls   atomic.Int64
+}
+
+var errSinkInjected = errors.New("recordingSink: injected error")
+
+func (r *recordingSink) Append(ev TakeoverEvent) error {
+	n := int(r.calls.Add(1)) - 1
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.failOn >= 0 && r.failOn == n {
+		return errSinkInjected
+	}
+	r.events = append(r.events, ev)
+	return nil
+}
+
+func (r *recordingSink) snapshot() []TakeoverEvent {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	out := make([]TakeoverEvent, len(r.events))
+	copy(out, r.events)
+	return out
+}
+
+func TestLock_WithLogSink_ReceivesAllStateChanges(t *testing.T) {
+	rec := &recordingSink{failOn: -1}
+	clk := newFakeClock(time.Date(2026, 5, 6, 0, 0, 0, 0, time.UTC))
+	l := New(WithClock(clk.Now), WithLogSink(rec))
+
+	if err := l.TryAcquire(mobileA); err != nil {
+		t.Fatalf("TryAcquire: %v", err)
+	}
+	if err := l.ForceTakeover(terminalA); err != nil {
+		t.Fatalf("ForceTakeover: %v", err)
+	}
+	if err := l.Release(terminalA); err != nil {
+		t.Fatalf("Release: %v", err)
+	}
+
+	// Now drive an auto-release path.
+	_ = l.TryAcquire(mobileB)
+	clk.Advance(61 * time.Second)
+	if !l.Sweep() {
+		t.Fatalf("Sweep should have fired")
+	}
+
+	got := rec.snapshot()
+	wantReasons := []AcquireReason{
+		AcquireFirstByte,
+		AcquireForce,
+		ReleaseExplicit,
+		AcquireFirstByte, // mobileB took over (was unheld after Release)
+		ReleaseAuto,
+	}
+	if len(got) != len(wantReasons) {
+		t.Fatalf("sink received %d events, want %d (%v)", len(got), len(wantReasons), got)
+	}
+	for i, want := range wantReasons {
+		if got[i].Reason != want {
+			t.Errorf("event[%d].Reason: got %s want %s", i, got[i].Reason, want)
+		}
+	}
+	// The lock's own History must match (sink is a side channel,
+	// not a replacement).
+	if hist := l.History(); len(hist) != len(got) {
+		t.Errorf("History/sink length mismatch: %d vs %d", len(hist), len(got))
+	}
+}
+
+func TestLock_WithLogSink_ErrorRoutedToHandler(t *testing.T) {
+	rec := &recordingSink{failOn: 0}
+	var sinkErr error
+	var sinkErrMu sync.Mutex
+	l := New(WithLogSink(rec), WithSinkErrorHandler(func(err error) {
+		sinkErrMu.Lock()
+		defer sinkErrMu.Unlock()
+		sinkErr = err
+	}))
+	if err := l.TryAcquire(mobileA); err != nil {
+		t.Fatalf("TryAcquire (sink errors must NOT block state machine): %v", err)
+	}
+	sinkErrMu.Lock()
+	defer sinkErrMu.Unlock()
+	if !errors.Is(sinkErr, errSinkInjected) {
+		t.Errorf("sink-error handler: got %v want %v", sinkErr, errSinkInjected)
+	}
+	// State machine still progressed.
+	if h, held := l.Holder(); !held || !h.Equal(mobileA) {
+		t.Errorf("sink error must not roll back transition; got holder=%v held=%v", h, held)
+	}
+}
+
+func TestLock_NilSinkDefault(t *testing.T) {
+	// Back-compat: lock.New() with no WithLogSink must not panic on
+	// state changes (sink == nil branch).
+	l := New()
+	if err := l.TryAcquire(mobileA); err != nil {
+		t.Fatalf("nil sink TryAcquire: %v", err)
+	}
+	if err := l.Release(mobileA); err != nil {
+		t.Fatalf("nil sink Release: %v", err)
+	}
+}
+
+// TestLock_WithJSONLSink_EndToEnd is the on-disk integration test:
+// fire N events through a real Lock + JSONLLogSink and assert the
+// file contains exactly N parseable lines with monotonic timestamps.
+func TestLock_WithJSONLSink_EndToEnd(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "users", "default", "sessions", "sess-z", "lock.log")
+	sink, err := NewJSONLLogSink(path)
+	if err != nil {
+		t.Fatalf("NewJSONLLogSink: %v", err)
+	}
+	defer func() { _ = sink.Close() }()
+
+	clk := newFakeClock(time.Date(2026, 5, 6, 0, 0, 0, 0, time.UTC))
+	l := New(WithClock(clk.Now), WithLogSink(sink))
+
+	const N = 8
+	for i := 0; i < N; i++ {
+		clk.Advance(time.Millisecond)
+		c := ClientID{Kind: KindTerminal, DeviceID: "term-" + idForN(i)}
+		if err := l.ForceTakeover(c); err != nil {
+			t.Fatalf("ForceTakeover #%d: %v", i, err)
+		}
+	}
+	got := readJSONL(t, path)
+	if len(got) != N {
+		t.Fatalf("audit log lines: got %d want %d", len(got), N)
+	}
+	// Monotonic timestamps.
+	for i := 1; i < len(got); i++ {
+		if got[i].At.Before(got[i-1].At) {
+			t.Errorf("non-monotonic at i=%d: %v < %v", i, got[i].At, got[i-1].At)
+		}
+	}
+	// Each entry parses as TakeoverEvent with reason=force.
+	for i, ev := range got {
+		if ev.Reason != AcquireForce {
+			t.Errorf("event[%d].Reason: got %s want %s", i, ev.Reason, AcquireForce)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- Spec §11.D ("audit log" row) requires every lock state change to
  persist to `~/.tether/users/<user>/sessions/<sid>/lock.log` so the
  audit trail survives daemon restarts. Pre-#37 the package only kept
  an in-memory ring buffer.
- Adds `lock.LogSink` interface + `WithLogSink` / `WithSinkErrorHandler`
  options (nil sink → in-memory only, fully back-compat) and ships
  `NewJSONLLogSink` — O_APPEND|O_CREATE|O_WRONLY at 0600, parents 0700,
  fsync per Append, mutex-serialized so concurrent goroutines never
  tear lines.
- Daemon wires the sink in `Run` against the spec path; new
  `Config.LockAuditLogPath` / `LockUser` / `LockSessionID` /
  `DisableLockAudit` knobs and `tether daemon --lock-audit-log` /
  `--no-audit` CLI flags. Sink open failure degrades to in-memory
  History — daemon stays up.

## Choices

- **Path layout**: `$HOME/.tether/users/default/sessions/default/lock.log`.
  v0.1 has no per-user concept (`<user>` defaults to `"default"`) and
  the daemon owns one process-wide lock (no per-session split yet —
  `<sid>` defaults to `"default"`). Path scaffold matches §11.D so the
  multi-tenant / per-session follow-ups only need to vary the user/sid
  fields.
- **Opt-in or always-on**: always-on for production (daemon's
  `Run()` resolves and opens the sink unless `DisableLockAudit` is
  set). Tests must override `LockAuditLogPath` to a tempdir or set
  `DisableLockAudit=true` to keep the host filesystem hermetic — the
  three existing daemon/agent integration tests were updated.
- **Rotation/retention**: none in v0.1. Writes forever; operator-
  managed (logrotate). Tracked as a §11.D follow-up.
- **Sink semantics**: errors do NOT roll back the in-memory state
  machine — durability is best-effort, in-memory state is the source of
  truth. Errors route to the optional handler (daemon logs verbose).
  Append is synchronous under the lock's mutex (volume is a handful
  of events per session; throughput cost is negligible).

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test -race -count=10 ./internal/lock/...` clean (60s)
- [x] `go test -race ./internal/daemon/... ./internal/agent/...` clean
- [x] Unit: N events → N parseable lines, monotonic timestamps, file
      mode 0600, parent dirs 0700, append-only preserves pre-existing
      content, Close idempotent + rejects further Appends.
- [x] Race: 16 × 32 concurrent Appends → 512 lines, no torn writes.
- [x] Integration: `TestIntegration_AttachLockGate` now also asserts
      the on-disk lock.log exists + non-empty + 0600 after the rw
      client's implicit acquire.

## Notes / surprises about the existing lock package

- The lock package is already passive (no goroutines) and emits
  TakeoverEvents from exactly three sites: `grantLocked` (covers all
  three acquire paths), `Release`, and `reapStaleLocked` — the wiring
  was clean: one helper `emitLocked(ev)` after each `history = append`
  call. No state-machine refactor needed.
- The Lock's mutex is held during `Append`, so a slow sink would
  serialize state-machine progress. Documented in the LogSink doc
  comment; revisit if profiling shows the synchronous fsync becoming
  a bottleneck (it shouldn't — handful of events per session).
- A pre-existing flaky test in `internal/backend/claude/stderr_cap_test.go`
  surfaces under `-race` (different test name fails on different runs;
  reproduces on clean `origin/main` too) — unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)