### PR TITLE
fix(agent): broker fail-fast on no subscribers + log/dead-code cleanup

### DIFF
--- a/internal/agent/attach_socket.go
+++ b/internal/agent/attach_socket.go
@@ -475,6 +475,15 @@ func (s *AttachServer) readInputs(_ context.Context, conn *attachConn, br *bufio
 		// still reach this point for non-auth-decision frames; drop
 		// them silently — a ro client has no business sending PTY
 		// bytes, and there's no InputSink to receive them anyway.
+		//
+		// **v0.1 reality check**: the daemon never wires InputSink
+		// (per spec D-04 / §11.W: daemon supervises, session owners
+		// spawn cc), so this entire `if InputSink != nil` block is
+		// effectively unreachable in production v0.1 — the lock
+		// state machine + lock.log audit trail are running
+		// infrastructure but receive no traffic. Tests exercise this
+		// branch with a recorder InputSink, which is the right shape
+		// for the eventual v0.2 daemon-side cc spawn integration.
 		if conn.mode != AttachModeReadWrite || s.cfg.InputSink == nil {
 			continue
 		}

--- a/internal/agent/auth.go
+++ b/internal/agent/auth.go
@@ -115,9 +115,12 @@ type AuthBroker struct {
 	// Timeout overrides DefaultAuthTimeout. Zero = use default.
 	Timeout time.Duration
 
-	// OnDecision is called once per Ask() resolution (allow/deny/timeout)
-	// for daemon-side audit logging. Optional.
-	OnDecision func(sid, toolName string, decision AuthDecision, fromCache bool)
+	// (Removed: an `OnDecision` callback for daemon-side audit logging
+	// was declared but never wired by any caller. If audit-log
+	// integration is wanted later, prefer pushing decisions through
+	// the existing lock.LogSink path or a dedicated
+	// auth-decisions.jsonl sink — that keeps the broker free of
+	// caller-installed callbacks.)
 
 	mu       sync.Mutex
 	pending  map[string]*pendingAuth         // requestId → channel
@@ -172,9 +175,6 @@ func (b *AuthBroker) Ask(ctx context.Context, sid, toolName string, toolInput js
 	// Cache hit — short-circuit before bothering the UI.
 	if cached, ok := b.remember[rememberKey{sid, toolName}]; ok {
 		b.mu.Unlock()
-		if b.OnDecision != nil {
-			b.OnDecision(sid, toolName, cached, true)
-		}
 		return cached, nil
 	}
 	rid := newRequestID()
@@ -199,8 +199,21 @@ func (b *AuthBroker) Ask(ctx context.Context, sid, toolName string, toolInput js
 			"summary":   summary,
 		},
 	}
-	if err := b.Emitter.Inject(env); err != nil {
+	delivered, err := b.Emitter.Inject(env)
+	if err != nil {
 		return AuthDecisionDenyOnce, fmt.Errorf("agent: broker inject: %w", err)
+	}
+	// Fail-fast on no UI listening for this sid. Without this, broker
+	// would block the full Timeout (default 60s) for a decision that
+	// can never come, and cc would see a delayed deny with no
+	// indication that the cause was "no UI attached" vs "user said
+	// no". Keep the deny semantic (fail-closed is the right safety
+	// posture), but return immediately + name the reason.
+	if delivered == 0 {
+		return AuthDecisionDenyOnce, fmt.Errorf(
+			"agent: auth deny — no UI client subscribed to session %q (broker emitted auth.tool-request but reached zero clients)",
+			sid,
+		)
 	}
 
 	timeout := b.Timeout
@@ -217,14 +230,8 @@ func (b *AuthBroker) Ask(ctx context.Context, sid, toolName string, toolInput js
 			b.remember[rememberKey{sid, toolName}] = d
 			b.mu.Unlock()
 		}
-		if b.OnDecision != nil {
-			b.OnDecision(sid, toolName, d, false)
-		}
 		return d, nil
 	case <-timer.C:
-		if b.OnDecision != nil {
-			b.OnDecision(sid, toolName, AuthDecisionDenyOnce, false)
-		}
 		return AuthDecisionDenyOnce, fmt.Errorf("agent: auth decision timeout after %s", timeout)
 	case <-ctx.Done():
 		return AuthDecisionDenyOnce, ctx.Err()

--- a/internal/agent/auth_test.go
+++ b/internal/agent/auth_test.go
@@ -7,6 +7,7 @@ import (
 	"net"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -169,6 +170,100 @@ func TestAuthBroker_RememberAlways(t *testing.T) {
 	}
 	if d := <-got; d != agent.AuthDecisionDenyOnce {
 		t.Fatalf("post-forget decision: %v", d)
+	}
+}
+
+// TestAuthBroker_NoSubscribers_FailsFast pins the M1 fix: when the
+// broker tries to inject an auth.tool-request envelope and there are
+// ZERO subscribers for the session, Ask must return deny-once
+// IMMEDIATELY with a clear "no UI subscribed" error. Before the fix,
+// Inject silently dropped on no-subscribers and Ask waited the full
+// Timeout (default 60s) for a reply that could never come — a
+// stub-masked production bug analogous to #47.
+//
+// This test sets a long Timeout deliberately; if the fast-fail path
+// regresses, the test would block until the timeout instead of
+// returning quickly.
+func TestAuthBroker_NoSubscribers_FailsFast(t *testing.T) {
+	t.Parallel()
+	em := newTestEmitter(t)
+	br, err := agent.NewAuthBroker(em)
+	if err != nil {
+		t.Fatalf("broker: %v", err)
+	}
+	// 10s — well above the fast-fail latency (~microseconds), but
+	// SHORT enough that a regression making this hang is visible
+	// before t.Parallel siblings finish.
+	br.Timeout = 10 * time.Second
+	t.Cleanup(br.Close)
+
+	// Deliberately do NOT subscribe — this is the production scenario
+	// where the UI is detached / not yet connected.
+
+	start := time.Now()
+	d, err := br.Ask(t.Context(), "no-listener-sid", "Bash", json.RawMessage(`{}`), "")
+	elapsed := time.Since(start)
+
+	if d != agent.AuthDecisionDenyOnce {
+		t.Errorf("decision = %v, want deny-once", d)
+	}
+	if err == nil {
+		t.Fatal("expected fast-fail error, got nil")
+	}
+	if !strings.Contains(err.Error(), "no UI client") {
+		t.Errorf("error message should mention no-UI cause; got: %v", err)
+	}
+	// The fast-fail must complete WELL under the broker Timeout. 1s is
+	// generous (real path is sub-ms); anything longer means we waited
+	// for the timer.
+	if elapsed > time.Second {
+		t.Errorf("fast-fail took %s; should be sub-ms (regressed back to full Timeout?)", elapsed)
+	}
+}
+
+// TestAuthBroker_AllSubscribersFull_FailsFast covers the related
+// scenario: subscribers exist but every one of them has a full out
+// channel (slow / disconnected consumer). Inject's drop-newest
+// returns delivered=0 even though len(subs)>0; broker must still
+// fast-fail rather than wait the full Timeout.
+func TestAuthBroker_AllSubscribersFull_FailsFast(t *testing.T) {
+	t.Parallel()
+	em := newTestEmitter(t)
+	br, err := agent.NewAuthBroker(em)
+	if err != nil {
+		t.Fatalf("broker: %v", err)
+	}
+	br.Timeout = 10 * time.Second
+	t.Cleanup(br.Close)
+
+	// Subscribe but don't drain — the out channel cap is 64; fill it
+	// up with no-op envelopes so Inject's non-blocking send drops.
+	const sid = "full-sub-sid"
+	out, cancel, err := em.Subscribe(sid)
+	if err != nil {
+		t.Fatalf("subscribe: %v", err)
+	}
+	defer cancel()
+	// Saturate the per-subscriber buffer (64 envelopes per
+	// envelope_emitter.go::Subscribe). We need to push >64 items
+	// because the relay goroutine drains one at a time; the tightest
+	// way is to flood the underlying watcher's per-sid channel via
+	// repeated Inject. But Inject also drops on full, so the simplest
+	// path is to just stop reading `out` and rely on the next Inject
+	// to find delivered=0. Doing 100 to be safe.
+	_ = out
+	for i := 0; i < 200; i++ {
+		_, _ = em.Inject(agent.LocalEnvelope{Kind: "noise", SessionID: sid})
+	}
+
+	start := time.Now()
+	_, err = br.Ask(t.Context(), sid, "Bash", json.RawMessage(`{}`), "")
+	elapsed := time.Since(start)
+	if err == nil {
+		t.Fatal("expected fast-fail error, got nil")
+	}
+	if elapsed > time.Second {
+		t.Errorf("fast-fail took %s; should be sub-ms", elapsed)
 	}
 }
 

--- a/internal/agent/envelope_emitter.go
+++ b/internal/agent/envelope_emitter.go
@@ -247,13 +247,22 @@ func (e *EnvelopeEmitter) Stats() (linesParsed, envelopesEmit, envelopesDrop int
 //
 // Best-effort delivery: if a subscriber's outbound channel is full, the
 // envelope is dropped for that subscriber (the channel buffer of 64 is
-// the same back-pressure model as the watcher relay). Returns
-// ErrEmitterClosed only if the emitter has been Close()'d.
-func (e *EnvelopeEmitter) Inject(env LocalEnvelope) error {
+// the same back-pressure model as the watcher relay). Returns the
+// number of subscribers the envelope was successfully delivered to
+// (post drop-on-full filter), plus an error: ErrEmitterClosed if the
+// emitter has been Close()'d.
+//
+// **A delivered count of zero is NOT an error from Inject's perspective**
+// — it just means nobody is currently listening for this sessionId.
+// Callers that need fail-fast semantics on no-subscribers (e.g.
+// AuthBroker, which would otherwise wait its full Timeout for a
+// reply that can never come) must check the count themselves and
+// short-circuit. See AuthBroker.Ask for the canonical pattern.
+func (e *EnvelopeEmitter) Inject(env LocalEnvelope) (delivered int, err error) {
 	e.mu.Lock()
 	if e.closed {
 		e.mu.Unlock()
-		return ErrEmitterClosed
+		return 0, ErrEmitterClosed
 	}
 	// Snapshot subs to avoid holding the lock while sending. New
 	// subscribers added concurrently won't see this envelope; that's
@@ -268,13 +277,15 @@ func (e *EnvelopeEmitter) Inject(env LocalEnvelope) error {
 	for _, s := range subs {
 		select {
 		case s.out <- env:
+			delivered++
 		default:
 			// Subscriber slow / disconnected; drop. The watcher's
 			// OnDrop reporting only fires on JSONL drops, so we don't
-			// double-count here.
+			// double-count here. The drop is reflected in the returned
+			// delivered count being less than len(subs).
 		}
 	}
-	return nil
+	return delivered, nil
 }
 
 // relay is the per-subscriber goroutine: pulls jsonl.Envelopes from the

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -158,10 +158,25 @@ func Run(ctx context.Context, cfg Config) error {
 	if stderr == nil {
 		stderr = io.Discard
 	}
+	// logf is the verbose-gated logger — used for routine progress
+	// (heartbeats, frame counts, etc.) where the operator can opt in
+	// via `tether daemon -v`. In production default (-v off), these
+	// are silently dropped.
 	logf := func(format string, args ...any) {
 		if cfg.Verbose {
 			fmt.Fprintf(stderr, format+"\n", args...)
 		}
+	}
+	// warnf is the always-on logger for events the user CANNOT
+	// diagnose without seeing them: audit-log file open failures,
+	// hookserver serve errors, broker emitter Inject errors. Goes to
+	// stderr regardless of the `-v` flag — these are rare enough they
+	// don't constitute log spam, and silencing them in default prod
+	// (which is what -v=false used to do) makes intermittent failures
+	// invisible. cmd/tether sets stderr=os.Stderr unconditionally so
+	// production sees these.
+	warnf := func(format string, args ...any) {
+		fmt.Fprintf(stderr, format+"\n", args...)
 	}
 
 	wd := watchdog.New()
@@ -222,17 +237,17 @@ func Run(ctx context.Context, cfg Config) error {
 		if !cfg.DisableLockAudit {
 			auditPath, perr := resolveLockAuditPath(cfg)
 			if perr != nil {
-				logf("[daemon] lock audit log: resolve path: %v (continuing in-memory only)", perr)
+				warnf("[daemon] lock audit log: resolve path: %v (continuing in-memory only)", perr)
 			} else {
 				sink, serr := lock.NewJSONLLogSink(auditPath)
 				if serr != nil {
-					logf("[daemon] lock audit log: open %q: %v (continuing in-memory only)", auditPath, serr)
+					warnf("[daemon] lock audit log: open %q: %v (continuing in-memory only)", auditPath, serr)
 				} else {
 					lockSink = sink
 					lockOpts = append(lockOpts,
 						lock.WithLogSink(sink),
 						lock.WithSinkErrorHandler(func(err error) {
-							logf("[daemon] lock audit log: append: %v", err)
+							warnf("[daemon] lock audit log: append: %v", err)
 						}),
 					)
 					logf("[daemon] lock audit log → %s", auditPath)


### PR DESCRIPTION
## Summary

P0 fix from the post-#47 audit pass — three findings (M1 real bug, L1 observability gap, L3 dead field, plus L2 doc comment) all in the same area.

### M1 — Real architectural bug, same shape as #47

`EnvelopeEmitter.Inject` silently dropped envelopes when no subscriber matched the `sessionId`. `AuthBroker.Ask` then waited the full Timeout (default 60s) for a decision that could never come and returned fail-closed deny. Same pattern as #47: system "appears to work" but is architecturally inert when the UI is detached / restarting / has buffered envelopes.

Caller scenarios that hit it:
- `tether-app` crashed / not yet attached when cc fires `PreToolUse`
- UI buffer (cap 64) saturated by a fast assistant burst before the auth request arrives
- Multi-rw-client model with all clients backpressured

**Fix**:
- `Inject` signature: was `error`, now `(delivered int, err error)`. `delivered` = subscribers that accepted the envelope (post drop-newest filter).
- `AuthBroker.Ask`: when `delivered==0`, return immediately with `AuthDecisionDenyOnce` + explicit `"no UI client subscribed"` error. Keeps fail-closed safety; ditches the 60s hang.

**Regression tests** (both ~10ms):
- `TestAuthBroker_NoSubscribers_FailsFast` — `Timeout=10s`, NO subscribe. Asserts fast-fail + clear error message.
- `TestAuthBroker_AllSubscribersFull_FailsFast` — subscribed but saturated; `delivered=0` despite `len(subs)>0`.

### L1 — Observability gap

`daemon.go::Run` had a single `logf` gated on `cfg.Verbose`. Production default (`tether daemon` without `-v`) sent everything to `io.Discard`, including audit-log file open failures. Tests passed because they set `Stderr=&bytes.Buffer{}` + `Verbose=true`; production users saw nothing.

**Fix**: parallel `warnf` always-on logger. Used by the 3 audit-log failure sites in `Run()`. `logf` still used for routine progress.

Subsystem-internal `logf` calls (`hookSubsystem`, `clientSubsystem`) **intentionally NOT touched** in this PR — wider scope, separate slice.

### L3 — Dead code

`AuthBroker.OnDecision` callback declared in PR #43 but never wired by any caller. Deleted + the 3 nil-checked call sites. Doc-comment explains where to push audit-log integration later if wanted.

### L2 — Documentation

`attach_socket.go::readInputs` has a "v0.1 reality check" comment now: the `if InputSink != nil` lock-path branch is dead in v0.1 production (daemon never wires `InputSink`, all rw attaches downgrade to ro, lock state machine receives no traffic). Tests still exercise it with a recorder sink; v0.2 daemon-side cc spawn integration will activate it.

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test -race -count=1 ./...` — all 11 packages pass
- [x] 2 new regression tests added; would hang full 10s timeout if M1 fix regresses

Refs the audit pass after PRs #43, #44, #47.