### PR TITLE
fix(jsonl): walk cc's per-bucket directory layout (P0 dogfood-blocker)

### DIFF
--- a/internal/cc/jsonl/watcher.go
+++ b/internal/cc/jsonl/watcher.go
@@ -75,16 +75,18 @@ type Options struct {
 // Concurrency: New starts one drain goroutine. Subscribe is safe to
 // call from any goroutine. Close is idempotent.
 type Watcher struct {
-	root  string
-	fsw   *fsnotify.Watcher
-	opts  Options
-	ctx   context.Context
-	cancel context.CancelFunc
+	root    string
+	dirMode bool // true if root is a directory (vs single-file mode)
+	fsw     *fsnotify.Watcher
+	opts    Options
+	ctx     context.Context
+	cancel  context.CancelFunc
 
 	mu       sync.Mutex
 	files    map[string]*fileState    // path → state
 	subs     map[string][]*subscriber // sessionID → subscribers
 	uuidSeen map[string]*uuidRing     // sessionID → bounded FIFO ring (dedup)
+	buckets  map[string]struct{}      // bucket dir paths registered with fsnotify
 	closed   bool
 	wg       sync.WaitGroup
 	stats    Stats
@@ -159,10 +161,22 @@ type subscriber struct {
 	dropped atomic.Int64
 }
 
-// New creates a Watcher rooted at `root`. If `root` is a directory
-// the watcher follows `<root>/*.jsonl` (and any new files matching
-// that pattern that appear). If `root` is a single .jsonl file the
-// watcher follows just that file.
+// New creates a Watcher rooted at `root`.
+//
+// If `root` is a directory the watcher follows `<root>/*.jsonl` AND
+// `<root>/<bucket>/*.jsonl` — exactly one level of subdirectory ("bucket")
+// is walked. This matches cc's per-cwd bucket layout
+// (`$HOME/.claude/projects/<encoded-cwd>/<sid>.jsonl`, see cc-sdk-route
+// §D.1 + §E.5) while remaining bounded — a misconfigured
+// `--projects-dir=/` will not walk the whole filesystem. Hidden
+// directories (name starts with `.`) are skipped to avoid inotify churn
+// from VCS / OS metadata dirs (`.git/`, `.DS_Store/`, ...).
+//
+// New bucket directories that appear AFTER startup are picked up via
+// the Create event on `root` and registered + scanned on the fly.
+//
+// If `root` is a single .jsonl file the watcher follows just that file
+// (single-file mode, behavior unchanged).
 //
 // New does not block — fsnotify and the drain loop run in goroutines.
 // Errors during Setup (root unreadable, fsnotify init fail) return
@@ -187,6 +201,7 @@ func New(parent context.Context, root string, opts Options) (*Watcher, error) {
 		files:    make(map[string]*fileState),
 		subs:     make(map[string][]*subscriber),
 		uuidSeen: make(map[string]*uuidRing),
+		buckets:  make(map[string]struct{}),
 	}
 
 	st, err := os.Stat(root)
@@ -196,10 +211,16 @@ func New(parent context.Context, root string, opts Options) (*Watcher, error) {
 		return nil, fmt.Errorf("jsonl watcher: stat root: %w", err)
 	}
 
-	var watchTarget string
 	if st.IsDir() {
-		watchTarget = root
-		// Pick up files already present.
+		w.dirMode = true
+		// Watch root for new bucket dirs + flat .jsonl files.
+		if err := fsw.Add(root); err != nil {
+			fsw.Close()
+			cancel()
+			return nil, fmt.Errorf("jsonl watcher: fsnotify add %q: %w", root, err)
+		}
+		// Pick up flat .jsonl files (legacy single-bucket layout) and
+		// register one-level-deep bucket subdirs (cc's actual layout).
 		entries, err := os.ReadDir(root)
 		if err != nil {
 			fsw.Close()
@@ -207,10 +228,20 @@ func New(parent context.Context, root string, opts Options) (*Watcher, error) {
 			return nil, fmt.Errorf("jsonl watcher: read root: %w", err)
 		}
 		for _, e := range entries {
-			if e.IsDir() || !strings.HasSuffix(e.Name(), ".jsonl") {
+			name := e.Name()
+			if strings.HasPrefix(name, ".") {
+				continue // skip .git, .DS_Store, etc.
+			}
+			path := filepath.Join(root, name)
+			if e.IsDir() {
+				if err := w.addBucket(path); err != nil {
+					w.reportError(path, err)
+				}
 				continue
 			}
-			path := filepath.Join(root, e.Name())
+			if !strings.HasSuffix(name, ".jsonl") {
+				continue
+			}
 			if err := w.openFile(path); err != nil {
 				w.reportError(path, err)
 			}
@@ -218,24 +249,98 @@ func New(parent context.Context, root string, opts Options) (*Watcher, error) {
 	} else {
 		// Single-file mode. fsnotify needs the *parent* directory
 		// to detect rename / replace; we filter to this one path.
-		watchTarget = filepath.Dir(root)
+		watchTarget := filepath.Dir(root)
 		if err := w.openFile(root); err != nil {
 			fsw.Close()
 			cancel()
 			return nil, err
 		}
-	}
-
-	if err := fsw.Add(watchTarget); err != nil {
-		fsw.Close()
-		cancel()
-		return nil, fmt.Errorf("jsonl watcher: fsnotify add %q: %w", watchTarget, err)
+		if err := fsw.Add(watchTarget); err != nil {
+			fsw.Close()
+			cancel()
+			return nil, fmt.Errorf("jsonl watcher: fsnotify add %q: %w", watchTarget, err)
+		}
 	}
 
 	w.wg.Add(1)
 	go w.drain()
 
 	return w, nil
+}
+
+// addBucket registers a one-level subdir of root as an additional
+// fsnotify watch + scans its existing .jsonl files. Used at startup and
+// at runtime when a new bucket Create event fires.
+//
+// Bounded recursion: we walk subdirs of `root` only. If the bucket
+// itself contains nested subdirectories, those are NOT recursed —
+// cc-sdk-route §D.1/§E.5 do not promise nested buckets, and unbounded
+// recursion would let a misconfigured `--projects-dir=/` hang the
+// daemon walking the whole filesystem. Nested dirs are reported via
+// OnError and otherwise ignored.
+func (w *Watcher) addBucket(path string) error {
+	w.mu.Lock()
+	if _, exists := w.buckets[path]; exists {
+		w.mu.Unlock()
+		return nil
+	}
+	w.buckets[path] = struct{}{}
+	w.mu.Unlock()
+
+	if err := w.fsw.Add(path); err != nil {
+		// roll back so a future Create can retry
+		w.mu.Lock()
+		delete(w.buckets, path)
+		w.mu.Unlock()
+		return fmt.Errorf("jsonl watcher: fsnotify add bucket %q: %w", path, err)
+	}
+
+	entries, err := os.ReadDir(path)
+	if err != nil {
+		return fmt.Errorf("jsonl watcher: read bucket %q: %w", path, err)
+	}
+	for _, e := range entries {
+		name := e.Name()
+		if strings.HasPrefix(name, ".") {
+			continue
+		}
+		if e.IsDir() {
+			// Reject multi-level structure with a clear error so a
+			// misconfigured projects-dir surfaces fast instead of
+			// silently dropping records.
+			w.reportError(filepath.Join(path, name), fmt.Errorf(
+				"jsonl watcher: nested directory under bucket not supported (cc layout is exactly one level: root/<bucket>/<sid>.jsonl)",
+			))
+			continue
+		}
+		if !strings.HasSuffix(name, ".jsonl") {
+			continue
+		}
+		fp := filepath.Join(path, name)
+		if err := w.openFile(fp); err != nil {
+			w.reportError(fp, err)
+		}
+	}
+	return nil
+}
+
+// dropBucket removes a bucket from tracking when its directory is
+// removed/renamed: drops fileState for any files under that bucket and
+// forgets the bucket itself. fsnotify automatically removes the watch
+// for a deleted directory, so we don't call fsw.Remove here.
+func (w *Watcher) dropBucket(path string) {
+	prefix := path + string(os.PathSeparator)
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if _, ok := w.buckets[path]; !ok {
+		return
+	}
+	delete(w.buckets, path)
+	for fp := range w.files {
+		if strings.HasPrefix(fp, prefix) {
+			delete(w.files, fp)
+		}
+	}
 }
 
 // Subscribe returns a channel that receives Envelopes for the given
@@ -444,7 +549,38 @@ func (w *Watcher) drain() {
 }
 
 func (w *Watcher) handleEvent(ev fsnotify.Event) {
-	// Filter on .jsonl suffix early.
+	// In dir mode, Create events at the root level may be either a new
+	// .jsonl file (legacy flat layout) OR a new bucket subdirectory
+	// (cc's actual layout). Rename/Remove on a tracked bucket dir
+	// triggers cleanup. We only do these checks in dir mode.
+	if w.dirMode {
+		// Skip hidden entries (.git, .DS_Store, ...) regardless of op.
+		if strings.HasPrefix(filepath.Base(ev.Name), ".") {
+			return
+		}
+		if ev.Op&fsnotify.Create != 0 {
+			// stat may race a Remove; ignore ENOENT.
+			if st, err := os.Stat(ev.Name); err == nil && st.IsDir() {
+				// Only register subdirs of root as buckets; nested
+				// dirs (would be under an existing bucket) are
+				// rejected by addBucket via the OnError path.
+				if filepath.Dir(ev.Name) == w.root {
+					if err := w.addBucket(ev.Name); err != nil {
+						w.reportError(ev.Name, err)
+					}
+				}
+				return
+			}
+		}
+		if ev.Op&(fsnotify.Remove|fsnotify.Rename) != 0 {
+			// If a tracked bucket dir was removed/renamed, drop its
+			// file state. Cheap: dropBucket no-ops when the path
+			// isn't a registered bucket.
+			w.dropBucket(ev.Name)
+		}
+	}
+
+	// Filter on .jsonl suffix for the file-level branches.
 	if !strings.HasSuffix(ev.Name, ".jsonl") {
 		return
 	}

--- a/internal/cc/jsonl/watcher_test.go
+++ b/internal/cc/jsonl/watcher_test.go
@@ -592,6 +592,195 @@ func TestSubscribeFromOffset_RejectsUnsupported(t *testing.T) {
 	}
 }
 
+// --- bucket-layout tests (cc's per-cwd subdir structure) ---
+
+// TestWatcher_BucketSubdir_PicksUpExistingFile verifies that at startup
+// the watcher walks one level into root and registers .jsonl files
+// inside bucket subdirs (cc-sdk-route §D.1 layout: root/<encoded-cwd>/<sid>.jsonl).
+func TestWatcher_BucketSubdir_PicksUpExistingFile(t *testing.T) {
+	root := t.TempDir()
+	bucket := filepath.Join(root, "bucket-A")
+	must(t, os.MkdirAll(bucket, 0o755))
+	sid := "sess-bucket-existing"
+	path := filepath.Join(bucket, sid+".jsonl")
+	must(t, os.WriteFile(path, []byte(
+		`{"type":"user","uuid":"u1","sessionId":"`+sid+`","message":{"role":"user","content":[]}}`+"\n"), 0o644))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	w, err := New(ctx, root, Options{})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	defer w.Close()
+
+	ch := w.Subscribe(sid)
+
+	// Trigger a re-read by appending another line.
+	must(t, appendLine(path,
+		`{"type":"assistant","uuid":"a1","sessionId":"`+sid+`","message":{"role":"assistant","content":[]}}`))
+
+	envs := readWithTimeout(t, ch, 2, 3*time.Second)
+	if len(envs) != 2 {
+		t.Fatalf("got %d envelopes, want 2", len(envs))
+	}
+	if envs[0].SourceUUID != "u1" || envs[1].SourceUUID != "a1" {
+		t.Errorf("envelope order/uuid: got %q, %q", envs[0].SourceUUID, envs[1].SourceUUID)
+	}
+}
+
+// TestWatcher_BucketCreatedAtRuntime_NewFile verifies that a bucket
+// directory created AFTER the watcher starts is discovered, watched,
+// and its newly-written .jsonl is tracked.
+func TestWatcher_BucketCreatedAtRuntime_NewFile(t *testing.T) {
+	root := t.TempDir()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	w, err := New(ctx, root, Options{})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	defer w.Close()
+
+	sid := "sess-bucket-runtime"
+	ch := w.Subscribe(sid)
+
+	bucket := filepath.Join(root, "bucket-B")
+	must(t, os.MkdirAll(bucket, 0o755))
+
+	// Give fsnotify a moment to deliver the bucket Create + addBucket
+	// to register the inner watch before the file write fires.
+	time.Sleep(100 * time.Millisecond)
+
+	path := filepath.Join(bucket, sid+".jsonl")
+	must(t, os.WriteFile(path, []byte(
+		`{"type":"user","uuid":"u1","sessionId":"`+sid+`","message":{"role":"user","content":[]}}`+"\n"), 0o644))
+
+	envs := readWithTimeout(t, ch, 1, 3*time.Second)
+	if envs[0].SourceUUID != "u1" {
+		t.Errorf("uuid = %q", envs[0].SourceUUID)
+	}
+}
+
+// TestWatcher_BucketRemoved_StopsLeaking verifies that removing a
+// bucket directory causes its file state to be dropped — w.files no
+// longer holds entries for files under that bucket, and w.buckets no
+// longer holds the bucket itself.
+func TestWatcher_BucketRemoved_StopsLeaking(t *testing.T) {
+	root := t.TempDir()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	w, err := New(ctx, root, Options{})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	defer w.Close()
+
+	sid := "sess-bucket-remove"
+	_ = w.Subscribe(sid)
+
+	bucket := filepath.Join(root, "bucket-C")
+	must(t, os.MkdirAll(bucket, 0o755))
+	time.Sleep(100 * time.Millisecond)
+
+	path := filepath.Join(bucket, sid+".jsonl")
+	must(t, os.WriteFile(path, []byte(
+		`{"type":"user","uuid":"u1","sessionId":"`+sid+`","message":{"role":"user","content":[]}}`+"\n"), 0o644))
+
+	// Wait for openFile to register the file.
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		w.mu.Lock()
+		_, present := w.files[path]
+		w.mu.Unlock()
+		if present {
+			break
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	w.mu.Lock()
+	if _, present := w.files[path]; !present {
+		w.mu.Unlock()
+		t.Fatalf("expected w.files[%q] to be registered before removal", path)
+	}
+	w.mu.Unlock()
+
+	// Now remove the bucket entirely.
+	must(t, os.RemoveAll(bucket))
+
+	// Wait for cleanup to land.
+	deadline = time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		w.mu.Lock()
+		_, fileLeft := w.files[path]
+		_, bucketLeft := w.buckets[bucket]
+		w.mu.Unlock()
+		if !fileLeft && !bucketLeft {
+			return // success
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if _, present := w.files[path]; present {
+		t.Errorf("w.files[%q] leaked after bucket RemoveAll", path)
+	}
+	if _, present := w.buckets[bucket]; present {
+		t.Errorf("w.buckets[%q] leaked after bucket RemoveAll", bucket)
+	}
+}
+
+// TestWatcher_HiddenDirSkipped verifies that a hidden directory at
+// startup (e.g. `.git`) is NOT registered as a bucket — avoids inotify
+// churn from VCS / OS metadata dirs that may sit alongside cc buckets.
+func TestWatcher_HiddenDirSkipped(t *testing.T) {
+	root := t.TempDir()
+	hidden := filepath.Join(root, ".git")
+	must(t, os.MkdirAll(hidden, 0o755))
+	// Drop a fake .jsonl inside; watcher must NOT pick it up.
+	must(t, os.WriteFile(filepath.Join(hidden, "should-not-track.jsonl"),
+		[]byte(`{"type":"user","uuid":"x","sessionId":"x","message":{"role":"user","content":[]}}`+"\n"), 0o644))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	w, err := New(ctx, root, Options{})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	defer w.Close()
+
+	w.mu.Lock()
+	if _, present := w.buckets[hidden]; present {
+		w.mu.Unlock()
+		t.Fatalf("hidden dir %q was registered as a bucket; should be skipped", hidden)
+	}
+	for fp := range w.files {
+		if filepath.Dir(fp) == hidden {
+			w.mu.Unlock()
+			t.Fatalf("file under hidden dir %q was registered: %q", hidden, fp)
+		}
+	}
+	w.mu.Unlock()
+
+	// Also verify a runtime-created hidden dir is ignored.
+	hidden2 := filepath.Join(root, ".DS_Store")
+	must(t, os.MkdirAll(hidden2, 0o755))
+	time.Sleep(150 * time.Millisecond)
+
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if _, present := w.buckets[hidden2]; present {
+		t.Fatalf("runtime hidden dir %q was registered as a bucket", hidden2)
+	}
+}
+
 // --- helpers ---
 
 func must(t *testing.T, err error) {


### PR DESCRIPTION
## Summary

- End-to-end smoke caught a P0: real cc writes session JSONL at `\$HOME/.claude/projects/<encoded-cwd>/<sid>.jsonl` — a bucket subdir, NOT a flat file under `projects/`. The previous `jsonl.Watcher` only did `os.ReadDir(root)` + `fsnotify.Add(root)` (single-level), so the default `--projects-dir=\$HOME/.claude/projects` with real cc silently saw zero JSONL files. Smoke test only worked because we hand-placed flat files.
- This PR makes the watcher bucket-aware: walk one level deep at startup, register each non-hidden subdir as an additional fsnotify watch + scan its `.jsonl` files, and pick up newly-created buckets at runtime via `Create` on `root`. On bucket Remove/Rename, drop file state under that bucket prefix.

## Design choices

**Single-level recursion (spec-anchored).** cc-sdk-route §D.1 + §E.5 promise exactly one level: `root/<encoded-cwd>/<sid>.jsonl`. We deliberately do NOT recurse further — a misconfigured `--projects-dir=/` under unbounded recursion would walk the whole filesystem at startup. If a nested directory is found under a bucket, it surfaces via `OnError` and is otherwise ignored. Fail loud, not silent.

**Bucket-removal cleanup.** `handleEvent` watches for `Remove`/`Rename` on a known bucket path; `dropBucket()` drops every `w.files` entry whose path starts with `bucket + os.PathSeparator` and forgets the bucket itself. fsnotify auto-removes the watch when the directory is deleted, so we don't call `fsw.Remove()` (which would error on a deleted path).

**Hidden-dir skip rule.** Names starting with `.` (`.git`, `.DS_Store`, ...) are skipped at startup AND at runtime. Avoids inotify churn from VCS / OS metadata dirs that may sit alongside cc's buckets.

**Single-file mode unchanged.** When `root` is a `.jsonl` file we still watch its parent dir + filter to that one path.

## fsnotify behavior surprises

None substantive. Two worth noting:

- fsnotify follows symlinks by default — not exercised in tests; if it bites in real cc deployments we add an explicit deny-list later. Spec doesn't promise symlinked buckets.
- Removing a watched directory auto-removes its inotify watch; `fsw.Remove()` on a deleted path errors. `dropBucket()` therefore only touches in-memory state.

## Test plan

- [x] `TestWatcher_BucketSubdir_PicksUpExistingFile` — pre-create `root/bucket-A/sid.jsonl`, start watcher, append, assert 2 envelopes.
- [x] `TestWatcher_BucketCreatedAtRuntime_NewFile` — empty root, `mkdir bucket-B`, write `bucket-B/sid.jsonl`, assert envelope received.
- [x] `TestWatcher_BucketRemoved_StopsLeaking` — same as above, then `os.RemoveAll(bucket)`, assert `w.files` + `w.buckets` cleaned up.
- [x] `TestWatcher_HiddenDirSkipped` — `mkdir .git` (startup) + `mkdir .DS_Store` (runtime); neither registers as a bucket.
- [x] All pre-existing tests stay green (`DirMode_PicksUpExistingFile`, `NewFile_AfterStart`, `TruncationDetected`, `RotationDetected`, `UUIDDedup`, `MultipleSubscribers_FanOut`, `Unsubscribe_PreventsLeak`, ...).
- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test -race -count=10 ./internal/cc/jsonl/...` clean (29.17s)
- [x] `go test -race ./...` whole repo clean

\U0001f916 Generated with [Claude Code](https://claude.com/claude-code)