### PR TITLE
feat(resume): pass --settings to cc so daemon hookserver actually fires

### DIFF
--- a/cmd/tether/cc_settings.go
+++ b/cmd/tether/cc_settings.go
@@ -1,0 +1,52 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+)
+
+// ccSettingsResolver resolves the cc settings.json path used to point a
+// spawned `claude` subprocess at the daemon's hookserver. The seam exists
+// because PR #44 wired the daemon's hookserver + settings.json writer, but
+// the cc subprocess that ACTUALLY needs the file (anything spawning cc)
+// must be told where it lives via `--settings <path>`.
+//
+// Precedence (highest first):
+//
+//  1. CLI flag (handled by callers; not by this resolver)
+//  2. TETHER_HOOK_SETTINGS env var, when non-empty
+//  3. <home>/.tether/cc-settings/settings.json on disk
+//
+// If nothing applies, returns empty string. An empty result MUST be
+// interpreted by callers as "do not pass --settings to cc" — graceful
+// fallback for users who run tether without `--auth-broker` (no daemon →
+// no settings.json on disk).
+//
+// The resolver explicitly stats the default-path target so a stale env
+// pointing at a missing file falls through to default-or-empty rather
+// than producing an obviously-broken `--settings` arg. Conversely the
+// env-var path is honored verbatim (no stat) — operators may legitimately
+// pre-create the file out-of-band, and a noisy "your env var points
+// nowhere" surface is better than silently dropping it.
+//
+// Pure-ish wrt environment: takes a homeProvider so tests can pin $HOME
+// without leaking into the parent process's env.
+func resolveCCSettings(homeProvider func() (string, error)) string {
+	if v := os.Getenv("TETHER_HOOK_SETTINGS"); v != "" {
+		return v
+	}
+	home, err := homeProvider()
+	if err != nil || home == "" {
+		return ""
+	}
+	def := filepath.Join(home, ".tether", "cc-settings", "settings.json")
+	if _, err := os.Stat(def); err != nil {
+		return ""
+	}
+	return def
+}
+
+// defaultHomeProvider is the production homeProvider used by resolveCCSettings.
+func defaultHomeProvider() (string, error) {
+	return os.UserHomeDir()
+}

--- a/cmd/tether/cc_settings_test.go
+++ b/cmd/tether/cc_settings_test.go
@@ -1,0 +1,325 @@
+package main
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestResolveCCSettings_EnvWins covers the highest-precedence rung: a
+// non-empty TETHER_HOOK_SETTINGS env var short-circuits, regardless of
+// whether $HOME/.tether/cc-settings/settings.json exists.
+func TestResolveCCSettings_EnvWins(t *testing.T) {
+	t.Setenv("TETHER_HOOK_SETTINGS", "/some/explicit/path.json")
+	got := resolveCCSettings(func() (string, error) {
+		// Also create a real default file to prove env still wins.
+		return t.TempDir(), nil
+	})
+	if got != "/some/explicit/path.json" {
+		t.Errorf("env should win; got %q", got)
+	}
+}
+
+// TestResolveCCSettings_DefaultPathExists exercises the fallback chain:
+// no env var, but the canonical $HOME/.tether/cc-settings/settings.json
+// is present on disk → return that path.
+func TestResolveCCSettings_DefaultPathExists(t *testing.T) {
+	t.Setenv("TETHER_HOOK_SETTINGS", "")
+	home := t.TempDir()
+	dir := filepath.Join(home, ".tether", "cc-settings")
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	want := filepath.Join(dir, "settings.json")
+	if err := os.WriteFile(want, []byte("{}"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	got := resolveCCSettings(func() (string, error) { return home, nil })
+	if got != want {
+		t.Errorf("default path: got %q, want %q", got, want)
+	}
+}
+
+// TestResolveCCSettings_DefaultMissing covers the graceful-fallback path:
+// no env, default path doesn't exist on disk → empty string. Empty must
+// be interpreted by callers as "do not pass --settings to cc".
+func TestResolveCCSettings_DefaultMissing(t *testing.T) {
+	t.Setenv("TETHER_HOOK_SETTINGS", "")
+	home := t.TempDir() // tempdir is empty — no settings.json under it
+	got := resolveCCSettings(func() (string, error) { return home, nil })
+	if got != "" {
+		t.Errorf("missing default should resolve to empty; got %q", got)
+	}
+}
+
+// TestResolveCCSettings_HomeProviderError: a homeProvider that errs out
+// should cause empty (rather than the resolver propagating the error).
+// Empty is the safe fallback — we don't want a CLI crash because the OS
+// can't introspect $HOME.
+func TestResolveCCSettings_HomeProviderError(t *testing.T) {
+	t.Setenv("TETHER_HOOK_SETTINGS", "")
+	got := resolveCCSettings(func() (string, error) { return "", errors.New("no home") })
+	if got != "" {
+		t.Errorf("homeProvider error should resolve to empty; got %q", got)
+	}
+}
+
+// TestResolveCCSettings_HomeProviderEmpty: empty home with nil error
+// also resolves to empty (defensive — distinct path from error).
+func TestResolveCCSettings_HomeProviderEmpty(t *testing.T) {
+	t.Setenv("TETHER_HOOK_SETTINGS", "")
+	got := resolveCCSettings(func() (string, error) { return "", nil })
+	if got != "" {
+		t.Errorf("empty home should resolve to empty; got %q", got)
+	}
+}
+
+// TestResolveCCSettings_EnvHonoredEvenWhenMissing: the env-var path is
+// honored verbatim, no stat. Operators may legitimately pre-create the
+// file out-of-band; "your env points nowhere" is loud but actionable —
+// silent drop would be worse.
+func TestResolveCCSettings_EnvHonoredEvenWhenMissing(t *testing.T) {
+	t.Setenv("TETHER_HOOK_SETTINGS", "/definitely/not/a/real/path.json")
+	got := resolveCCSettings(func() (string, error) { return t.TempDir(), nil })
+	if got != "/definitely/not/a/real/path.json" {
+		t.Errorf("env should be honored verbatim; got %q", got)
+	}
+}
+
+// TestRunResume_ExecPassesSettings is the integration test from the spec:
+// stub the execve syscall, invoke runResume with a real default
+// settings.json on disk, and assert the captured argv contains
+// `--settings <expected-path>`.
+//
+// We can't let the real syscall.Exec fire (it'd replace the test
+// process); the package-level execClaudeSyscall var lets tests substitute
+// a recorder.
+func TestRunResume_ExecPassesSettings(t *testing.T) {
+	root := t.TempDir()
+	// Real cwd that ExecClaude will chdir into; pair it with a bucket
+	// derived from EncodeBucket so ResolveSession can find the jsonl.
+	cwd := filepath.Join(t.TempDir(), "work")
+	if err := os.MkdirAll(cwd, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	bucket := EncodeBucket(cwd)
+	if err := os.MkdirAll(filepath.Join(root, bucket), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	sid := "settings-on-sid"
+	jsonl := filepath.Join(root, bucket, sid+".jsonl")
+	if err := os.WriteFile(jsonl, []byte("{}\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Stand up a fake settings.json under a fake $HOME that the resolver
+	// can find via defaultHomeProvider() — set HOME for this test.
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("TETHER_HOOK_SETTINGS", "")
+	settingsDir := filepath.Join(home, ".tether", "cc-settings")
+	if err := os.MkdirAll(settingsDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	wantSettings := filepath.Join(settingsDir, "settings.json")
+	if err := os.WriteFile(wantSettings, []byte("{}"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	// Fake claude binary: must exist on PATH-or-absolute for exec.LookPath
+	// to resolve. Script content doesn't matter — execClaudeSyscall is
+	// stubbed.
+	fakeDir := t.TempDir()
+	fakeBin := filepath.Join(fakeDir, "claude-fake")
+	if err := os.WriteFile(fakeBin, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Stub the execve and capture argv.
+	var gotArgv []string
+	orig := execClaudeSyscall
+	execClaudeSyscall = func(argv0 string, argv []string, env []string) error {
+		gotArgv = argv
+		return nil // pretend exec succeeded
+	}
+	defer func() { execClaudeSyscall = orig }()
+
+	// Restore cwd after ExecClaude's os.Chdir mutates it.
+	origCwd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = os.Chdir(origCwd) }()
+
+	code := runResume([]string{
+		"--projects-dir", root,
+		"--binary", fakeBin,
+		"--cwd", cwd,
+		sid,
+	})
+	if code != 0 {
+		t.Fatalf("runResume exit=%d", code)
+	}
+	got := strings.Join(gotArgv, " ")
+	if !strings.Contains(got, "--settings "+wantSettings) {
+		t.Errorf("argv should contain --settings %s; got: %s", wantSettings, got)
+	}
+	if !strings.Contains(got, "--resume "+sid) {
+		t.Errorf("argv should contain --resume %s; got: %s", sid, got)
+	}
+}
+
+// TestRunResume_ExecOmitsSettingsWhenAbsent is the negative complement:
+// when no env var, no CLI flag, and no on-disk default, argv must NOT
+// contain `--settings`. This pins the graceful-fallback contract for
+// users running tether without `--auth-broker`.
+func TestRunResume_ExecOmitsSettingsWhenAbsent(t *testing.T) {
+	root := t.TempDir()
+	cwd := filepath.Join(t.TempDir(), "work")
+	if err := os.MkdirAll(cwd, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	bucket := EncodeBucket(cwd)
+	if err := os.MkdirAll(filepath.Join(root, bucket), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	sid := "no-settings-sid"
+	jsonl := filepath.Join(root, bucket, sid+".jsonl")
+	if err := os.WriteFile(jsonl, []byte("{}\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// $HOME pointed at a tempdir with NO cc-settings/settings.json.
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("TETHER_HOOK_SETTINGS", "")
+
+	fakeDir := t.TempDir()
+	fakeBin := filepath.Join(fakeDir, "claude-fake")
+	if err := os.WriteFile(fakeBin, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	var gotArgv []string
+	orig := execClaudeSyscall
+	execClaudeSyscall = func(argv0 string, argv []string, env []string) error {
+		gotArgv = argv
+		return nil
+	}
+	defer func() { execClaudeSyscall = orig }()
+
+	origCwd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = os.Chdir(origCwd) }()
+
+	code := runResume([]string{
+		"--projects-dir", root,
+		"--binary", fakeBin,
+		"--cwd", cwd,
+		sid,
+	})
+	if code != 0 {
+		t.Fatalf("runResume exit=%d", code)
+	}
+	got := strings.Join(gotArgv, " ")
+	if strings.Contains(got, "--settings") {
+		t.Errorf("argv should NOT contain --settings when no source resolves; got: %s", got)
+	}
+	if !strings.Contains(got, "--resume "+sid) {
+		t.Errorf("argv should still contain --resume %s; got: %s", sid, got)
+	}
+}
+
+// TestRunResume_CLIFlagOverridesEnv pins the precedence ordering:
+// --settings flag > TETHER_HOOK_SETTINGS env > default-path-on-disk.
+func TestRunResume_CLIFlagOverridesEnv(t *testing.T) {
+	root := t.TempDir()
+	cwd := filepath.Join(t.TempDir(), "work")
+	if err := os.MkdirAll(cwd, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	bucket := EncodeBucket(cwd)
+	if err := os.MkdirAll(filepath.Join(root, bucket), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	sid := "prec-sid"
+	jsonl := filepath.Join(root, bucket, sid+".jsonl")
+	if err := os.WriteFile(jsonl, []byte("{}\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("TETHER_HOOK_SETTINGS", "/from/env/settings.json")
+
+	fakeDir := t.TempDir()
+	fakeBin := filepath.Join(fakeDir, "claude-fake")
+	if err := os.WriteFile(fakeBin, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	var gotArgv []string
+	orig := execClaudeSyscall
+	execClaudeSyscall = func(argv0 string, argv []string, env []string) error {
+		gotArgv = argv
+		return nil
+	}
+	defer func() { execClaudeSyscall = orig }()
+
+	origCwd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = os.Chdir(origCwd) }()
+
+	wantFlag := "/from/cli/settings.json"
+	code := runResume([]string{
+		"--projects-dir", root,
+		"--binary", fakeBin,
+		"--cwd", cwd,
+		"--settings", wantFlag,
+		sid,
+	})
+	if code != 0 {
+		t.Fatalf("runResume exit=%d", code)
+	}
+	got := strings.Join(gotArgv, " ")
+	if !strings.Contains(got, "--settings "+wantFlag) {
+		t.Errorf("CLI flag should win over env; argv: %s", got)
+	}
+	if strings.Contains(got, "/from/env/settings.json") {
+		t.Errorf("env path should be shadowed by --settings flag; argv: %s", got)
+	}
+}
+
+// TestBuildResumeArgv_ShapeWithSettings + WithoutSettings pin the pure
+// helper's output. Belt-and-suspenders against accidental drift in the
+// argv ordering (cc parses positionally for some flags).
+func TestBuildResumeArgv_ShapeWithSettings(t *testing.T) {
+	got := BuildResumeArgv("/usr/bin/claude", "abc", "/path/to/settings.json")
+	want := []string{"/usr/bin/claude", "--resume", "abc", "--settings", "/path/to/settings.json"}
+	if len(got) != len(want) {
+		t.Fatalf("len: got %d, want %d (%v vs %v)", len(got), len(want), got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("argv[%d]: got %q, want %q", i, got[i], want[i])
+		}
+	}
+}
+
+func TestBuildResumeArgv_ShapeWithoutSettings(t *testing.T) {
+	got := BuildResumeArgv("/usr/bin/claude", "abc", "")
+	want := []string{"/usr/bin/claude", "--resume", "abc"}
+	if len(got) != len(want) {
+		t.Fatalf("len: got %d, want %d (%v vs %v)", len(got), len(want), got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("argv[%d]: got %q, want %q", i, got[i], want[i])
+		}
+	}
+}

--- a/cmd/tether/main.go
+++ b/cmd/tether/main.go
@@ -29,6 +29,7 @@ import (
 	"fmt"
 	"os"
 	"os/signal"
+	"strings"
 	"syscall"
 
 	"github.com/piaobeizu/tether/internal/daemon"
@@ -122,6 +123,15 @@ func runDaemon(args []string) int {
 
 // runResume parses flags + dispatches to the resume wrapper. Returns an
 // exit code.
+//
+// cc settings precedence (highest first):
+//
+//  1. --settings flag
+//  2. TETHER_HOOK_SETTINGS env var
+//  3. $HOME/.tether/cc-settings/settings.json (only when present on disk)
+//
+// When all three resolve to empty, no `--settings` arg is passed to cc —
+// preserving legacy behavior for users running without `--auth-broker`.
 func runResume(argv []string) int {
 	fs := flag.NewFlagSet("resume", flag.ContinueOnError)
 	fs.SetOutput(os.Stderr)
@@ -130,9 +140,12 @@ func runResume(argv []string) int {
 	dryRun := fs.Bool("dry-run", false, "print resolved cwd + argv, do not exec claude")
 	binary := fs.String("binary", "claude", "path/name of the claude binary to exec")
 	projectsDir := fs.String("projects-dir", "", "override ~/.claude/projects (for tests)")
+	settings := fs.String("settings", "",
+		"path to cc settings.json (overrides TETHER_HOOK_SETTINGS env + the "+
+			"$HOME/.tether/cc-settings/settings.json default; empty means rely on the precedence chain)")
 
 	fs.Usage = func() {
-		fmt.Fprintln(os.Stderr, "usage: tether resume <sid> [--bucket B] [--cwd PATH] [--dry-run] [--binary PATH]")
+		fmt.Fprintln(os.Stderr, "usage: tether resume <sid> [--bucket B] [--cwd PATH] [--dry-run] [--binary PATH] [--settings PATH]")
 		fmt.Fprintln(os.Stderr, "")
 		fs.PrintDefaults()
 	}
@@ -170,14 +183,20 @@ func runResume(argv []string) int {
 		return 1
 	}
 
+	settingsPath := *settings
+	if settingsPath == "" {
+		settingsPath = resolveCCSettings(defaultHomeProvider)
+	}
+
 	if *dryRun {
 		fmt.Printf("cwd:    %s\n", res.Cwd)
 		fmt.Printf("bucket: %s\n", res.Bucket)
-		fmt.Printf("exec:   %s --resume %s\n", *binary, sid)
+		argv := BuildResumeArgv(*binary, sid, settingsPath)
+		fmt.Printf("exec:   %s\n", strings.Join(argv, " "))
 		return 0
 	}
 
-	if err := ExecClaude(*binary, res.Cwd, sid); err != nil {
+	if err := ExecClaude(*binary, res.Cwd, sid, settingsPath); err != nil {
 		fmt.Fprintf(os.Stderr, "tether resume: %v\n", err)
 		return 1
 	}

--- a/cmd/tether/resume.go
+++ b/cmd/tether/resume.go
@@ -303,8 +303,33 @@ func EncodeBucket(cwd string) string {
 	return strings.ReplaceAll(cwd, "/", "-")
 }
 
-// ExecClaude execve's into `claude --resume <sid>` after chdir'ing to cwd.
-// On success this never returns. Returns an error only if chdir or exec fail.
+// BuildResumeArgv produces the argv (including argv[0]) for the claude
+// invocation `tether resume` execve's into. Pure helper, exported for
+// tests so they can assert flag wiring without exercising the full
+// process replacement.
+//
+// settingsPath, when non-empty, appends `--settings <path>` so cc loads
+// its hook config from the daemon-owned settings.json (PR #44 hookserver
+// integration). Empty preserves legacy behavior — cc reads its default
+// `~/.claude/settings.json`.
+func BuildResumeArgv(binary, sid, settingsPath string) []string {
+	argv := []string{binary, "--resume", sid}
+	if settingsPath != "" {
+		argv = append(argv, "--settings", settingsPath)
+	}
+	return argv
+}
+
+// execClaudeSyscall is the production execve path. It's a package-level
+// var so tests can stub it with a recorder that captures argv without
+// actually replacing the test process. Production code MUST NOT mutate.
+var execClaudeSyscall = func(argv0 string, argv []string, env []string) error {
+	return syscall.Exec(argv0, argv, env)
+}
+
+// ExecClaude execve's into `claude --resume <sid> [--settings <p>]` after
+// chdir'ing to cwd. On success this never returns. Returns an error only
+// if chdir or exec fail.
 //
 // We use syscall.Exec rather than exec.Command + Run so that the user gets a
 // PTY-attached claude with no Go process in the middle — clean signal
@@ -315,7 +340,11 @@ func EncodeBucket(cwd string) string {
 // only emits paths that exist on disk), but a malformed bucket name like
 // `-tmp-..-etc` could in principle slip through the naive fallback —
 // hard-fail here rather than silently chdir'ing to an unintended location.
-func ExecClaude(binary, cwd, sid string) error {
+//
+// settingsPath, when non-empty, is forwarded to cc as `--settings <path>`
+// so the daemon's hookserver wiring (PR #44) actually fires. Empty
+// preserves the pre-PR behavior (cc reads ~/.claude/settings.json).
+func ExecClaude(binary, cwd, sid, settingsPath string) error {
 	cwd = filepath.Clean(cwd)
 	if hasDotDot(cwd) {
 		return fmt.Errorf("refusing to chdir: %q contains .. segments after Clean", cwd)
@@ -327,8 +356,8 @@ func ExecClaude(binary, cwd, sid string) error {
 	if err := os.Chdir(cwd); err != nil {
 		return fmt.Errorf("chdir %s: %w", cwd, err)
 	}
-	argv := []string{resolvedBin, "--resume", sid}
-	return syscall.Exec(resolvedBin, argv, os.Environ())
+	argv := BuildResumeArgv(resolvedBin, sid, settingsPath)
+	return execClaudeSyscall(resolvedBin, argv, os.Environ())
 }
 
 // hasDotDot reports whether p has any `..` segment after splitting on the

--- a/cmd/tether/resume_test.go
+++ b/cmd/tether/resume_test.go
@@ -238,7 +238,7 @@ func TestResolveSessionWithCwd_RejectsDotDot(t *testing.T) {
 // path containing `..` segments. Uses a non-absolute relative path so
 // Clean preserves the `..` (Clean of an absolute path collapses `..`).
 func TestExecClaude_RejectsDotDot(t *testing.T) {
-	err := ExecClaude("claude", "../escape", "sid")
+	err := ExecClaude("claude", "../escape", "sid", "")
 	if err == nil {
 		t.Fatal("expected error rejecting .. in cwd")
 	}
@@ -264,7 +264,7 @@ func TestExecClaude_RejectsDotDotFromBucket(t *testing.T) {
 		"foo/../../escape", // Clean → ../escape
 	}
 	for _, c := range cases {
-		err := ExecClaude("claude", c, "sid")
+		err := ExecClaude("claude", c, "sid", "")
 		if err == nil {
 			t.Errorf("ExecClaude should reject %q (contains .. after Clean=%q)",
 				c, filepath.Clean(c))

--- a/internal/agent/claude_provider.go
+++ b/internal/agent/claude_provider.go
@@ -86,9 +86,10 @@ func (p *ClaudeCodeProvider) Spawn(ctx context.Context, opts SpawnOpts) (*AgentS
 	}
 
 	sess, err := claude.New(ctx, claude.SpawnOpts{
-		ProjectCwd: opts.ProjectCwd,
-		Model:      opts.Model,
-		BinaryPath: binPath,
+		ProjectCwd:   opts.ProjectCwd,
+		Model:        opts.Model,
+		BinaryPath:   binPath,
+		SettingsPath: opts.SettingsPath,
 	}, p.auth)
 	if err != nil {
 		return nil, err

--- a/internal/agent/provider.go
+++ b/internal/agent/provider.go
@@ -135,6 +135,20 @@ type SpawnOpts struct {
 	// ProviderConfig is a provider-specific escape hatch. Keys outside the
 	// provider's known set must be silently ignored.
 	ProviderConfig map[string]any
+
+	// SettingsPath, when non-empty, points the agent at a daemon-owned
+	// settings.json (cc: hook wiring + permission routing). Empty means
+	// the agent reads its default user-level config — the legacy
+	// behavior preserved for callers that don't run a daemon.
+	//
+	// For ClaudeCodeProvider this forwards to claude.SpawnOpts.SettingsPath
+	// → cc's `--settings <path>` flag. Other providers may ignore.
+	//
+	// Callers (cmd/tether/*) typically populate this via
+	// resolveCCSettings(); see cmd/tether/cc_settings.go for the
+	// precedence chain. v0.1 daemon doesn't itself spawn cc — once it
+	// does, this is the seam it'll use.
+	SettingsPath string
 }
 
 // HookCap describes one hook event the provider can fire toward tether.

--- a/internal/backend/claude/spawn_test.go
+++ b/internal/backend/claude/spawn_test.go
@@ -54,6 +54,29 @@ func TestBuildArgs_ResumeAndModel(t *testing.T) {
 	}
 }
 
+// TestBuildArgs_WithSettings exercises the seam PR #44 added: SettingsPath
+// → `--settings <path>`. Empty omits the flag entirely (covered by
+// TestBuildArgs_Defaults). pf2.resume-settings-wire is the consumer side
+// of this seam — populate the field from the resolver in cmd/tether and
+// cc finally honors the daemon-owned settings.json.
+func TestBuildArgs_WithSettings(t *testing.T) {
+	args := BuildArgs(SpawnOpts{SettingsPath: "/tmp/cc-settings/settings.json"})
+	joined := strings.Join(args, " ")
+	if !strings.Contains(joined, "--settings /tmp/cc-settings/settings.json") {
+		t.Errorf("settings flag missing: %q", joined)
+	}
+}
+
+// TestBuildArgs_NoSettingsWhenEmpty asserts the negative complement —
+// empty SettingsPath emits no `--settings` token.
+func TestBuildArgs_NoSettingsWhenEmpty(t *testing.T) {
+	args := BuildArgs(SpawnOpts{SettingsPath: ""})
+	joined := strings.Join(args, " ")
+	if strings.Contains(joined, "--settings") {
+		t.Errorf("--settings should be omitted when SettingsPath empty: %q", joined)
+	}
+}
+
 // F.2 verification: empty PATH + missing binary → ErrBinaryNotFound carrying PATH.
 func TestSpawn_BinaryNotFound(t *testing.T) {
 	t.Setenv("PATH", "/this/path/intentionally/empty")


### PR DESCRIPTION
## Summary

P0 dogfood-blocker fix: PR #44 wired `cc.HookServer` + the daemon's
`settings.json` writer, but the cc subprocess that ACTUALLY needs to
read it (when the user runs `tether resume <sid>`) didn't get told
where the file is. Broker was wired but inert. This slice populates the
`SpawnOpts.SettingsPath` seam #44 already added.

- New `cmd/tether/cc_settings.go::resolveCCSettings()` resolves the
  settings path via the precedence chain documented below. Empty result
  means "do not pass `--settings` to cc" — graceful fallback for users
  running tether without `--auth-broker`.
- `tether resume` gains a `--settings <path>` CLI flag. `ExecClaude`
  now appends `--settings <path>` to argv when the resolver returns
  non-empty.
- `agent.SpawnOpts.SettingsPath` plumbed into
  `claude.SpawnOpts.SettingsPath` so when the daemon eventually spawns
  cc sessions itself, the same seam covers it without further wiring.

## Settings path precedence (highest wins)

1. `--settings <path>` CLI flag on `tether resume`
2. `TETHER_HOOK_SETTINGS` env var
3. `$HOME/.tether/cc-settings/settings.json` (only when present on disk)
4. empty → no `--settings` arg passed (legacy behavior)

Env-var path is honored verbatim (no stat) — operators may pre-create
the file out-of-band; silently dropping a misconfigured env would be
worse than a loud breakage. Default-path is stat'd so a missing-file +
no-broker case falls through cleanly.

## cc-spawn callers wired

| Caller | File:line | Status |
|---|---|---|
| `tether resume <sid>` | `cmd/tether/resume.go:340` (`ExecClaude`) | wired via `runResume` resolving + `BuildResumeArgv` |
| `agent.ClaudeCodeProvider.Spawn` | `internal/agent/claude_provider.go:88` | seam plumbed: `agent.SpawnOpts.SettingsPath` → `claude.SpawnOpts.SettingsPath` (no production caller in v0.1) |
| `cmd/spike/main.go` | 4 sites | NOT wired — manual scenario driver, intentionally left as-is per task scope |

`tether resume` is the only production cc-spawn path in v0.1. The
daemon doesn't itself spawn cc yet; when it does, the
`agent.SpawnOpts` seam covers it. `cmd/spike` is a manual test driver,
treated as out-of-scope per the task brief.

## Surprising notes about how cc spawns are organized

- `tether resume` does NOT use `claude.SpawnOpts` / `claude.Session.New`
  at all. It `syscall.Exec`s directly to `claude --resume <sid>` for
  clean PTY signal handling (no Go process in the middle). PR #44's
  `SpawnOpts.SettingsPath` field thus only covers the
  `claude.Session.New` path; for resume we needed parallel
  argv-building (`BuildResumeArgv`) and a separate flag append.
- `agent.ClaudeCodeProvider.Spawn` exists but has no production caller
  in v0.1 — only tests + `cmd/spike`. The plumb-through is
  forward-compat groundwork for the daemon's eventual session spawner.
- The package-level `execClaudeSyscall` var is a test seam — production
  code never mutates it; it lets the integration tests stub
  `syscall.Exec` (which would otherwise replace the test process).

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test -race -count=1 ./...` all packages pass
- [x] `go test -race -count=10` on new tests stable
- [x] Unit: resolver honors env > default; returns empty when default missing
- [x] Unit: resolver returns path when default present
- [x] Integration: stub execve, runResume produces argv containing `--settings <expected>` when settings.json exists
- [x] Integration: argv OMITS `--settings` when settings.json absent
- [x] Precedence: `--settings` CLI flag wins over `TETHER_HOOK_SETTINGS` env
- [x] `claude.BuildArgs` emits `--settings` only when `SpawnOpts.SettingsPath` non-empty

🤖 Generated with [Claude Code](https://claude.com/claude-code)