### PR TITLE
feat(agent): tool-authorization broker — PreToolUse → UI prompt → decision

### DIFF
--- a/internal/agent/attach_socket.go
+++ b/internal/agent/attach_socket.go
@@ -116,6 +116,15 @@ type AttachServerConfig struct {
 	// message).
 	InputSink func(sessionID string, data []byte) error
 
+	// AuthBroker, when non-nil, intercepts rw-mode input frames whose
+	// payload parses as an auth.tool-decision JSON envelope and routes
+	// them to the broker instead of the PTY InputSink. All other input
+	// frames are passed through unchanged. Optional — leaving nil
+	// disables tool-authorization decisions over the attach socket
+	// (the PreToolUse handler then either has no UI surface or uses
+	// some other transport; v0.1 wires it here only).
+	AuthBroker *AuthBroker
+
 	// OnError surfaces accept-loop / per-conn errors to the daemon
 	// log. Optional.
 	OnError func(err error)
@@ -424,6 +433,24 @@ func (s *AttachServer) readInputs(_ context.Context, conn *attachConn, br *bufio
 			return err
 		}
 
+		// Auth decision frames are control plane — intercept BEFORE the
+		// lock check so a UI tab that doesn't hold the writer lock can
+		// still answer "may I run this tool?" prompts. The decision
+		// router is keyed by requestId so cross-tab traffic is fine.
+		if s.cfg.AuthBroker != nil && looksLikeAuthDecisionFrame(buf) {
+			var frame AuthDecisionFrame
+			if err := json.Unmarshal(buf, &frame); err == nil &&
+				frame.Type == KindAuthToolDecision {
+				if subErr := s.cfg.AuthBroker.SubmitDecision(frame); subErr != nil {
+					s.reportError(fmt.Errorf("attach: auth decision: %w", subErr))
+				}
+				continue
+			}
+			// JSON-shaped but not a valid decision frame — fall through
+			// to PTY input so we don't accidentally swallow payloads
+			// that legitimately start with '{'.
+		}
+
 		// TryAcquire — first byte from this client wins if lock is
 		// free; touches forward the auto-release timer otherwise.
 		if err := s.cfg.Lock.TryAcquire(conn.client); err != nil {
@@ -507,6 +534,30 @@ func WriteInputFrame(w io.Writer, payload []byte) error {
 // ErrFrameTooLarge is returned by ReadFrame when the length prefix
 // exceeds the 1MB safety cap.
 var ErrFrameTooLarge = errors.New("agent: attach frame > 1MB")
+
+// looksLikeAuthDecisionFrame is a fast pre-filter that avoids json.Unmarshal
+// cost on every PTY input keystroke. We only attempt JSON parsing when the
+// payload looks like a top-level JSON object that contains the literal
+// "auth.tool-decision". A malicious user typing the substring into a PTY
+// would still hit the unmarshal path but fall through (Type field check)
+// without consequence.
+func looksLikeAuthDecisionFrame(buf []byte) bool {
+	if len(buf) < 2 || buf[0] != '{' {
+		return false
+	}
+	// Cheap substring scan; bounded — buf is ≤1MB by frame cap.
+	const needle = "\"auth.tool-decision\""
+	if len(buf) < len(needle) {
+		return false
+	}
+	// Tiny inlined search to avoid pulling in `bytes` here for one match.
+	for i := 0; i+len(needle) <= len(buf); i++ {
+		if buf[i] == '"' && string(buf[i:i+len(needle)]) == needle {
+			return true
+		}
+	}
+	return false
+}
 
 // ErrHeaderTooLarge is returned by serveConn when the newline-
 // terminated header read exceeds MaxHeaderBytes.

--- a/internal/agent/auth.go
+++ b/internal/agent/auth.go
@@ -1,0 +1,306 @@
+// Package agent — tool-authorization broker (PreToolUse → UI prompt → decision).
+//
+// Wire shape
+// ----------
+// Two new LocalEnvelope kinds carry the round-trip:
+//
+//   • KindAuthToolRequest  ("auth.tool-request")  daemon → UI
+//   • KindAuthToolDecision ("auth.tool-decision") UI    → daemon (input frame)
+//
+// DO NOT rename without updating tether-app/src/components/AuthPrompt.tsx
+// and tether-app/src/transport/auth.ts — the field names below are pinned
+// across both repos. Wire shape is byte-identical on Go and TS sides.
+//
+// Request envelope (daemon → UI):
+//   LocalEnvelope{
+//     Kind:      "auth.tool-request",
+//     SessionID: "<cc session id>",
+//     PlaintextMetadata: {
+//       "requestId": "<ULID-ish unique id, daemon-issued>",
+//       "toolName":  "Bash",
+//       "toolInput": <raw json passthrough from cc PreToolUse>,
+//       "summary":   "<short human-readable args summary, ≤120 chars>"
+//     }
+//   }
+//
+// Decision frame (UI → daemon, length-prefixed JSON on the rw input
+// direction of the attach socket):
+//   {
+//     "type":       "auth.tool-decision",
+//     "requestId":  "<echoes request>",
+//     "decision":   "allow-once" | "allow-always" | "deny-once" | "deny-always"
+//   }
+//
+// "always" is per-(sessionId, toolName) and lives in-process only — restart
+// the daemon and the user is asked again. Persistence is a deliberate
+// follow-up: v0.1 keeps the cache in RAM so misclicks don't survive a
+// daemon crash.
+//
+// Timeout: Ask() blocks up to 60s by default (AuthBroker.Timeout).
+// On timeout the broker logs and returns deny — fail-closed.
+
+package agent
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"sync"
+	"time"
+)
+
+// LocalEnvelope kind tags reserved for tool-authorization. Keeping these
+// as exported constants so the attach socket / UI bridge can dispatch
+// without stringly-typed magic.
+//
+// DO NOT rename without updating tether-app/src/components/AuthPrompt.tsx
+// (frame.body.kind switch) — these strings are the cross-repo contract.
+const (
+	KindAuthToolRequest  = "auth.tool-request"
+	KindAuthToolDecision = "auth.tool-decision"
+)
+
+// AuthDecision is the four-valued enum the UI returns. The strings are
+// pinned to the wire — if you rename, update the TS side in lock-step.
+type AuthDecision string
+
+const (
+	AuthDecisionAllowOnce   AuthDecision = "allow-once"
+	AuthDecisionAllowAlways AuthDecision = "allow-always"
+	AuthDecisionDenyOnce    AuthDecision = "deny-once"
+	AuthDecisionDenyAlways  AuthDecision = "deny-always"
+)
+
+// IsAllow returns true for both single-shot and remembered allow decisions.
+func (d AuthDecision) IsAllow() bool {
+	return d == AuthDecisionAllowOnce || d == AuthDecisionAllowAlways
+}
+
+// IsAlways returns true for sticky decisions ("always" prefix). Used by
+// the broker to populate the remember-cache.
+func (d AuthDecision) IsAlways() bool {
+	return d == AuthDecisionAllowAlways || d == AuthDecisionDenyAlways
+}
+
+// AuthDecisionFrame is the wire shape the UI sends back over the rw
+// input direction of the attach socket. Field tags are pinned — DO NOT
+// rename without updating tether-app/src/transport/auth.ts.
+type AuthDecisionFrame struct {
+	Type      string       `json:"type"`
+	RequestID string       `json:"requestId"`
+	Decision  AuthDecision `json:"decision"`
+}
+
+// DefaultAuthTimeout caps the wait for a decision. Chosen at 60s as the
+// upper bound for "user is at the keyboard but not actively watching" —
+// long enough that a context-switch doesn't cause spurious denials,
+// short enough that a forgotten prompt doesn't pin the cc tool call
+// indefinitely. Tunable via AuthBroker.Timeout.
+const DefaultAuthTimeout = 60 * time.Second
+
+// AuthBroker mediates PreToolUse → UI prompt → decision. One broker
+// per daemon instance.
+//
+// Concurrency: all methods are safe for concurrent invocation. Ask()
+// from multiple cc tool calls in parallel each get their own requestId
+// and channel. SubmitDecision() routes by requestId.
+type AuthBroker struct {
+	// Emitter is how the broker pushes the request envelope to attached
+	// UI clients. Required.
+	Emitter *EnvelopeEmitter
+
+	// Timeout overrides DefaultAuthTimeout. Zero = use default.
+	Timeout time.Duration
+
+	// OnDecision is called once per Ask() resolution (allow/deny/timeout)
+	// for daemon-side audit logging. Optional.
+	OnDecision func(sid, toolName string, decision AuthDecision, fromCache bool)
+
+	mu       sync.Mutex
+	pending  map[string]*pendingAuth         // requestId → channel
+	remember map[rememberKey]AuthDecision    // (sid, toolName) → "always" decision
+	closed   bool
+}
+
+type pendingAuth struct {
+	sid      string
+	toolName string
+	ch       chan AuthDecision
+}
+
+type rememberKey struct {
+	sid  string
+	tool string
+}
+
+// ErrAuthBrokerClosed is returned by Ask after Close has run.
+var ErrAuthBrokerClosed = errors.New("agent: auth broker closed")
+
+// NewAuthBroker constructs a broker. Emitter is required.
+func NewAuthBroker(em *EnvelopeEmitter) (*AuthBroker, error) {
+	if em == nil {
+		return nil, errors.New("agent: NewAuthBroker requires an Emitter")
+	}
+	return &AuthBroker{
+		Emitter:  em,
+		pending:  make(map[string]*pendingAuth),
+		remember: make(map[rememberKey]AuthDecision),
+	}, nil
+}
+
+// Ask emits a request envelope to UI clients and blocks for a decision
+// up to the configured timeout. Returns the decision; on timeout returns
+// AuthDecisionDenyOnce + a non-nil error so the caller sees the wall-
+// clock failure (fail-closed). ctx cancellation also returns deny+ctx.Err.
+//
+// toolInput is forwarded verbatim as plaintext metadata; summary is the
+// short string surfaced in the UI ("≤120 chars" is a soft target, the
+// broker doesn't truncate).
+func (b *AuthBroker) Ask(ctx context.Context, sid, toolName string, toolInput json.RawMessage, summary string) (AuthDecision, error) {
+	if sid == "" || toolName == "" {
+		return AuthDecisionDenyOnce, errors.New("agent: AuthBroker.Ask requires sid + toolName")
+	}
+
+	b.mu.Lock()
+	if b.closed {
+		b.mu.Unlock()
+		return AuthDecisionDenyOnce, ErrAuthBrokerClosed
+	}
+	// Cache hit — short-circuit before bothering the UI.
+	if cached, ok := b.remember[rememberKey{sid, toolName}]; ok {
+		b.mu.Unlock()
+		if b.OnDecision != nil {
+			b.OnDecision(sid, toolName, cached, true)
+		}
+		return cached, nil
+	}
+	rid := newRequestID()
+	pa := &pendingAuth{sid: sid, toolName: toolName, ch: make(chan AuthDecision, 1)}
+	b.pending[rid] = pa
+	b.mu.Unlock()
+
+	// Always clean up the pending entry on exit.
+	defer func() {
+		b.mu.Lock()
+		delete(b.pending, rid)
+		b.mu.Unlock()
+	}()
+
+	env := LocalEnvelope{
+		Kind:      KindAuthToolRequest,
+		SessionID: sid,
+		PlaintextMetadata: map[string]any{
+			"requestId": rid,
+			"toolName":  toolName,
+			"toolInput": toolInput,
+			"summary":   summary,
+		},
+	}
+	if err := b.Emitter.Inject(env); err != nil {
+		return AuthDecisionDenyOnce, fmt.Errorf("agent: broker inject: %w", err)
+	}
+
+	timeout := b.Timeout
+	if timeout <= 0 {
+		timeout = DefaultAuthTimeout
+	}
+	timer := time.NewTimer(timeout)
+	defer timer.Stop()
+
+	select {
+	case d := <-pa.ch:
+		if d.IsAlways() {
+			b.mu.Lock()
+			b.remember[rememberKey{sid, toolName}] = d
+			b.mu.Unlock()
+		}
+		if b.OnDecision != nil {
+			b.OnDecision(sid, toolName, d, false)
+		}
+		return d, nil
+	case <-timer.C:
+		if b.OnDecision != nil {
+			b.OnDecision(sid, toolName, AuthDecisionDenyOnce, false)
+		}
+		return AuthDecisionDenyOnce, fmt.Errorf("agent: auth decision timeout after %s", timeout)
+	case <-ctx.Done():
+		return AuthDecisionDenyOnce, ctx.Err()
+	}
+}
+
+// SubmitDecision is invoked by the attach socket reader when a decision
+// frame arrives from the UI. Returns nil on successful routing; non-nil
+// if the requestId is unknown (already timed out / never issued — the
+// caller should log + drop, not panic).
+func (b *AuthBroker) SubmitDecision(frame AuthDecisionFrame) error {
+	if frame.RequestID == "" {
+		return errors.New("agent: empty requestId in decision frame")
+	}
+	switch frame.Decision {
+	case AuthDecisionAllowOnce, AuthDecisionAllowAlways,
+		AuthDecisionDenyOnce, AuthDecisionDenyAlways:
+		// ok
+	default:
+		return fmt.Errorf("agent: unknown decision %q", frame.Decision)
+	}
+	b.mu.Lock()
+	pa, ok := b.pending[frame.RequestID]
+	b.mu.Unlock()
+	if !ok {
+		return fmt.Errorf("agent: no pending auth for requestId %q (timed out?)", frame.RequestID)
+	}
+	select {
+	case pa.ch <- frame.Decision:
+		return nil
+	default:
+		// Channel was already filled (duplicate decision). Idempotent —
+		// drop the second.
+		return nil
+	}
+}
+
+// ForgetRemembered drops a sticky "always" entry (if any) for
+// (sid, toolName). Useful for a future "revoke" UX; v0.1 has no caller
+// but it's the natural inverse and keeps the surface symmetric.
+func (b *AuthBroker) ForgetRemembered(sid, toolName string) {
+	b.mu.Lock()
+	delete(b.remember, rememberKey{sid, toolName})
+	b.mu.Unlock()
+}
+
+// Close fails any pending Ask() with ErrAuthBrokerClosed. Idempotent.
+func (b *AuthBroker) Close() {
+	b.mu.Lock()
+	if b.closed {
+		b.mu.Unlock()
+		return
+	}
+	b.closed = true
+	pendings := b.pending
+	b.pending = nil
+	b.mu.Unlock()
+	for _, pa := range pendings {
+		// Non-blocking send — Ask() will fall through to the timer/ctx
+		// path if the channel is already full. We use deny-once as the
+		// shutdown signal.
+		select {
+		case pa.ch <- AuthDecisionDenyOnce:
+		default:
+		}
+	}
+}
+
+func newRequestID() string {
+	var b [12]byte
+	if _, err := rand.Read(b[:]); err != nil {
+		// crypto/rand failure is essentially impossible on linux/darwin/win
+		// but if it does happen, fall back to a wall-clock id so Ask() can
+		// still proceed (the requestId only needs uniqueness within a
+		// daemon run, not unforgeability).
+		return fmt.Sprintf("auth-%d", time.Now().UnixNano())
+	}
+	return "auth-" + hex.EncodeToString(b[:])
+}

--- a/internal/agent/auth_handlers.go
+++ b/internal/agent/auth_handlers.go
@@ -1,0 +1,120 @@
+// Package agent — adapter that wires AuthBroker into cc.HookHandlers.
+//
+// The cc/hookserver expects a HookHandlers interface; the broker has
+// the broker-shaped Ask() API. This file translates cc PreToolUse JSON
+// payloads → broker Ask() calls and the resulting AuthDecision back
+// into the cc allow/deny string.
+
+package agent
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/piaobeizu/tether/internal/cc"
+)
+
+// BrokerHookHandlers implements cc.HookHandlers by delegating
+// PreToolUse to an AuthBroker. The other four hooks fall through to a
+// permissive observer (PostToolUse / SessionStart / Stop are pure
+// observers; UserPromptSubmit returns "allow" — v0.1 has no
+// user-prompt authz UX).
+//
+// Wrap with NewBrokerHookHandlers; pass to cc.NewHookServer.
+type BrokerHookHandlers struct {
+	Broker *AuthBroker
+}
+
+// NewBrokerHookHandlers returns a HookHandlers that uses broker for
+// PreToolUse decisions.
+func NewBrokerHookHandlers(b *AuthBroker) *BrokerHookHandlers {
+	return &BrokerHookHandlers{Broker: b}
+}
+
+// preToolUsePayload is the subset of cc's PreToolUse JSON we read. We
+// keep this internal — the daemon's seam invariant is "don't interpret
+// event content"; the only fields here are the ones we need to label
+// the UI prompt.
+type preToolUsePayload struct {
+	SessionID string          `json:"session_id"`
+	ToolName  string          `json:"tool_name"`
+	ToolInput json.RawMessage `json:"tool_input"`
+	Input     json.RawMessage `json:"input"` // older cc payload variant
+}
+
+// PreToolUse asks the broker; surfaces decision back to cc.
+func (h *BrokerHookHandlers) PreToolUse(ctx context.Context, payload json.RawMessage) (cc.HookResponse, error) {
+	if h.Broker == nil {
+		// Fail-closed: no broker means no UX surface to consult.
+		return cc.HookResponse{Decision: "deny", Reason: "tether: no auth broker wired"}, nil
+	}
+	var p preToolUsePayload
+	if err := json.Unmarshal(payload, &p); err != nil {
+		return cc.HookResponse{Decision: "deny", Reason: "tether: malformed PreToolUse payload"}, nil
+	}
+	if p.ToolName == "" {
+		return cc.HookResponse{Decision: "deny", Reason: "tether: PreToolUse missing tool_name"}, nil
+	}
+	input := p.ToolInput
+	if len(input) == 0 {
+		input = p.Input
+	}
+	summary := summarizeToolInput(p.ToolName, input)
+
+	d, err := h.Broker.Ask(ctx, p.SessionID, p.ToolName, input, summary)
+	if err != nil {
+		// Includes timeout + ctx cancel. Decision is already deny on
+		// these paths; surface the reason for cc UI.
+		return cc.HookResponse{Decision: "deny", Reason: fmt.Sprintf("tether: %s", err.Error())}, nil
+	}
+	if d.IsAllow() {
+		return cc.HookResponse{Decision: "allow", Reason: "tether: user authorized"}, nil
+	}
+	return cc.HookResponse{Decision: "deny", Reason: "tether: user denied"}, nil
+}
+
+// PostToolUse is a pure observer.
+func (*BrokerHookHandlers) PostToolUse(_ context.Context, _ json.RawMessage) error { return nil }
+
+// SessionStart is a pure observer.
+func (*BrokerHookHandlers) SessionStart(_ context.Context, _ json.RawMessage) error { return nil }
+
+// UserPromptSubmit currently allows everything. v0.1 has no user-prompt
+// authz; revisit when the spec adds one.
+func (*BrokerHookHandlers) UserPromptSubmit(_ context.Context, _ json.RawMessage) (cc.HookResponse, error) {
+	return cc.HookResponse{Decision: "allow"}, nil
+}
+
+// Stop is a pure observer.
+func (*BrokerHookHandlers) Stop(_ context.Context, _ json.RawMessage) error { return nil }
+
+// summarizeToolInput produces a short human-readable string for the UI
+// prompt. We do NOT try to be clever here — the UI gets the full raw
+// json in toolInput and can format however it wants. This is a best-
+// effort fallback for narrow displays.
+func summarizeToolInput(toolName string, input json.RawMessage) string {
+	const maxLen = 120
+	if len(input) == 0 {
+		return toolName
+	}
+	// Try to extract a few well-known fields for nicer summaries.
+	var m map[string]any
+	if err := json.Unmarshal(input, &m); err == nil {
+		for _, key := range []string{"command", "cmd", "file_path", "path", "url"} {
+			if v, ok := m[key]; ok {
+				s := fmt.Sprintf("%s: %v", toolName, v)
+				if len(s) > maxLen {
+					return s[:maxLen-1] + "…"
+				}
+				return s
+			}
+		}
+	}
+	// Fallback: raw json prefix.
+	s := fmt.Sprintf("%s %s", toolName, string(input))
+	if len(s) > maxLen {
+		return s[:maxLen-1] + "…"
+	}
+	return s
+}

--- a/internal/agent/auth_handlers_test.go
+++ b/internal/agent/auth_handlers_test.go
@@ -1,0 +1,109 @@
+package agent_test
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/piaobeizu/tether/internal/agent"
+)
+
+func TestBrokerHookHandlers_PreToolUse_Allow(t *testing.T) {
+	t.Parallel()
+	em := newTestEmitter(t)
+	br, _ := agent.NewAuthBroker(em)
+	t.Cleanup(br.Close)
+	br.Timeout = 2 * time.Second
+
+	envCh, cancel, _ := em.Subscribe("sid-h")
+	defer cancel()
+
+	// Auto-respond with allow-once when the request comes through.
+	go func() {
+		env := <-envCh
+		rid, _ := env.PlaintextMetadata["requestId"].(string)
+		// Verify the summary used a known field.
+		summary, _ := env.PlaintextMetadata["summary"].(string)
+		if !strings.Contains(summary, "Bash") || !strings.Contains(summary, "ls") {
+			t.Errorf("summary missing tool/cmd: %q", summary)
+		}
+		_ = br.SubmitDecision(agent.AuthDecisionFrame{
+			Type:      agent.KindAuthToolDecision,
+			RequestID: rid,
+			Decision:  agent.AuthDecisionAllowOnce,
+		})
+	}()
+
+	h := agent.NewBrokerHookHandlers(br)
+	payload := json.RawMessage(`{"session_id":"sid-h","tool_name":"Bash","tool_input":{"command":"ls"}}`)
+	resp, err := h.PreToolUse(t.Context(), payload)
+	if err != nil {
+		t.Fatalf("PreToolUse: %v", err)
+	}
+	if resp.Decision != "allow" {
+		t.Fatalf("decision: %q (want allow)", resp.Decision)
+	}
+}
+
+func TestBrokerHookHandlers_PreToolUse_Deny(t *testing.T) {
+	t.Parallel()
+	em := newTestEmitter(t)
+	br, _ := agent.NewAuthBroker(em)
+	t.Cleanup(br.Close)
+	br.Timeout = 2 * time.Second
+
+	envCh, cancel, _ := em.Subscribe("sid-d")
+	defer cancel()
+
+	go func() {
+		env := <-envCh
+		rid, _ := env.PlaintextMetadata["requestId"].(string)
+		_ = br.SubmitDecision(agent.AuthDecisionFrame{
+			Type:      agent.KindAuthToolDecision,
+			RequestID: rid,
+			Decision:  agent.AuthDecisionDenyOnce,
+		})
+	}()
+
+	h := agent.NewBrokerHookHandlers(br)
+	resp, _ := h.PreToolUse(t.Context(), json.RawMessage(`{"session_id":"sid-d","tool_name":"Bash"}`))
+	if resp.Decision != "deny" {
+		t.Fatalf("decision: %q (want deny)", resp.Decision)
+	}
+}
+
+func TestBrokerHookHandlers_PreToolUse_MalformedPayload(t *testing.T) {
+	t.Parallel()
+	em := newTestEmitter(t)
+	br, _ := agent.NewAuthBroker(em)
+	t.Cleanup(br.Close)
+
+	h := agent.NewBrokerHookHandlers(br)
+	resp, _ := h.PreToolUse(t.Context(), json.RawMessage(`not json`))
+	if resp.Decision != "deny" {
+		t.Fatalf("malformed payload should deny; got %q", resp.Decision)
+	}
+}
+
+func TestBrokerHookHandlers_PreToolUse_MissingToolName(t *testing.T) {
+	t.Parallel()
+	em := newTestEmitter(t)
+	br, _ := agent.NewAuthBroker(em)
+	t.Cleanup(br.Close)
+
+	h := agent.NewBrokerHookHandlers(br)
+	resp, _ := h.PreToolUse(t.Context(), json.RawMessage(`{"session_id":"x"}`))
+	if resp.Decision != "deny" {
+		t.Fatalf("missing tool_name should deny; got %q", resp.Decision)
+	}
+}
+
+func TestBrokerHookHandlers_PreToolUse_NoBroker(t *testing.T) {
+	t.Parallel()
+	h := &agent.BrokerHookHandlers{Broker: nil}
+	resp, _ := h.PreToolUse(t.Context(), json.RawMessage(`{"session_id":"x","tool_name":"Bash"}`))
+	if resp.Decision != "deny" {
+		t.Fatalf("nil broker should deny; got %q", resp.Decision)
+	}
+}

--- a/internal/agent/auth_test.go
+++ b/internal/agent/auth_test.go
@@ -1,0 +1,388 @@
+package agent_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/piaobeizu/tether/internal/agent"
+	"github.com/piaobeizu/tether/internal/lock"
+)
+
+// helper: build an emitter rooted at a tmp dir so the watcher init
+// doesn't pull in $HOME.
+func newTestEmitter(t *testing.T) *agent.EnvelopeEmitter {
+	t.Helper()
+	dir := t.TempDir()
+	em, err := agent.NewEnvelopeEmitter(t.Context(), agent.EmitterConfig{
+		ProjectsDir: dir,
+	})
+	if err != nil {
+		t.Fatalf("emitter: %v", err)
+	}
+	t.Cleanup(func() { _ = em.Close() })
+	return em
+}
+
+func TestAuthBroker_AllowOnce(t *testing.T) {
+	t.Parallel()
+	em := newTestEmitter(t)
+	br, err := agent.NewAuthBroker(em)
+	if err != nil {
+		t.Fatalf("broker: %v", err)
+	}
+	t.Cleanup(br.Close)
+
+	// Subscribe so Inject has somewhere to land.
+	envCh, cancel, err := em.Subscribe("sid-1")
+	if err != nil {
+		t.Fatalf("subscribe: %v", err)
+	}
+	defer cancel()
+
+	// Drive Ask in a goroutine; capture the requestId from the emitted
+	// envelope, then submit the decision.
+	type result struct {
+		d   agent.AuthDecision
+		err error
+	}
+	resCh := make(chan result, 1)
+	go func() {
+		d, err := br.Ask(t.Context(), "sid-1", "Bash", json.RawMessage(`{"cmd":"ls"}`), "Bash: ls")
+		resCh <- result{d, err}
+	}()
+
+	var rid string
+	select {
+	case env := <-envCh:
+		if env.Kind != agent.KindAuthToolRequest {
+			t.Fatalf("expected kind %q, got %q", agent.KindAuthToolRequest, env.Kind)
+		}
+		if env.SessionID != "sid-1" {
+			t.Fatalf("sid mismatch: %q", env.SessionID)
+		}
+		got, _ := env.PlaintextMetadata["requestId"].(string)
+		if got == "" {
+			t.Fatalf("missing requestId in envelope: %+v", env.PlaintextMetadata)
+		}
+		rid = got
+	case <-time.After(2 * time.Second):
+		t.Fatal("timeout waiting for request envelope")
+	}
+
+	if err := br.SubmitDecision(agent.AuthDecisionFrame{
+		Type:      agent.KindAuthToolDecision,
+		RequestID: rid,
+		Decision:  agent.AuthDecisionAllowOnce,
+	}); err != nil {
+		t.Fatalf("submit: %v", err)
+	}
+
+	select {
+	case r := <-resCh:
+		if r.err != nil {
+			t.Fatalf("Ask err: %v", r.err)
+		}
+		if r.d != agent.AuthDecisionAllowOnce {
+			t.Fatalf("decision: %v", r.d)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timeout waiting for Ask result")
+	}
+}
+
+func TestAuthBroker_RememberAlways(t *testing.T) {
+	t.Parallel()
+	em := newTestEmitter(t)
+	br, err := agent.NewAuthBroker(em)
+	if err != nil {
+		t.Fatalf("broker: %v", err)
+	}
+	t.Cleanup(br.Close)
+
+	envCh, cancel, _ := em.Subscribe("sid-2")
+	defer cancel()
+
+	// First call: allow-always.
+	go func() {
+		env := <-envCh
+		rid, _ := env.PlaintextMetadata["requestId"].(string)
+		_ = br.SubmitDecision(agent.AuthDecisionFrame{
+			Type:      agent.KindAuthToolDecision,
+			RequestID: rid,
+			Decision:  agent.AuthDecisionAllowAlways,
+		})
+	}()
+	d, err := br.Ask(t.Context(), "sid-2", "Read", json.RawMessage(`{"file_path":"/tmp/x"}`), "Read /tmp/x")
+	if err != nil || d != agent.AuthDecisionAllowAlways {
+		t.Fatalf("first ask: d=%v err=%v", d, err)
+	}
+
+	// Second call should hit cache — no envelope, no submit needed.
+	d2, err := br.Ask(t.Context(), "sid-2", "Read", json.RawMessage(`{"file_path":"/tmp/y"}`), "")
+	if err != nil {
+		t.Fatalf("second ask err: %v", err)
+	}
+	if d2 != agent.AuthDecisionAllowAlways {
+		t.Fatalf("second ask decision: %v (cache miss)", d2)
+	}
+
+	// Different sid → cache miss. New subscription to sid-3.
+	envCh2, cancel2, _ := em.Subscribe("sid-3")
+	defer cancel2()
+	go func() {
+		env := <-envCh2
+		rid, _ := env.PlaintextMetadata["requestId"].(string)
+		_ = br.SubmitDecision(agent.AuthDecisionFrame{
+			Type:      agent.KindAuthToolDecision,
+			RequestID: rid,
+			Decision:  agent.AuthDecisionDenyOnce,
+		})
+	}()
+	d3, _ := br.Ask(t.Context(), "sid-3", "Read", json.RawMessage(`{}`), "")
+	if d3 != agent.AuthDecisionDenyOnce {
+		t.Fatalf("sid-3 should not hit sid-2 cache: got %v", d3)
+	}
+
+	// ForgetRemembered — re-ask should fire envelope again.
+	br.ForgetRemembered("sid-2", "Read")
+	got := make(chan agent.AuthDecision, 1)
+	go func() {
+		d, _ := br.Ask(t.Context(), "sid-2", "Read", json.RawMessage(`{}`), "")
+		got <- d
+	}()
+	select {
+	case env := <-envCh:
+		rid, _ := env.PlaintextMetadata["requestId"].(string)
+		_ = br.SubmitDecision(agent.AuthDecisionFrame{
+			Type:      agent.KindAuthToolDecision,
+			RequestID: rid,
+			Decision:  agent.AuthDecisionDenyOnce,
+		})
+	case <-time.After(2 * time.Second):
+		t.Fatal("ForgetRemembered did not re-ask")
+	}
+	if d := <-got; d != agent.AuthDecisionDenyOnce {
+		t.Fatalf("post-forget decision: %v", d)
+	}
+}
+
+func TestAuthBroker_Timeout(t *testing.T) {
+	t.Parallel()
+	em := newTestEmitter(t)
+	br, err := agent.NewAuthBroker(em)
+	if err != nil {
+		t.Fatalf("broker: %v", err)
+	}
+	br.Timeout = 50 * time.Millisecond
+	t.Cleanup(br.Close)
+
+	// Subscribe so Inject succeeds (even though we'll never decide).
+	_, cancel, _ := em.Subscribe("sid-t")
+	defer cancel()
+
+	d, err := br.Ask(t.Context(), "sid-t", "Bash", json.RawMessage(`{}`), "")
+	if err == nil {
+		t.Fatal("expected timeout error")
+	}
+	if d != agent.AuthDecisionDenyOnce {
+		t.Fatalf("timeout decision: %v (want deny-once)", d)
+	}
+}
+
+func TestAuthBroker_CtxCancel(t *testing.T) {
+	t.Parallel()
+	em := newTestEmitter(t)
+	br, _ := agent.NewAuthBroker(em)
+	t.Cleanup(br.Close)
+
+	_, cancelSub, _ := em.Subscribe("sid-c")
+	defer cancelSub()
+
+	ctx, cancel := context.WithCancel(t.Context())
+	resCh := make(chan error, 1)
+	go func() {
+		_, err := br.Ask(ctx, "sid-c", "Bash", nil, "")
+		resCh <- err
+	}()
+	cancel()
+	select {
+	case err := <-resCh:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("err: %v (want context.Canceled)", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("ctx cancel did not propagate")
+	}
+}
+
+func TestAuthBroker_UnknownRequestID(t *testing.T) {
+	t.Parallel()
+	em := newTestEmitter(t)
+	br, _ := agent.NewAuthBroker(em)
+	t.Cleanup(br.Close)
+
+	err := br.SubmitDecision(agent.AuthDecisionFrame{
+		Type:      agent.KindAuthToolDecision,
+		RequestID: "auth-bogus",
+		Decision:  agent.AuthDecisionAllowOnce,
+	})
+	if err == nil {
+		t.Fatal("expected error on unknown requestId")
+	}
+}
+
+func TestAuthBroker_Validation(t *testing.T) {
+	t.Parallel()
+	em := newTestEmitter(t)
+	br, _ := agent.NewAuthBroker(em)
+	t.Cleanup(br.Close)
+
+	// Empty sid.
+	if _, err := br.Ask(t.Context(), "", "Bash", nil, ""); err == nil {
+		t.Fatal("expected error on empty sid")
+	}
+	// Empty toolName.
+	if _, err := br.Ask(t.Context(), "sid", "", nil, ""); err == nil {
+		t.Fatal("expected error on empty toolName")
+	}
+	// Empty requestId in submit.
+	if err := br.SubmitDecision(agent.AuthDecisionFrame{Type: agent.KindAuthToolDecision}); err == nil {
+		t.Fatal("expected error on empty requestId")
+	}
+	// Unknown decision.
+	if err := br.SubmitDecision(agent.AuthDecisionFrame{
+		Type:      agent.KindAuthToolDecision,
+		RequestID: "x",
+		Decision:  agent.AuthDecision("bogus"),
+	}); err == nil {
+		t.Fatal("expected error on unknown decision string")
+	}
+}
+
+// Integration-flavored: spin up an AttachServer with a broker and feed
+// a JSON decision frame through readInputs to verify the broker
+// receives it via the input direction of the attach socket.
+func TestAttachServer_AuthDecisionRouting(t *testing.T) {
+	t.Parallel()
+
+	tmp := t.TempDir()
+	sockPath := filepath.Join(tmp, "attach.sock")
+
+	em := newTestEmitter(t)
+	br, _ := agent.NewAuthBroker(em)
+	t.Cleanup(br.Close)
+	br.Timeout = 2 * time.Second
+
+	srv, err := agent.NewAttachServer(agent.AttachServerConfig{
+		SocketPath: sockPath,
+		Emitter:    em,
+		Lock:       lock.New(),
+		// InputSink stays non-nil so rw mode is allowed; record any
+		// non-decision bytes so we can assert the JSON frame did NOT
+		// fall through to the PTY sink.
+		InputSink: func(_ string, data []byte) error {
+			t.Errorf("PTY sink got auth-decision bytes: %q", data)
+			return nil
+		},
+		AuthBroker: br,
+		SocketPerm: 0o600,
+	})
+	if err != nil {
+		t.Fatalf("server: %v", err)
+	}
+	defer func() { _ = srv.Close() }()
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	serveDone := make(chan error, 1)
+	go func() { serveDone <- srv.Serve(ctx) }()
+
+	// Connect.
+	c, err := net.Dial("unix", sockPath)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	defer c.Close()
+
+	// Subscribe before sending the header so Ask() finds a subscriber.
+	_, cancelSub, _ := em.Subscribe("sid-attach")
+	defer cancelSub()
+
+	// Header.
+	hdr := []byte(`{"sessionId":"sid-attach","mode":"rw","client":{"kind":"terminal","deviceId":"dev-1"}}` + "\n")
+	if _, err := c.Write(hdr); err != nil {
+		t.Fatalf("write header: %v", err)
+	}
+
+	// Read ack.
+	if _, err := agent.ReadFrame(c); err != nil {
+		t.Fatalf("read ack: %v", err)
+	}
+
+	// Issue an Ask (spawns a request envelope) and capture rid.
+	resCh := make(chan agent.AuthDecision, 1)
+	go func() {
+		d, _ := br.Ask(t.Context(), "sid-attach", "Bash", json.RawMessage(`{"cmd":"ls"}`), "Bash: ls")
+		resCh <- d
+	}()
+
+	// Read frames until we see the auth-tool-request envelope. The
+	// daemon only fans request envelopes via Inject — here we read
+	// them via the attach socket subscriber.
+	var requestID string
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		_ = c.SetReadDeadline(time.Now().Add(500 * time.Millisecond))
+		frame, err := agent.ReadFrame(c)
+		if err != nil {
+			// timeout — keep polling
+			continue
+		}
+		var env agent.LocalEnvelope
+		if err := json.Unmarshal(frame, &env); err == nil {
+			if env.Kind == agent.KindAuthToolRequest {
+				rid, _ := env.PlaintextMetadata["requestId"].(string)
+				requestID = rid
+				break
+			}
+		}
+	}
+	if requestID == "" {
+		t.Fatal("did not see auth.tool-request envelope")
+	}
+
+	// Send the decision frame back via the input direction.
+	decision := agent.AuthDecisionFrame{
+		Type:      agent.KindAuthToolDecision,
+		RequestID: requestID,
+		Decision:  agent.AuthDecisionAllowOnce,
+	}
+	body, _ := json.Marshal(decision)
+	if err := agent.WriteInputFrame(c, body); err != nil {
+		t.Fatalf("write input frame: %v", err)
+	}
+
+	// Ask should resolve.
+	select {
+	case d := <-resCh:
+		if d != agent.AuthDecisionAllowOnce {
+			t.Fatalf("decision: %v", d)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("Ask did not resolve from socket-routed decision")
+	}
+
+	cancel()
+	select {
+	case <-serveDone:
+	case <-time.After(2 * time.Second):
+		t.Error("server did not exit after ctx cancel")
+	}
+	_ = os.Remove(sockPath)
+}

--- a/internal/agent/envelope_emitter.go
+++ b/internal/agent/envelope_emitter.go
@@ -220,6 +220,43 @@ func (e *EnvelopeEmitter) Stats() (linesParsed, envelopesEmit, envelopesDrop int
 	return st.LinesParsed, st.EnvelopesEmit, st.EnvelopesDrop
 }
 
+// Inject pushes a daemon-originated envelope to all subscribers of
+// env.SessionID. Used by AuthBroker (and any future server-side event
+// source) to fan a non-JSONL envelope into the same delivery path as
+// watcher events.
+//
+// Best-effort delivery: if a subscriber's outbound channel is full, the
+// envelope is dropped for that subscriber (the channel buffer of 64 is
+// the same back-pressure model as the watcher relay). Returns
+// ErrEmitterClosed only if the emitter has been Close()'d.
+func (e *EnvelopeEmitter) Inject(env LocalEnvelope) error {
+	e.mu.Lock()
+	if e.closed {
+		e.mu.Unlock()
+		return ErrEmitterClosed
+	}
+	// Snapshot subs to avoid holding the lock while sending. New
+	// subscribers added concurrently won't see this envelope; that's
+	// fine — Inject is a fan-out broadcast, not a replay log.
+	subs := make([]*emitterSub, 0, len(e.subs))
+	for _, s := range e.subs {
+		if s.sid == env.SessionID {
+			subs = append(subs, s)
+		}
+	}
+	e.mu.Unlock()
+	for _, s := range subs {
+		select {
+		case s.out <- env:
+		default:
+			// Subscriber slow / disconnected; drop. The watcher's
+			// OnDrop reporting only fires on JSONL drops, so we don't
+			// double-count here.
+		}
+	}
+	return nil
+}
+
 // relay is the per-subscriber goroutine: pulls jsonl.Envelopes from the
 // watcher, projects to LocalEnvelope, sends to out. Exits on ctx.Done()
 // or when the watcher channel closes.

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -61,6 +61,20 @@ type Config struct {
 	// rw mode (clients are auto-downgraded to ro).
 	InputSink func(sessionID string, data []byte) error
 
+	// EnableAuthBroker, when true, constructs an AuthBroker bound to
+	// the daemon's envelope emitter and wires it into the attach
+	// socket so auth.tool-decision input frames route through the
+	// broker. Callers that integrate the cc HookServer can fetch
+	// the broker via the OnReady hook to build a BrokerHookHandlers.
+	EnableAuthBroker bool
+
+	// OnReady, when non-nil, is invoked once after the daemon's
+	// shared components (emitter, broker, lock state) are constructed
+	// and BEFORE the supervisor begins running subsystems. Callers
+	// use it as the wiring seam to plumb cc.NewHookServer with a
+	// BrokerHookHandlers driven by daemon.AuthBroker. Optional.
+	OnReady func(DaemonComponents)
+
 	// SubsystemFactories lets tests install fake subsystems in place
 	// of the real daemon/client. nil → use defaultSubsystems with
 	// the components built from this Config.
@@ -73,6 +87,17 @@ type Config struct {
 // context, but the same instance — implementations must NOT keep
 // per-run state on the receiver).
 type SubsystemFactory func() watchdog.Subsystem
+
+// DaemonComponents bundles the shared state the daemon constructs
+// before supervising subsystems. Surfaced via Config.OnReady so
+// callers can wire follow-on integrations (e.g. cc.HookServer with
+// BrokerHookHandlers driven by AuthBroker) without forcing those
+// dependencies into this package's import graph.
+type DaemonComponents struct {
+	Emitter    *agent.EnvelopeEmitter
+	Lock       *lock.Lock
+	AuthBroker *agent.AuthBroker // nil when EnableAuthBroker = false
+}
 
 // Run constructs a Watchdog, registers the configured subsystems,
 // and blocks until ctx is canceled. Returns nil on clean shutdown,
@@ -140,11 +165,21 @@ func Run(ctx context.Context, cfg Config) error {
 
 		lockSM := lock.New()
 
+		var broker *agent.AuthBroker
+		if cfg.EnableAuthBroker {
+			broker, err = agent.NewAuthBroker(emitter)
+			if err != nil {
+				_ = emitter.Close()
+				return fmt.Errorf("daemon: auth broker: %w", err)
+			}
+		}
+
 		attach, err := agent.NewAttachServer(agent.AttachServerConfig{
 			SocketPath: socketPath,
 			Emitter:    emitter,
 			Lock:       lockSM,
 			InputSink:  cfg.InputSink,
+			AuthBroker: broker,
 			OnError: func(err error) {
 				logf("[daemon] attach: %v", err)
 			},
@@ -161,11 +196,22 @@ func Run(ctx context.Context, cfg Config) error {
 		// permanently disabled, see clientSubsystem doc).
 		_ = attach.Close()
 
-		factories = realSubsystems(socketPath, emitter, lockSM, cfg.InputSink, logf)
+		if cfg.OnReady != nil {
+			cfg.OnReady(DaemonComponents{
+				Emitter:    emitter,
+				Lock:       lockSM,
+				AuthBroker: broker,
+			})
+		}
+
+		factories = realSubsystems(socketPath, emitter, lockSM, cfg.InputSink, broker, logf)
 		// emitter lives for the daemon's full lifetime; clean up
 		// on Run exit. clientSubsystem owns its per-run AttachServer
 		// and closes it inside Run's defer.
 		defer func() {
+			if broker != nil {
+				broker.Close()
+			}
 			_ = emitter.Close()
 		}()
 	}
@@ -196,6 +242,7 @@ func realSubsystems(
 	em *agent.EnvelopeEmitter,
 	lockSM *lock.Lock,
 	inputSink func(string, []byte) error,
+	broker *agent.AuthBroker,
 	logf func(format string, args ...any),
 ) []SubsystemFactory {
 	return []SubsystemFactory{
@@ -206,6 +253,7 @@ func realSubsystems(
 				emitter:    em,
 				lock:       lockSM,
 				inputSink:  inputSink,
+				broker:     broker,
 				logf:       logf,
 			}
 		},
@@ -261,6 +309,7 @@ type clientSubsystem struct {
 	emitter    *agent.EnvelopeEmitter
 	lock       *lock.Lock
 	inputSink  func(sessionID string, data []byte) error
+	broker     *agent.AuthBroker // nil unless EnableAuthBroker=true
 	logf       func(format string, args ...any)
 }
 
@@ -273,6 +322,7 @@ func (c *clientSubsystem) Run(ctx context.Context, hb func()) error {
 		Emitter:    c.emitter,
 		Lock:       c.lock,
 		InputSink:  c.inputSink,
+		AuthBroker: c.broker,
 		OnError: func(err error) {
 			if c.logf != nil {
 				c.logf("[daemon] attach: %v", err)


### PR DESCRIPTION
## Summary

Pairs with **piaobeizu/tether-app#15**.

Daemon-side wire layer for the v0.1 backlog item "Tool authorization UX → WT protocol mapping". When cc fires a `PreToolUse` hook the daemon today's `noopHandlers` either auto-allows (config error) or auto-denies (the safe-default fallback) — there's no UX surface to actually ask the user. This PR adds the broker that emits an `auth.tool-request` envelope to attached UI clients, blocks for a decision (60s default), and surfaces it back to cc as allow / deny.

## Wire shape (cross-repo contract)

```
LocalEnvelope { kind: "auth.tool-request", sessionId,
                plaintextMetadata: { requestId, toolName, toolInput, summary } }
```

Decision flows back through the attach socket's existing rw input direction as a JSON-shaped frame:

```json
{ "type": "auth.tool-decision", "requestId": "...",
  "decision": "allow-once" | "allow-always" | "deny-once" | "deny-always" }
```

JSON field names are pinned via Go struct tags + the matching TS types in `tether-app/src/transport/auth.ts`. DO NOT rename without updating both repos in lockstep — the daemon and UI talk via the byte-shape, not the type names. A cross-repo `// DO NOT rename without updating tether-app/...` comment is parked on the kind constants in `internal/agent/auth.go`.

## Design choices

| Decision | Choice | Why |
|---|---|---|
| Envelope channel | **Extend `LocalEnvelope`** with new kinds, route via existing emitter | Attach socket already carries LocalEnvelope; adding a second socket for control-plane traffic doubles the surface area for marginal isolation gain. New `EnvelopeEmitter.Inject()` fan-outs daemon-originated envelopes to per-sid subscribers without touching the JSONL watcher path. |
| Decision routing | **Sniff JSON on rw input frames** | The attach socket's input direction already exists for PTY bytes. We pre-filter with a cheap `{` + `"auth.tool-decision"` substring scan before `json.Unmarshal`; PTY input that happens to start with `{` falls through to the PTY sink unchanged. Lock check is bypassed for decision frames so a UI tab without writer lock can still answer prompts. |
| Timeout | **60s default** (`DefaultAuthTimeout`) | Long enough to absorb a context-switch ("user is at the keyboard but not actively watching"); short enough that a forgotten prompt doesn't pin a cc tool call indefinitely. Tunable via `AuthBroker.Timeout`. On timeout: fail-closed (`deny-once` + non-nil error so audit logs see the wall-clock failure). |
| "Always" persistence | **In-memory only (v0.1)** | `(sessionId, toolName) → decision` map keyed in the broker. Daemon restart re-asks. Persistence to disk is a deliberate v0.2 follow-up — defers the "where do we put it" / "what's the precedence with skill manifests" questions. `ForgetRemembered()` is the symmetric inverse, parked for a future "revoke" UX. |
| HookHandlers wiring | **`BrokerHookHandlers` adapter** | Implements `cc.HookHandlers` by delegating PreToolUse to the broker. Caller-controlled (the daemon's `OnReady` callback hands the broker over so the cc.HookServer can be constructed in the integrating layer without forcing `internal/cc` into `internal/daemon`'s import graph). |

## What landed

| File | Notes |
|---|---|
| `internal/agent/auth.go` | `AuthBroker`, request/decision wire types, kind constants, requestId generator. Doc-block on `KindAuthToolRequest` / `KindAuthToolDecision` is the cross-repo contract anchor. |
| `internal/agent/auth_handlers.go` | `BrokerHookHandlers` adapter + `summarizeToolInput()` for the UI prompt label. |
| `internal/agent/envelope_emitter.go` | New `Inject(env)` method — daemon-originated fan-out to per-sid subscribers, drop-on-full back-pressure. |
| `internal/agent/attach_socket.go` | `AuthBroker` field on `AttachServerConfig`; `readInputs` sniffs decision frames and routes to broker before lock check. |
| `internal/daemon/daemon.go` | `EnableAuthBroker` + `OnReady(DaemonComponents)` config knobs; broker lifetime tied to emitter cleanup. |
| `internal/agent/auth_test.go` | Allow-once / remember-always / cache-miss-on-different-sid / forget / timeout / ctx-cancel / unknown-requestId / validation + integration test that drives a JSON decision frame through a real AttachServer. |
| `internal/agent/auth_handlers_test.go` | Allow / deny / malformed payload / missing tool_name / nil broker. |

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test -race -count=1 ./...` → all packages pass
- [ ] Manual: wire `EnableAuthBroker=true` + an `OnReady` hook that constructs a `cc.HookServer` with `agent.NewBrokerHookHandlers(broker)`, run cc with the URLs, exercise a Bash tool call

🤖 Generated with [Claude Code](https://claude.com/claude-code)