### PR TITLE
fix(agent): auth-decision frames must flow even when InputSink=nil

### DIFF
--- a/internal/agent/attach_socket.go
+++ b/internal/agent/attach_socket.go
@@ -389,9 +389,24 @@ func (s *AttachServer) serveConn(ctx context.Context, conn *attachConn) {
 		return
 	}
 
-	// Spawn input reader if rw.
+	// Spawn input reader for rw, OR for ro when an AuthBroker is wired.
+	//
+	// Why ro+AuthBroker still needs an input reader:
+	// `auth.tool-decision` frames are CONTROL-PLANE (see readInputs's
+	// pre-lock intercept). When the daemon has no PTY input sink (the
+	// v0.1 default — daemon doesn't spawn cc itself), rw mode auto-
+	// downgrades to ro via the InputSink-nil check above. But the UI
+	// MUST still be able to send auth decisions back, otherwise every
+	// PreToolUse hook hits the broker's 60s timeout and fail-closed
+	// deny — making the auth flow architecturally inert.
+	//
+	// In ro+AuthBroker mode, readInputs's existing branching only fires
+	// the auth-decision intercept; non-decision frames fall through to
+	// the lock-gated PTY path, where TryAcquire succeeds (no holder
+	// yet) but the InputSink-nil call would panic — so we also gate
+	// that block on InputSink presence inside readInputs (see below).
 	inputErr := make(chan error, 1)
-	if desired == AttachModeReadWrite {
+	if desired == AttachModeReadWrite || s.cfg.AuthBroker != nil {
 		go func() { inputErr <- s.readInputs(ctx, conn, br) }()
 	}
 
@@ -453,6 +468,15 @@ func (s *AttachServer) readInputs(_ context.Context, conn *attachConn, br *bufio
 			// JSON-shaped but not a valid decision frame — fall through
 			// to PTY input so we don't accidentally swallow payloads
 			// that legitimately start with '{'.
+		}
+
+		// PTY input path. Skipped when the conn is ro (no InputSink
+		// wired, OR client requested ro). In ro+AuthBroker mode we
+		// still reach this point for non-auth-decision frames; drop
+		// them silently — a ro client has no business sending PTY
+		// bytes, and there's no InputSink to receive them anyway.
+		if conn.mode != AttachModeReadWrite || s.cfg.InputSink == nil {
+			continue
 		}
 
 		// TryAcquire — first byte from this client wins if lock is

--- a/internal/daemon/hookserver_integration_test.go
+++ b/internal/daemon/hookserver_integration_test.go
@@ -266,6 +266,194 @@ func TestIntegration_HookServerWireup_PreToolUse_AllowOnce(t *testing.T) {
 	}
 }
 
+// TestIntegration_HookServerWireup_NoInputSink_AuthDecisionFlows is
+// the regression test for the dogfood-smoke bug: `tether daemon
+// --auth-broker` runs with InputSink=nil (the daemon doesn't spawn
+// cc itself), which auto-downgrades rw → ro on attach. Before the
+// fix, that downgrade caused readInputs to never start, so the UI's
+// auth.tool-decision frame was never read and the broker timed out
+// at 60s with fail-closed deny — making the entire auth flow inert
+// in production.
+//
+// Fix (attach_socket.go::serveConn): when AuthBroker is wired,
+// readInputs spawns even on ro mode; non-decision frames just drop
+// silently inside readInputs.
+//
+// This test mirrors the AllowOnce test above but explicitly leaves
+// InputSink nil to lock in the production scenario.
+func TestIntegration_HookServerWireup_NoInputSink_AuthDecisionFlows(t *testing.T) {
+	t.Parallel()
+
+	tmp := t.TempDir()
+	projectsDir := filepath.Join(tmp, "projects")
+	attachSocket := filepath.Join(tmp, "attach.sock")
+	hookSettingsDir := filepath.Join(tmp, "cc-settings")
+	if err := os.MkdirAll(projectsDir, 0o700); err != nil {
+		t.Fatalf("setup: %v", err)
+	}
+
+	settingsCh := make(chan string, 1)
+	var stderr bytes.Buffer
+	cfg := daemon.Config{
+		Verbose:          true,
+		Stderr:           &stderr,
+		ProjectsDir:      projectsDir,
+		AttachSocketPath: attachSocket,
+		LockAuditLogPath: filepath.Join(tmp, "lock.log"),
+		EnableAuthBroker: true,
+		HookSettingsDir:  hookSettingsDir,
+		// IMPORTANT: NO InputSink. Mirrors `tether daemon --auth-broker`
+		// in production — daemon doesn't spawn cc, so there's no PTY
+		// to feed bytes into.
+		OnHookSettingsReady: func(p string) { settingsCh <- p },
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	done := make(chan error, 1)
+	go func() { done <- daemon.Run(ctx, cfg) }()
+	defer func() {
+		cancel()
+		select {
+		case <-done:
+		case <-time.After(3 * time.Second):
+			t.Errorf("daemon shutdown stalled; logs:\n%s", stderr.String())
+		}
+	}()
+
+	var settingsPath string
+	select {
+	case settingsPath = <-settingsCh:
+	case <-time.After(3 * time.Second):
+		t.Fatalf("OnHookSettingsReady never fired; logs:\n%s", stderr.String())
+	}
+	baseURL := assertSettingsFile(t, settingsPath)
+
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if _, err := os.Stat(attachSocket); err == nil {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	const sid = "no-sink-sid"
+	conn, err := net.Dial("unix", attachSocket)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	defer conn.Close()
+
+	hdr := agent.AttachHeader{SessionID: sid, Mode: string(agent.AttachModeReadWrite)}
+	hdr.Client.Kind = "terminal"
+	hdr.Client.DeviceID = "no-sink-client"
+	body, _ := json.Marshal(hdr)
+	if _, err := conn.Write(append(body, '\n')); err != nil {
+		t.Fatalf("write header: %v", err)
+	}
+	_ = conn.SetReadDeadline(time.Now().Add(2 * time.Second))
+	ackBuf, err := agent.ReadFrame(conn)
+	if err != nil {
+		t.Fatalf("read ack: %v", err)
+	}
+	var ack agent.AckFrame
+	if err := json.Unmarshal(ackBuf, &ack); err != nil {
+		t.Fatalf("decode ack: %v", err)
+	}
+	// Daemon downgrades rw → ro because InputSink is nil — that's
+	// expected. The point of this test is that auth-decision frames
+	// STILL flow despite the downgrade.
+	if ack.Mode != "ro" {
+		t.Fatalf("ack.Mode=%q; expected ro (rw should downgrade with no InputSink)", ack.Mode)
+	}
+
+	// POST PreToolUse to hookserver.
+	preBody := fmt.Sprintf(`{"session_id":%q,"tool_name":"Bash","tool_input":{"command":"echo hi"}}`, sid)
+	type postResult struct {
+		status int
+		body   []byte
+		err    error
+	}
+	resCh := make(chan postResult, 1)
+	go func() {
+		req, _ := http.NewRequestWithContext(ctx, http.MethodPost,
+			baseURL+"/hooks/pre-tool-use", strings.NewReader(preBody))
+		req.Header.Set("Content-Type", "application/json")
+		client := &http.Client{Timeout: 10 * time.Second}
+		resp, err := client.Do(req)
+		if err != nil {
+			resCh <- postResult{err: err}
+			return
+		}
+		defer resp.Body.Close()
+		b, _ := io.ReadAll(resp.Body)
+		resCh <- postResult{status: resp.StatusCode, body: b}
+	}()
+
+	// Read the auth.tool-request envelope.
+	var reqID string
+	_ = conn.SetReadDeadline(time.Now().Add(5 * time.Second))
+	for {
+		buf, err := agent.ReadFrame(conn)
+		if err != nil {
+			t.Fatalf("read auth.tool-request: %v\nlogs:\n%s", err, stderr.String())
+		}
+		var env struct {
+			Kind              string         `json:"kind"`
+			SessionID         string         `json:"sessionId"`
+			PlaintextMetadata map[string]any `json:"plaintextMetadata"`
+		}
+		if err := json.Unmarshal(buf, &env); err != nil {
+			continue
+		}
+		if env.Kind != agent.KindAuthToolRequest {
+			continue
+		}
+		reqID, _ = env.PlaintextMetadata["requestId"].(string)
+		if reqID == "" {
+			t.Fatalf("missing requestId: %s", buf)
+		}
+		break
+	}
+
+	// THIS is what the original bug broke: send back a decision frame
+	// despite being downgraded to ro. The fix means readInputs is
+	// running anyway (because AuthBroker is wired) and intercepts.
+	dec := agent.AuthDecisionFrame{
+		Type:      agent.KindAuthToolDecision,
+		RequestID: reqID,
+		Decision:  agent.AuthDecisionAllowOnce,
+	}
+	decBytes, _ := json.Marshal(dec)
+	if err := agent.WriteInputFrame(conn, decBytes); err != nil {
+		t.Fatalf("write decision: %v", err)
+	}
+
+	select {
+	case r := <-resCh:
+		if r.err != nil {
+			t.Fatalf("POST failed: %v\nlogs:\n%s", r.err, stderr.String())
+		}
+		if r.status != http.StatusOK {
+			t.Fatalf("POST status=%d body=%s want 200", r.status, r.body)
+		}
+		var doc struct {
+			HookSpecificOutput struct {
+				PermissionDecision string `json:"permissionDecision"`
+			} `json:"hookSpecificOutput"`
+		}
+		if err := json.Unmarshal(r.body, &doc); err != nil {
+			t.Fatalf("decode response: %v", err)
+		}
+		if doc.HookSpecificOutput.PermissionDecision != "allow" {
+			t.Fatalf("permissionDecision=%q want allow — broker did not receive the decision frame; the ro-mode readInputs spawn fix is broken",
+				doc.HookSpecificOutput.PermissionDecision)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatalf("POST timed out — broker likely never received the decision; logs:\n%s", stderr.String())
+	}
+}
+
 // assertSettingsFile verifies <HookSettingsDir>/settings.json exists,
 // parses, and has all 5 hook events pointing at the same
 // http://127.0.0.1:N baseURL. Returns that baseURL for the caller.


### PR DESCRIPTION
## Summary

P0 dogfood-blocker surfaced by end-to-end smoke testing on main after #44 / #45 / #46 landed. The auth flow ships but is architecturally **inert in the production scenario**.

### Symptom (smoke)
```
tether daemon -v --auth-broker
→ AuthBroker emits `auth.tool-request` envelope on PreToolUse hook
→ UI receives it, sends back `auth.tool-decision allow-once`
→ broker NEVER sees the decision; 60s timeout → fail-closed deny
→ cc's tool call fails
```

### Root cause (`attach_socket.go:392-396`)

```go
// Spawn input reader if rw.
if desired == AttachModeReadWrite {
    go func() { inputErr <- s.readInputs(ctx, conn, br) }()
}
```

`tether daemon --auth-broker` runs with `InputSink=nil` (daemon doesn't spawn cc — that's the spec separation, daemon supervises + session owners spawn). The `InputSink`-nil check at line 364 auto-downgrades rw → ro. With `desired=ro`, `readInputs` is never spawned → the UI's `auth.tool-decision` frame is never read → broker times out.

### Why existing tests didn't catch this

`TestIntegration_HookServerWireup_PreToolUse_AllowOnce` literally workarounds the bug:

```go
// The PTY isn't real here — a no-op sink is enough; we never send a
// non-decision input frame.
InputSink: func(_ string, _ []byte) error { return nil },
```

That stub masks the production behavior. Production is `InputSink=nil`.

### Fix

When `AuthBroker` is wired, spawn `readInputs` unconditionally (even on ro). `readInputs`'s existing pre-lock auth-decision intercept handles decision frames; the new ro-mode short-circuit at the lock-check path silently drops non-decision frames (a ro client has no business sending PTY bytes anyway, and there's no `InputSink` to receive them).

### Regression test

`TestIntegration_HookServerWireup_NoInputSink_AuthDecisionFlows` mirrors `AllowOnce` but explicitly leaves `InputSink` nil. Verified the test bites: with `attach_socket.go` reverted, FAILS within 5s on POST timeout. With fix, PASSES in 22ms.

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test -race -count=1 ./...` — all 11 packages pass
- [x] `go test -race -count=10 -run TestIntegration_HookServerWireup ./internal/daemon/...` — 20/20 green
- [x] Confirmed test bites: with `attach_socket.go` reverted, regression test fails at 5s POST timeout

Refs PRs #43 (broker), #44 (hookserver wireup) — this is the dogfood-blocker that closes the loop.