### PR TITLE
feat(transport): WT channel multiplex (slice #2)

### DIFF
--- a/cmd/tether/main.go
+++ b/cmd/tether/main.go
@@ -79,6 +79,9 @@ func runDaemon(args []string) int {
 	hookSettingsDir := fs.String("hook-settings-dir", "",
 		"directory for the cc settings.json the daemon generates "+
 			"(default $HOME/.tether/cc-settings; only used when --auth-broker is set)")
+	wtAddr := fs.String("wt-addr", "",
+		"WebTransport listener bind address (e.g. ':4444'); empty disables WT "+
+			"(v0.1 default — slice #2 of WT block, accepts sessions only)")
 	if err := fs.Parse(args); err != nil {
 		return 2
 	}
@@ -105,6 +108,7 @@ func runDaemon(args []string) int {
 		DisableLockAudit: *noAudit,
 		EnableAuthBroker: *enableAuth,
 		HookSettingsDir:  *hookSettingsDir,
+		WTListenAddr:     *wtAddr,
 		// Surface the resolved settings.json path on stdout so
 		// downstream tooling (the future `tether resume` integration,
 		// or a session-spawning sidecar) can read it without poking
@@ -207,7 +211,7 @@ func usage(w *os.File) {
 	fmt.Fprintln(w, "usage: tether <subcommand> [flags]")
 	fmt.Fprintln(w, "")
 	fmt.Fprintln(w, "Subcommands:")
-	fmt.Fprintln(w, "  daemon                         start the supervised daemon (watchdog + daemon + client)")
+	fmt.Fprintln(w, "  daemon                         start the supervised daemon (watchdog + daemon + client; --wt-addr opts in to WebTransport)")
 	fmt.Fprintln(w, "  skill install <name|git-url>   install a skill into the global pool")
 	fmt.Fprintln(w, "  skill list [--json]            list installed skills (--json: machine-readable, consumed by tether-app UI)")
 	fmt.Fprintln(w, "  skill remove <name>            uninstall a skill")

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -23,6 +23,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net"
 	"os"
 	"path/filepath"
 	"time"
@@ -131,6 +132,22 @@ type Config struct {
 	// fixture filesystem touched. Default false (audit log is on
 	// for production).
 	DisableLockAudit bool
+
+	// WTListenAddr, when non-empty, opts in to the WebTransport
+	// listener subsystem (slice #2 of the WT block, spec §3.3 / §11.V).
+	// Format is host:port (e.g. ":4444"); empty disables the WT
+	// subsystem entirely (v0.1 default — desktop / mobile clients still
+	// route through the local UDS attach socket until slice #5 lands).
+	//
+	// The wtSubsystem just accepts sessions in slice #2; envelope
+	// dispatch off the events channel is slice #3.
+	WTListenAddr string
+
+	// WTListener, when non-nil, hands the wtSubsystem a pre-bound UDP
+	// socket instead of binding via ListenAndServe. Tests use this to
+	// pick a free :0 port and learn the actual address; production
+	// leaves it nil and lets WTListenAddr drive the bind.
+	WTListener net.PacketConn
 
 	// EnableStubSweeper opts in to the GC stub-session sweeper
 	// (internal/daemon/sweeper.go). Default false for v0.1: ship
@@ -344,6 +361,16 @@ func Run(ctx context.Context, cfg Config) error {
 				Emitter:     emitter,
 				Logf:        logf,
 			}))
+		}
+		// WT subsystem — opt-in via WTListenAddr (slice #2 of WT block).
+		// In v0.1 this just accepts sessions and logs; envelope dispatch
+		// is slice #3.
+		if cfg.WTListenAddr != "" || cfg.WTListener != nil {
+			addr := cfg.WTListenAddr
+			if addr == "" && cfg.WTListener != nil {
+				addr = cfg.WTListener.LocalAddr().String()
+			}
+			factories = append(factories, wtSubsystemFactory(addr, cfg.WTListener, logf))
 		}
 		// emitter lives for the daemon's full lifetime; clean up
 		// on Run exit. clientSubsystem owns its per-run AttachServer

--- a/internal/daemon/wtsubsystem.go
+++ b/internal/daemon/wtsubsystem.go
@@ -1,0 +1,104 @@
+// wtsubsystem.go — watchdog-supervised owner of the WebTransport
+// listener (slice #2 of the WT block).
+//
+// In slice #2 the wtSubsystem just accepts WT sessions and logs them.
+// Slice #3 will rewire the session handler to dispatch envelopes
+// off the events channel; for now the channel router is exercised
+// only by tests, and the daemon exists primarily to prove the
+// supervisor wiring.
+//
+// Restart safety: like clientSubsystem, this stores config rather
+// than a built *wt.Server. Each Run() builds a fresh listener so a
+// crashed Serve loop recovers cleanly on the next watchdog restart.
+
+package daemon
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"time"
+
+	"github.com/piaobeizu/tether/internal/transport/wt"
+	"github.com/piaobeizu/tether/internal/watchdog"
+)
+
+// wtSubsystem owns the lifetime of the WT listener under the watchdog.
+//
+// It holds *config* (Addr + an optional pre-bound packet conn for
+// tests), not a *wt.Server — so a watchdog restart constructs a fresh
+// listener rather than re-running a closed one.
+type wtSubsystem struct {
+	addr string
+
+	// listener is an optional pre-bound UDP socket for tests. Production
+	// uses ListenAndServe via wt.Server.Serve; tests build a UDP socket
+	// on :0 and pass it here so they can learn the bound port.
+	listener net.PacketConn
+
+	logf func(format string, args ...any)
+	hb   func()
+}
+
+func (w *wtSubsystem) Name() string { return "wt" }
+
+func (w *wtSubsystem) Run(ctx context.Context, hb func()) error {
+	hb()
+
+	srv, err := wt.New(ctx, wt.Config{
+		Addr: w.addr,
+		// Default session handler — sit on the session until close.
+		// Slice #3 swaps this for envelope dispatch off the events
+		// channel.
+	})
+	if err != nil {
+		return fmt.Errorf("wt subsystem: new: %w", err)
+	}
+	defer func() { _ = srv.Close() }()
+
+	// Heartbeat side goroutine so the supervisor's deadlock detector
+	// stays happy while we just sit waiting for ctx / Serve to return.
+	hbDone := make(chan struct{})
+	defer func() { <-hbDone }()
+	go func() {
+		defer close(hbDone)
+		t := time.NewTicker(time.Second)
+		defer t.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-t.C:
+				hb()
+			}
+		}
+	}()
+
+	if w.logf != nil {
+		w.logf("[daemon] wt listener starting on %s", w.addr)
+	}
+
+	var serveErr error
+	if w.listener != nil {
+		serveErr = srv.ServeListener(ctx, w.listener)
+	} else {
+		serveErr = srv.Serve(ctx)
+	}
+	if serveErr != nil && !errors.Is(serveErr, context.Canceled) {
+		return serveErr
+	}
+	return nil
+}
+
+// wtSubsystemFactory wraps wtSubsystem under the SubsystemFactory
+// signature daemon.Run consumes.
+func wtSubsystemFactory(addr string, listener net.PacketConn, logf func(format string, args ...any)) SubsystemFactory {
+	return func() watchdog.Subsystem {
+		return &wtSubsystem{
+			addr:     addr,
+			listener: listener,
+			logf:     logf,
+		}
+	}
+}

--- a/internal/daemon/wtsubsystem_test.go
+++ b/internal/daemon/wtsubsystem_test.go
@@ -1,0 +1,93 @@
+package daemon_test
+
+import (
+	"bytes"
+	"context"
+	"net"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/piaobeizu/tether/internal/daemon"
+)
+
+// syncBuf is a goroutine-safe io.Writer wrapping bytes.Buffer. The
+// daemon's verbose logger writes from multiple goroutines (supervisor
+// + per-subsystem); a plain strings.Builder/bytes.Buffer races under
+// `-race`.
+type syncBuf struct {
+	mu  sync.Mutex
+	buf bytes.Buffer
+}
+
+func (s *syncBuf) Write(p []byte) (int, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.buf.Write(p)
+}
+
+func (s *syncBuf) String() string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.buf.String()
+}
+
+// TestRun_WTSubsystem_StartsAndStops verifies that setting
+// WTListenAddr (or WTListener) makes daemon.Run spawn the wt subsystem
+// under the watchdog and tears it down cleanly on ctx cancel.
+//
+// We use WTListener with a pre-bound :0 UDP socket so the test doesn't
+// need a fixed port.
+func TestRun_WTSubsystem_StartsAndStops(t *testing.T) {
+	t.Parallel()
+
+	tmp := t.TempDir()
+	projectsDir := filepath.Join(tmp, "projects")
+	attachSocket := filepath.Join(tmp, "attach.sock")
+	if err := os.MkdirAll(projectsDir, 0o700); err != nil {
+		t.Fatalf("setup: %v", err)
+	}
+
+	udp, err := net.ListenUDP("udp", &net.UDPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 0})
+	if err != nil {
+		t.Fatalf("ListenUDP: %v", err)
+	}
+	// daemon.Run will close the WT listener via wt.Server.Close → conn.
+	// No explicit defer udp.Close() here; the WT subsystem owns it.
+
+	var stderrBuf syncBuf
+	cfg := daemon.Config{
+		Verbose:          true,
+		Stderr:           &stderrBuf,
+		ProjectsDir:      projectsDir,
+		AttachSocketPath: attachSocket,
+		LockAuditLogPath: filepath.Join(tmp, "lock.log"),
+		WTListener:       udp,
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- daemon.Run(ctx, cfg) }()
+
+	// Give the subsystem time to log "wt listener starting".
+	time.Sleep(200 * time.Millisecond)
+
+	cancel()
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Errorf("daemon.Run = %v; want nil", err)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("daemon.Run did not exit within 3s of ctx cancel")
+	}
+
+	logs := stderrBuf.String()
+	if !strings.Contains(logs, "wt listener starting") {
+		t.Errorf("expected wt listener log line; got:\n%s", logs)
+	}
+}

--- a/internal/transport/wt/README.md
+++ b/internal/transport/wt/README.md
@@ -1,49 +1,126 @@
-# `internal/transport/wt` — WebTransport server (slice #1, skeleton)
+# `internal/transport/wt` — WebTransport server (slice #2, channel multiplex)
 
 This package is the daemon-side **WebTransport-over-HTTP/3** server that
 the desktop and mobile apps will dial into per spec
 [`2026-04-26-tether-go-quic-design.md`] §3.3 / §11.V (D-13 / D-21).
 
-## Status: SLICE #1 — server skeleton, NOT wired into the daemon
+## Status: SLICE #2 — channel multiplex layered onto the slice #1 listener
 
-What this slice ships:
+Slice #1 shipped the listener skeleton + a single-stream JSON echo handler.
+Slice #2 replaces that with the real **5-channel router** from §3.3.3.
 
-- `Server` boots an HTTP/3 + WebTransport listener on a UDP port.
-- A single endpoint (`/wt`) accepts WT upgrades.
-- Each accepted session runs an **echo handler** on its first
-  client-opened bidi stream — read JSON, write the same bytes back.
-  This is the smoke surface that proves the wire works without
-  committing to channel-specific semantics yet.
-- A `dev_cert.go` self-signed cert generator covers local dev. Prod
-  callers pass `Cert` + `Key` via `Config` and bypass the dev path.
+### What this slice ships
 
-What this slice intentionally does **not** do:
+- A 1-byte channel-id wire convention on every stream + datagram.
+- Per-`Session` accept loop demuxing incoming streams onto per-channel
+  queues (control / events / agent-bytes / catch-up / datagram).
+- Server `Session` API: `Control` / `Events` / `OpenAgentBytes` /
+  `AcceptCatchUp` / `SendDatagram` / `RecvDatagram`, plus the symmetric
+  Open/Accept variants for direction parity.
+- A Go-side `Client` mirroring the same conventions (used by tests +
+  future internal callers).
+- A watchdog-supervised `wtSubsystem` in `internal/daemon` that owns
+  the listener lifecycle. Opt-in via `daemon.Config.WTListenAddr` (or
+  `cmd/tether daemon --wt-addr`); the v0.1 default is empty (UDS attach
+  remains the local surface).
+
+### What this slice intentionally does NOT do
 
 | Future slice | Scope |
 |---|---|
-| **#2 — 5-channel multiplex** | Open the spec §3.3.3 channels (control / events / agent-bytes / catch-up / datagram) on top of the same `Session`. Replace the bidi echo with proper newline-delimited JSON envelope framing on each channel. |
-| **#3 — envelope dispatch** | Decode §3.3.1 wire envelopes (id / sessionId / fromDeviceId / toDeviceId / kind / nonce / ciphertext), enforce replay window + dedup LRU, route to per-session pubsub. Cross-link with `internal/agent.LocalEnvelope` (wrap the local shape into a wire envelope when a remote subscriber is present). |
+| **#3 — envelope dispatch** | Decode §3.3.1 wire envelopes (id / sessionId / fromDeviceId / toDeviceId / kind / nonce / ciphertext), enforce replay window + dedup LRU, route to per-session pubsub. The events channel carries opaque bytes today; slice #3 layers JSON-NL framing + envelope routing on top. |
 | **#4 — pairing + auth** | X25519 ECDH handshake from `internal/crypto`, device pairing flow, derive per-session keys, refuse unauthenticated upgrades. Replace the dev-cert "any origin allowed" with origin pinning. |
-| **#5 — daemon wiring** | Mount the WT server as a watchdog-supervised subsystem in `internal/daemon`. Replace `tether attach` (the local UDS path) for the desktop/mobile clients per D-21. The UDS path stays for `tether attach` from the daemon-host shell. |
+| **#5 — replace UDS attach** | Switch desktop / mobile clients off the local Unix socket onto WT entirely; the local `tether attach` shell stays on UDS by design. |
 
-## Why a skeleton instead of one big PR
+## Wire convention
 
-- Confidence in the `quic-go` + `webtransport-go` API surface is paid up-front and reused across slices.
-- The 5-channel layout, envelope dispatch, and pairing each have their own design surface — coupling them with the listener bootstrap creates a 1500-LOC PR that can't be reviewed.
-- Subsequent slices have a stable place to attach without churning the listener.
+Every stream and every datagram carries a one-byte **channel-id** as
+its first byte:
+
+```
+0x01 = control      (bidi, client → server initiated)
+0x02 = events       (bidi, server → client initiated)
+0x03 = agent-bytes  (uni,  server → client only — D-14: not consumed remotely in v0.1)
+0x04 = catch-up     (bidi, client → server initiated)
+0x05 = datagram     (tag for unreliable health-probe payloads; never appears on a stream)
+```
+
+The receiving side reads the byte off any newly-accepted stream and
+routes it to the per-channel queue. **Bad / unknown tags trigger a
+stream-level reset (`streamErrorCodeBadChannelID = 0x01`); the session
+itself is NOT torn down** — one buggy or hostile stream cannot poison
+a healthy session.
+
+A stream that opens but never sends the tag would otherwise pin a
+goroutine; the receiving side's `readChannelID` issues an `io.ReadFull`
+with no explicit deadline today (the WT session context cancels it on
+close), and the **5-second eviction budget tracked in `defaultChannelIDDeadline` is reserved for slice #3 hardening** — see "Known
+gotchas" below.
+
+## API surface
+
+### Server-side (`Session`)
+
+```go
+sess.Control(ctx)            // accept client-initiated bidi  (0x01)
+sess.Events(ctx)             // open server-initiated bidi    (0x02)
+sess.OpenAgentBytes(ctx)     // open server-initiated uni     (0x03)
+sess.AcceptCatchUp(ctx)      // accept client-initiated bidi  (0x04)
+sess.SendDatagram(payload)   // unreliable                    (0x05)
+sess.RecvDatagram(ctx)       // unreliable                    (0x05)
+```
+
+Symmetric helpers also exist (`OpenControl`, `AcceptEvents`,
+`AcceptAgentBytes`, `OpenCatchUp`) so both ends can speak the inverse
+direction when needed (e.g. server-initiated control RPC in a future
+slice).
+
+### Client-side (`Client`)
+
+The mirror image. The client opens control + catch-up; accepts events
++ agent-bytes; sends/receives datagrams. `OpenRawTagged(tag byte)` is
+an escape hatch for negative tests that need to drive bad tags into
+the server's accept loop.
+
+### Session handler injection
+
+`Config.SessionHandler func(*Session)` lets the integrator wire a
+per-session handler. Default: log accept + sit on the session until
+close (used by the daemon `wtSubsystem` in slice #2). Tests inject
+per-channel echo handlers to drive the router end-to-end.
 
 ## Architectural decisions baked in
 
-- **TLS 1.3 floor + ALPN `h3`** — HTTP/3 mandates both. Set explicitly via `tls.Config.MinVersion` + `NextProtos`.
-- **Single endpoint `/wt`** — channels multiplex inside one WT session, not across URL paths.
-- **Default UDP port `:4444`** — avoids conflict with PoC-2's `:4433` so dev workflows can run both. Configurable via `Config.Addr`.
-- **Cert handling** — caller-supplied `Cert`+`Key` wins; fully empty triggers the auto-gen ECDSA P-256 dev cert (7-day validity, loopback SANs by default). Mixing one of cert/key without the other is rejected explicitly.
-- **`webtransport.ConfigureHTTP3Server` is mandatory** — without it, the H3 SETTINGS frame doesn't advertise WebTransport and clients fail with "WebTransport not enabled" (PoC-2 step1 caught this).
-- **`EnableStreamResetPartialDelivery: true` in QUIC config** — required by webtransport-go ≥ v0.10 (PoC-2 step5 caught this).
-- **Server passive on stream open** — by convention the client opens the control stream first; the server `AcceptStream`s it. Server-initiated streams (events / catch-up) are opened from the server side in slice #2.
-- **`*webtransport.Stream` exposed directly, not wrapped** — webtransport-go has its own `Stream` type distinct from `quic.Stream`. Wrapping it before slice #2 designs the dispatch surface would be premature.
+- **1-byte channel-id (not varint)** — 5 channels today, 251 spare;
+  fixed width keeps the read path allocation-free and matches the
+  spec's use of "stream / datagram tag" not "stream type id".
+- **Default session handler is "sit on the session"** — not a stream
+  echo; envelope dispatch is a slice #3 concern. Tests inject
+  channel-aware echo handlers.
+- **Server runs the accept loop, callers consume from queues** — keeps
+  the demux off the hot path and means `Control(ctx)` etc. are simple
+  receives. Per-channel queue capacity is 16 (small constant; no
+  channel needs deep buffering at v0.1 traffic levels).
+- **Bad channel-id resets the offending stream, not the session** —
+  one buggy / hostile stream cannot poison a healthy session, matching
+  the wire-level "stream is the failure unit" model of QUIC.
+- **`MaxIncomingStreams` defaults from the underlying QUIC config** —
+  webtransport-go inherits these from the H3 server. The dev-cert
+  client picks 64 each (uni + bidi); production overrides via
+  `Config.QUIC*` knobs once added in slice #4.
+- **Go-side `Client` is exported** — needed for tests + future
+  internal callers (cross-host pairing, internal probes). Tauri /
+  mobile clients re-implement the wire convention in
+  TypeScript / Kotlin.
+- **`agent-bytes` is uni only** — server-only writer per §3.3.3
+  (PTY raw bytes flow server→client). The reverse direction has no
+  v0.1 consumer; if a slice #5 ever needs it, the convention extends
+  cleanly (just open a uni from the client side with `0x03`).
+- **`wtSubsystem` is opt-in** — `WTListenAddr == "" && WTListener == nil`
+  means the watchdog never spawns it. Keeps the v0.1 default surface
+  identical to pre-slice-#2 (UDS attach only).
 
-## Quick local smoke (after slice #1 lands)
+## Quick local smoke
 
 ```go
 ctx, cancel := context.WithCancel(context.Background())
@@ -52,27 +129,54 @@ defer cancel()
 srv, err := wt.New(ctx, wt.Config{
     Addr:   ":4444",
     Logger: log.New(os.Stderr, "wt: ", log.LstdFlags),
+    SessionHandler: func(sess *wt.Session) {
+        ctrl, _ := sess.Control(ctx)
+        defer ctrl.Close()
+        io.Copy(ctrl, ctrl)
+    },
 })
 if err != nil { /* handle */ }
 go srv.Serve(ctx)
-// dial via webtransport.Dialer to https://127.0.0.1:4444/wt, OpenStreamSync,
-// write JSON, read it back.
+// dial via wt.Dial → cli.OpenControl(ctx) → write+close → ReadAll
 ```
 
-The integration test in `server_test.go` is the executable form of this.
+The integration tests in `server_test.go` are the executable form of
+the full 5-channel surface.
 
 ## Known gotchas (read before extending)
 
-1. **Cert trust on macOS / Android dev devices** — self-signed certs require either trust-store install or the `serverCertificateHashes` browser API (Chromium / WebView). The dev cert generator exposes `SPKISHA256` so future slices can hand the fingerprint to a Tauri command.
-2. **Port-binding under unprivileged users** — UDP `:4444` is fine. Anything `< 1024` requires CAP_NET_BIND_SERVICE on Linux or root on other Unixes; production deploys typically front this with a Cloudflare / Cloud Load Balancer that handles HTTPS termination at the edge — but WebTransport requires QUIC end-to-end, so termination must be QUIC-aware (Cloudflare's HTTP/3 product is, plain L4 LBs aren't).
-3. **`quic.ErrServerClosed`** is the graceful-shutdown sentinel; `Serve` swallows it and returns nil. `http.ErrServerClosed` from the H3 layer is also swallowed.
-4. **Ports + listener handoff for tests** — webtransport-go's `Server` doesn't expose the post-bind port when you `ListenAndServe` on `:0`. Use the `ServeListener` entrypoint with a pre-bound `net.PacketConn` instead — that's the test pattern.
+1. **Cert trust on macOS / Android dev devices** — self-signed certs
+   require either trust-store install or the `serverCertificateHashes`
+   browser API (Chromium / WebView). The dev cert generator exposes
+   `SPKISHA256` so future slices can hand the fingerprint to a Tauri
+   command.
+2. **Port-binding under unprivileged users** — UDP `:4444` is fine.
+   Anything `< 1024` requires CAP_NET_BIND_SERVICE on Linux or root on
+   other Unixes.
+3. **`quic.ErrServerClosed`** is the graceful-shutdown sentinel;
+   `Serve` swallows it and returns nil. `http.ErrServerClosed` from
+   the H3 layer is also swallowed.
+4. **Listener handoff for tests** — webtransport-go's `Server` doesn't
+   expose the post-bind port when you `ListenAndServe` on `:0`. Use
+   the `ServeListener` entrypoint with a pre-bound `net.PacketConn`
+   instead — that's the test pattern (`bootTestServer` in
+   `server_test.go`).
+5. **Stream-tag eviction is "best-effort" today** — a stream that
+   opens and never writes its 1-byte tag pins a routing goroutine
+   until the session-level context closes. v0.1 trusts paired peers;
+   slice #4 (auth) will tighten this with a per-stream
+   `SetReadDeadline(now + defaultChannelIDDeadline)`.
+6. **Datagrams require `EnableDatagrams: true` on BOTH sides** —
+   already on in the server's `quic.Config`; the test client and
+   `wt.Dial` set it explicitly. Forgetting it on a custom client
+   silently turns `SendDatagram` into a no-op.
 
 ## Spec cross-references
 
 - §3.3 — wire model big picture
 - §3.3.1 — envelope schema (slice #3)
-- §3.3.3 — 5 channel layout (slice #2)
+- §3.3.3 — 5 channel layout (this slice)
 - §11.V — transport implementation choice
 - D-13 / D-21 — desktop is always remote; v0.1 has no UDS direct path for desktop / mobile
+- D-14 — agent-bytes channel reserved but not consumed remotely in v0.1
 - §10 PoC-2 — the listener bring-up smoke (already passed; this package is the production version)

--- a/internal/transport/wt/channel.go
+++ b/internal/transport/wt/channel.go
@@ -1,0 +1,103 @@
+// channel.go — wire-level channel multiplex per spec §3.3.3.
+//
+// One WT session carries five logical channels. Streams (and datagrams)
+// are tagged with a single-byte channel-id prefix so the receiver can
+// route an incoming stream to the right per-channel queue without an
+// out-of-band setup handshake.
+//
+// Wire convention (slice #2):
+//
+//	bidi / uni stream :  [channel-id : 1 byte] [channel payload …]
+//	datagram          :  [channel-id : 1 byte] [datagram payload …]
+//
+// 1 byte is plenty for the 5 v0.1 channels with 251 spare values for
+// future use; keeping the prefix fixed-width keeps the read path
+// allocation-free (vs varint).
+//
+// Direction conventions (matched by Session + Client):
+//
+//	Channel       Kind    Initiator
+//	control       bidi    client
+//	events        bidi    server
+//	agent-bytes   uni     server  (server-only writer; v0.1 not consumed
+//	                              remotely per D-14 but the channel
+//	                              exists so future slices can flip it on)
+//	catch-up      bidi    client
+//	datagram      ─       both    (no streams; tagged datagrams)
+package wt
+
+import (
+	"errors"
+	"fmt"
+	"time"
+)
+
+// ChannelID is a one-byte tag placed at the head of every WT stream
+// (and datagram payload) so the receiving side can demux without an
+// out-of-band handshake.
+type ChannelID byte
+
+const (
+	ChannelControl    ChannelID = 0x01
+	ChannelEvents     ChannelID = 0x02
+	ChannelAgentBytes ChannelID = 0x03
+	ChannelCatchUp    ChannelID = 0x04
+	ChannelDatagram   ChannelID = 0x05
+)
+
+// String renders a channel-id for log output. Unknown values fall back
+// to a hex form so bad-prefix error logs are still useful.
+func (c ChannelID) String() string {
+	switch c {
+	case ChannelControl:
+		return "control"
+	case ChannelEvents:
+		return "events"
+	case ChannelAgentBytes:
+		return "agent-bytes"
+	case ChannelCatchUp:
+		return "catch-up"
+	case ChannelDatagram:
+		return "datagram"
+	default:
+		return fmt.Sprintf("channel(0x%02x)", byte(c))
+	}
+}
+
+// valid returns true for the 5 channel-ids defined in §3.3.3. Wire
+// values outside this set MUST trigger a stream-level reset on the
+// receiving side; the offending sender either has a bug or is hostile.
+func (c ChannelID) valid() bool {
+	switch c {
+	case ChannelControl, ChannelEvents, ChannelAgentBytes, ChannelCatchUp, ChannelDatagram:
+		return true
+	default:
+		return false
+	}
+}
+
+// streamCapable returns true for channel-ids that ride on a stream.
+// ChannelDatagram is the lone exception — its tag marks datagrams, not
+// streams.
+func (c ChannelID) streamCapable() bool {
+	return c.valid() && c != ChannelDatagram
+}
+
+// errBadChannelID is returned by the accept loop when the leading byte
+// of an incoming stream is not one of the 5 known channel-ids OR is
+// the datagram tag (which must NOT appear on a stream). The accept
+// loop resets the offending stream and keeps the session alive — one
+// bad stream does not poison the connection.
+var errBadChannelID = errors.New("wt: bad channel-id prefix")
+
+// Default budget for the receiving side to read the 1-byte channel-id
+// prefix off a freshly-accepted stream. A misbehaving / abandoned
+// client that opens a stream and never writes the tag would otherwise
+// pin a goroutine forever; 5s is generous (RTT + handshake + scheduler
+// jitter all fit) but cheap to evict on.
+const defaultChannelIDDeadline = 5 * time.Second
+
+// streamErrorCodeBadChannelID is the WT stream-level error code we
+// reset offending streams with when the leading byte isn't a known
+// channel-id. Application-defined; chosen for log uniqueness.
+const streamErrorCodeBadChannelID = 0x01

--- a/internal/transport/wt/client.go
+++ b/internal/transport/wt/client.go
@@ -1,0 +1,316 @@
+// client.go — Go-side WebTransport client mirroring the §3.3.3
+// channel multiplex.
+//
+// The client is the symmetric counterpart of Session: it opens
+// control / catch-up bidi streams (writing the channel-id prefix
+// first), and accepts events bidi + agent-bytes uni streams (consuming
+// the prefix in a per-Client accept loop). Datagrams use the same
+// 1-byte prefix.
+//
+// In v0.1 this is used by:
+//
+//   - WT package tests — the only way to exercise the channel router
+//     end-to-end.
+//   - Future internal callers — once a Go-side daemon attaches to a
+//     remote WT server (e.g. for cross-host pairing), this is the
+//     client.
+//
+// The Tauri / mobile clients re-implement the same wire convention in
+// TypeScript / Kotlin; they do NOT depend on this package.
+
+package wt
+
+import (
+	"context"
+	"crypto/tls"
+	"errors"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"sync"
+	"time"
+
+	"github.com/quic-go/quic-go"
+	"github.com/quic-go/webtransport-go"
+)
+
+// ClientConfig bundles the dial knobs.
+type ClientConfig struct {
+	// URL is the wt:// or https:// endpoint (the server mounts /wt).
+	URL string
+
+	// TLSClientConfig is the TLS config used for the H3 dial. Required
+	// — the caller must supply a RootCAs / InsecureSkipVerify path.
+	TLSClientConfig *tls.Config
+
+	// Logger receives operational events. nil = discard.
+	Logger *log.Logger
+}
+
+// Client is the daemon-internal Go client for a WT server speaking
+// the channel-id wire convention. Concurrency-safe: methods may be
+// called from multiple goroutines.
+type Client struct {
+	raw    *webtransport.Session
+	logger *log.Logger
+
+	bidiQ map[ChannelID]chan *webtransport.Stream
+	uniQ  map[ChannelID]chan *webtransport.ReceiveStream
+
+	mu          sync.Mutex
+	closed      bool
+	closeQueues sync.Once
+	queuesDone  chan struct{}
+}
+
+// Dial connects to the WT server at cfg.URL and returns a Client. The
+// returned Client owns a goroutine pair (bidi + uni accept loop) that
+// runs until Close is called or the server tears the session down.
+func Dial(ctx context.Context, cfg ClientConfig) (*Client, error) {
+	if cfg.URL == "" {
+		return nil, errors.New("wt: ClientConfig.URL required")
+	}
+	if cfg.TLSClientConfig == nil {
+		return nil, errors.New("wt: ClientConfig.TLSClientConfig required")
+	}
+	logger := cfg.Logger
+	if logger == nil {
+		logger = log.New(io.Discard, "", 0)
+	}
+	d := &webtransport.Dialer{
+		TLSClientConfig: cfg.TLSClientConfig,
+		QUICConfig: &quic.Config{
+			MaxIncomingStreams:               64,
+			MaxIncomingUniStreams:            64,
+			EnableDatagrams:                  true,
+			EnableStreamResetPartialDelivery: true,
+			KeepAlivePeriod:                  5 * time.Second,
+		},
+	}
+	rsp, sess, err := d.Dial(ctx, cfg.URL, http.Header{})
+	if err != nil {
+		return nil, fmt.Errorf("wt: dial: %w", err)
+	}
+	if rsp.StatusCode != 200 {
+		_ = sess.CloseWithError(0, "bad status")
+		return nil, fmt.Errorf("wt: dial: status %d", rsp.StatusCode)
+	}
+
+	c := &Client{
+		raw:        sess,
+		logger:     logger,
+		bidiQ:      make(map[ChannelID]chan *webtransport.Stream, 4),
+		uniQ:       make(map[ChannelID]chan *webtransport.ReceiveStream, 1),
+		queuesDone: make(chan struct{}),
+	}
+	// Mirror the server's accept queues. Client receives:
+	//   events    — server-initiated bidi
+	//   catch-up  — only if server initiates a catch-up (reverse path,
+	//               rare but legal)
+	//   control   — symmetric (server-initiated control RPC, future)
+	for _, ch := range []ChannelID{ChannelControl, ChannelEvents, ChannelCatchUp} {
+		c.bidiQ[ch] = make(chan *webtransport.Stream, streamCapacity)
+	}
+	c.uniQ[ChannelAgentBytes] = make(chan *webtransport.ReceiveStream, streamCapacity)
+
+	go c.acceptBidiLoop()
+	go c.acceptUniLoop()
+	return c, nil
+}
+
+// Context returns a context that is closed when the underlying WT
+// session ends.
+func (c *Client) Context() context.Context { return c.raw.Context() }
+
+// OpenControl opens the client→server control bidi stream, writing
+// the channel-id byte before returning it.
+func (c *Client) OpenControl(ctx context.Context) (*webtransport.Stream, error) {
+	return c.openBidi(ctx, ChannelControl)
+}
+
+// AcceptEvents accepts the server-initiated events bidi stream. The
+// channel-id byte has already been consumed.
+func (c *Client) AcceptEvents(ctx context.Context) (*webtransport.Stream, error) {
+	return c.acceptBidi(ctx, ChannelEvents)
+}
+
+// OpenCatchUp opens the client→server catch-up bidi stream.
+func (c *Client) OpenCatchUp(ctx context.Context) (*webtransport.Stream, error) {
+	return c.openBidi(ctx, ChannelCatchUp)
+}
+
+// AcceptAgentBytes accepts the server-initiated agent-bytes uni-
+// stream. The channel-id byte has already been consumed.
+func (c *Client) AcceptAgentBytes(ctx context.Context) (*webtransport.ReceiveStream, error) {
+	return c.acceptUni(ctx, ChannelAgentBytes)
+}
+
+// SendDatagram sends a datagram tagged with ChannelDatagram.
+func (c *Client) SendDatagram(payload []byte) error {
+	return sendTaggedDatagram(c.raw, ChannelDatagram, payload)
+}
+
+// RecvDatagram blocks until a datagram arrives, validates the prefix,
+// and returns the payload.
+func (c *Client) RecvDatagram(ctx context.Context) ([]byte, error) {
+	return recvTaggedDatagram(c.raw, ctx, ChannelDatagram)
+}
+
+// OpenRawTagged is an escape hatch: open a bidi stream with the given
+// channel-id prefix even if the channel isn't normally client-
+// initiated. Used by the bad-channel-id test to feed garbage into the
+// server's accept loop.
+func (c *Client) OpenRawTagged(ctx context.Context, tag byte) (*webtransport.Stream, error) {
+	str, err := c.raw.OpenStreamSync(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if _, err := str.Write([]byte{tag}); err != nil {
+		_ = str.Close()
+		return nil, err
+	}
+	return str, nil
+}
+
+// Close tears the WT session down. Idempotent.
+func (c *Client) Close() error {
+	c.mu.Lock()
+	if c.closed {
+		c.mu.Unlock()
+		return nil
+	}
+	c.closed = true
+	c.mu.Unlock()
+	err := c.raw.CloseWithError(0, "client close")
+	c.closeQueues.Do(func() { close(c.queuesDone) })
+	return err
+}
+
+// openBidi opens a bidi stream and writes the channel-id tag.
+func (c *Client) openBidi(ctx context.Context, ch ChannelID) (*webtransport.Stream, error) {
+	str, err := c.raw.OpenStreamSync(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if _, err := str.Write([]byte{byte(ch)}); err != nil {
+		_ = str.Close()
+		return nil, fmt.Errorf("wt: write %s tag: %w", ch, err)
+	}
+	return str, nil
+}
+
+func (c *Client) acceptBidi(ctx context.Context, ch ChannelID) (*webtransport.Stream, error) {
+	q, ok := c.bidiQ[ch]
+	if !ok {
+		return nil, fmt.Errorf("wt: no client bidi queue for %s", ch)
+	}
+	select {
+	case str, ok := <-q:
+		if !ok {
+			return nil, errors.New("wt: client closed")
+		}
+		return str, nil
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	case <-c.queuesDone:
+		return nil, errors.New("wt: client closed")
+	case <-c.raw.Context().Done():
+		return nil, errors.New("wt: client closed")
+	}
+}
+
+func (c *Client) acceptUni(ctx context.Context, ch ChannelID) (*webtransport.ReceiveStream, error) {
+	q, ok := c.uniQ[ch]
+	if !ok {
+		return nil, fmt.Errorf("wt: no client uni queue for %s", ch)
+	}
+	select {
+	case str, ok := <-q:
+		if !ok {
+			return nil, errors.New("wt: client closed")
+		}
+		return str, nil
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	case <-c.queuesDone:
+		return nil, errors.New("wt: client closed")
+	case <-c.raw.Context().Done():
+		return nil, errors.New("wt: client closed")
+	}
+}
+
+func (c *Client) acceptBidiLoop() {
+	defer c.closeQueues.Do(func() { close(c.queuesDone) })
+	for {
+		str, err := c.raw.AcceptStream(c.raw.Context())
+		if err != nil {
+			return
+		}
+		go c.routeIncomingBidi(str)
+	}
+}
+
+func (c *Client) acceptUniLoop() {
+	for {
+		str, err := c.raw.AcceptUniStream(c.raw.Context())
+		if err != nil {
+			return
+		}
+		go c.routeIncomingUni(str)
+	}
+}
+
+func (c *Client) routeIncomingBidi(str *webtransport.Stream) {
+	tag, err := readChannelID(str)
+	if err != nil {
+		c.logger.Printf("wt-client: bidi stream tag read: %v", err)
+		str.CancelRead(streamErrorCodeBadChannelID)
+		str.CancelWrite(streamErrorCodeBadChannelID)
+		return
+	}
+	if !tag.streamCapable() {
+		c.logger.Printf("wt-client: bidi stream rejected: %s", tag)
+		str.CancelRead(streamErrorCodeBadChannelID)
+		str.CancelWrite(streamErrorCodeBadChannelID)
+		return
+	}
+	q, ok := c.bidiQ[tag]
+	if !ok {
+		c.logger.Printf("wt-client: bidi stream %s arrived but no queue", tag)
+		str.CancelRead(streamErrorCodeBadChannelID)
+		str.CancelWrite(streamErrorCodeBadChannelID)
+		return
+	}
+	select {
+	case q <- str:
+	case <-c.raw.Context().Done():
+		str.CancelRead(streamErrorCodeBadChannelID)
+		str.CancelWrite(streamErrorCodeBadChannelID)
+	}
+}
+
+func (c *Client) routeIncomingUni(str *webtransport.ReceiveStream) {
+	tag, err := readChannelID(str)
+	if err != nil {
+		c.logger.Printf("wt-client: uni stream tag read: %v", err)
+		str.CancelRead(streamErrorCodeBadChannelID)
+		return
+	}
+	if !tag.streamCapable() {
+		c.logger.Printf("wt-client: uni stream rejected: %s", tag)
+		str.CancelRead(streamErrorCodeBadChannelID)
+		return
+	}
+	q, ok := c.uniQ[tag]
+	if !ok {
+		c.logger.Printf("wt-client: uni stream %s arrived but no queue", tag)
+		str.CancelRead(streamErrorCodeBadChannelID)
+		return
+	}
+	select {
+	case q <- str:
+	case <-c.raw.Context().Done():
+		str.CancelRead(streamErrorCodeBadChannelID)
+	}
+}

--- a/internal/transport/wt/server.go
+++ b/internal/transport/wt/server.go
@@ -1,40 +1,49 @@
-// Package wt is the WebTransport-over-HTTP/3 server skeleton for the
-// tether daemon's cross-device transport (spec §3.3 / §11.V / D-13 /
-// D-21).
+// Package wt is the WebTransport-over-HTTP/3 server for the tether
+// daemon's cross-device transport (spec §3.3 / §11.V / D-13 / D-21).
 //
-// Status — slice #1 (server skeleton):
+// Status — slice #2 (channel multiplex layered onto slice #1's listener):
 //
 //   - Boots a webtransport-go server on a configurable UDP port.
 //   - Accepts WT sessions at a single endpoint path ("/wt").
-//   - Per session, opens ONE control bidi stream that JSON-echoes
-//     incoming envelopes back to the client (smoke surface for the v0.1
-//     wire).
+//   - Each Session runs a per-session accept loop demuxing incoming
+//     bidi/uni streams onto per-channel queues using the §3.3.3 1-byte
+//     channel-id wire convention:
+//       0x01 control / 0x02 events / 0x03 agent-bytes / 0x04 catch-up /
+//       0x05 datagram (tag for unreliable payloads).
+//   - Exposes per-channel API on Session: Control, Events,
+//     OpenAgentBytes, AcceptCatchUp, SendDatagram, RecvDatagram (plus
+//     symmetric counterparts).
+//   - A Go-side Client mirrors the same conventions for tests + future
+//     internal callers.
 //   - Generates a self-signed dev cert when no cert is configured;
 //     production paths supply Cert/Key and skip the dev cert path.
 //
 // What this package does NOT do yet (later slices):
 //
-//   - 5-channel multiplex (control / events / agent-bytes / catch-up /
-//     datagram) per §3.3.3 — slice #2 will layer the full channel set
-//     on top of this skeleton.
 //   - §3.3.1 wire envelope dispatch (encrypted payload, AD-bound kind,
-//     replay/dedup) — slice #3.
-//   - Pairing / device auth (§ pairing / X25519 ECDH handshake from
+//     replay/dedup) — slice #3. Channels currently carry opaque bytes.
+//   - Pairing / device auth (X25519 ECDH handshake from
 //     internal/crypto) — slice #4.
-//   - Wiring as a watchdog-supervised subsystem in
-//     internal/daemon.daemon.Run() — deliberate: the WT block has to
-//     stand alone before it earns a daemon supervisor slot, and the
-//     existing UDS attach socket (internal/agent.attach_socket.go) is
-//     the v0.1 in-process surface for now (D-21 says desktop should
-//     not use UDS, but `tether attach` on the daemon-host shell still
-//     does, so we keep that path untouched).
+//   - Replacing UDS attach for desktop / mobile clients — slice #5.
 //
-// API surface is intentionally minimal:
+// Daemon integration: opt-in via daemon.Config.WTListenAddr (or the
+// `--wt-addr` flag on `cmd/tether daemon`); empty == disabled. The
+// existing UDS attach socket stays the v0.1 local surface for
+// `tether attach` on the daemon-host shell.
 //
-//	srv, err := wt.New(ctx, wt.Config{Addr: ":4444"})
-//	go srv.Serve(ctx)  // blocks until ctx cancels or listener errors
-//	...
-//	srv.Close()        // idempotent shutdown
+// Quick API surface:
+//
+//	srv, err := wt.New(ctx, wt.Config{
+//	    Addr: ":4444",
+//	    SessionHandler: func(s *wt.Session) {
+//	        ctrl, _ := s.Control(ctx)
+//	        // ... dispatch envelopes off ctrl + s.Events / etc.
+//	    },
+//	})
+//	go srv.Serve(ctx)
+//	// client side:
+//	cli, _ := wt.Dial(ctx, wt.ClientConfig{URL: "https://...:4444/wt", ...})
+//	str, _ := cli.OpenControl(ctx)
 package wt
 
 import (
@@ -93,6 +102,17 @@ type Config struct {
 	// origin (dev default). Production should pin to expected client
 	// origins (the desktop / mobile app's bundle origin).
 	CheckOrigin func(*http.Request) bool
+
+	// SessionHandler runs once per accepted WT session. nil → use the
+	// default "log + idle until close" handler suitable for the daemon
+	// wtSubsystem (slice #2 doesn't yet wire envelope dispatch). Tests
+	// inject custom handlers (e.g. per-channel echo) to drive the
+	// channel router.
+	//
+	// The handler runs in its own goroutine; returning from it does
+	// NOT close the session. The session lifecycle is owned by the
+	// Server (closed on Server.Close).
+	SessionHandler func(*Session)
 }
 
 // Server is the WT listener. Exactly one Serve call per Server; reuse
@@ -105,6 +125,8 @@ type Server struct {
 
 	h3 *http3.Server
 	wt *webtransport.Server
+
+	sessionHandler func(*Session)
 
 	// sessions tracked for graceful shutdown.
 	mu       sync.Mutex
@@ -129,9 +151,18 @@ func New(_ context.Context, cfg Config) (*Server, error) {
 	}
 
 	srv := &Server{
-		addr:     addr,
-		logger:   logger,
-		sessions: make(map[*Session]struct{}),
+		addr:           addr,
+		logger:         logger,
+		sessions:       make(map[*Session]struct{}),
+		sessionHandler: cfg.SessionHandler,
+	}
+	if srv.sessionHandler == nil {
+		srv.sessionHandler = func(sess *Session) {
+			// Default: log accept + sit on the session until it closes.
+			// The daemon wtSubsystem uses this — slice #3 will swap in
+			// real envelope dispatch.
+			<-sess.Context().Done()
+		}
 	}
 
 	// Cert: caller-supplied wins; otherwise auto-gen dev cert.
@@ -279,8 +310,8 @@ func (s *Server) Close() error {
 }
 
 // handleUpgrade is the HTTP handler for the /wt endpoint. It performs
-// the WebTransport upgrade and dispatches accepted sessions into the
-// session goroutine.
+// the WebTransport upgrade, wires up the channel-demux Session, and
+// hands it to the configured session handler.
 func (s *Server) handleUpgrade(w http.ResponseWriter, r *http.Request) {
 	wtSess, err := s.wt.Upgrade(w, r)
 	if err != nil {
@@ -289,10 +320,7 @@ func (s *Server) handleUpgrade(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	sess := &Session{
-		raw:    wtSess,
-		logger: s.logger,
-	}
+	sess := newSession(wtSess, s.logger)
 
 	s.mu.Lock()
 	if s.sessions == nil {
@@ -311,31 +339,8 @@ func (s *Server) handleUpgrade(w http.ResponseWriter, r *http.Request) {
 			s.mu.Lock()
 			delete(s.sessions, sess)
 			s.mu.Unlock()
+			_ = sess.closeWithError(0, "session done")
 		}()
-		s.runEchoSession(sess)
+		s.sessionHandler(sess)
 	}()
-}
-
-// runEchoSession is the v0.1 smoke handler: open the control stream,
-// JSON-echo whatever envelopes the client sends. Slice #2 will replace
-// this with the real 5-channel dispatch.
-func (s *Server) runEchoSession(sess *Session) {
-	defer func() { _ = sess.closeWithError(0, "session done") }()
-
-	// The CLIENT opens the control stream — we accept it. This matches
-	// the spec direction: clients drive session setup; the server is
-	// passive at the WT layer.
-	ctrl, err := sess.acceptControlStream()
-	if err != nil {
-		s.logger.Printf("wt: accept control stream: %v", err)
-		return
-	}
-	defer ctrl.Close()
-
-	// Echo loop: read until the client half-closes, write back byte-
-	// for-byte. JSON framing is the client's responsibility for v0.1
-	// (newline-delimited JSON is the planned framing in slice #2).
-	if _, err := io.Copy(ctrl, ctrl); err != nil && !errors.Is(err, io.EOF) {
-		s.logger.Printf("wt: control echo: %v", err)
-	}
 }

--- a/internal/transport/wt/server_test.go
+++ b/internal/transport/wt/server_test.go
@@ -4,26 +4,25 @@ import (
 	"context"
 	"crypto/tls"
 	"crypto/x509"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
 	"net"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
-
-	"github.com/quic-go/quic-go"
-	"github.com/quic-go/webtransport-go"
 )
 
 // bootTestServer wires up a Server on a random loopback UDP port using
 // the ServeListener entrypoint and returns the dialable URL plus an
 // x509.CertPool the client can trust.
 //
-// Lifecycle: the returned cancel function shuts the server down + waits
-// for Serve to return. Tests should always defer it.
-func bootTestServer(t *testing.T) (url string, pool *x509.CertPool, cancel func()) {
+// `handler` is the per-session handler the server runs for each
+// accepted session; tests inject a channel-aware echo or whatever they
+// need to drive the router. Pass nil for the default sit-on-session
+// handler.
+func bootTestServer(t *testing.T, handler func(*Session)) (url string, pool *x509.CertPool, cancel func()) {
 	t.Helper()
 
 	udp, err := net.ListenUDP("udp", &net.UDPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 0})
@@ -35,7 +34,8 @@ func bootTestServer(t *testing.T) (url string, pool *x509.CertPool, cancel func(
 	ctx, cancelCtx := context.WithCancel(context.Background())
 
 	srv, err := New(ctx, Config{
-		Addr: fmt.Sprintf("127.0.0.1:%d", port),
+		Addr:           fmt.Sprintf("127.0.0.1:%d", port),
+		SessionHandler: handler,
 		// Logger left nil → discard.
 	})
 	if err != nil {
@@ -50,12 +50,9 @@ func bootTestServer(t *testing.T) (url string, pool *x509.CertPool, cancel func(
 		_ = srv.ServeListener(ctx, udp)
 	}()
 
-	// Build a client trust pool from the auto-generated cert.
 	pool = x509.NewCertPool()
 	leaf := srv.TLSCertificate().Leaf
 	if leaf == nil {
-		// Should never happen — generateDevCert sets Leaf — but be
-		// defensive in case future Cert paths skip the parse.
 		_ = srv.Close()
 		<-done
 		_ = udp.Close()
@@ -78,78 +75,442 @@ func bootTestServer(t *testing.T) (url string, pool *x509.CertPool, cancel func(
 	return fmt.Sprintf("https://127.0.0.1:%d%s", port, EndpointPath), pool, cancel
 }
 
-// TestServer_EchoControlEnvelope is the integration smoke: boot a real
-// WT server, dial it with the same lib's client, open one bidi
-// stream, send a JSON envelope, read it back. This is the wire-level
-// proof that slice #1 actually works end-to-end.
-func TestServer_EchoControlEnvelope(t *testing.T) {
-	t.Parallel()
-
-	url, pool, cancel := bootTestServer(t)
-	defer cancel()
-
-	d := &webtransport.Dialer{
+// dialClient is the test-side helper around Dial that wires the
+// server's self-signed cert pool.
+func dialClient(t *testing.T, ctx context.Context, url string, pool *x509.CertPool) *Client {
+	t.Helper()
+	c, err := Dial(ctx, ClientConfig{
+		URL: url,
 		TLSClientConfig: &tls.Config{
 			RootCAs:    pool,
 			NextProtos: []string{alpnH3},
 			MinVersion: tls.VersionTLS13,
 		},
-		QUICConfig: &quic.Config{
-			MaxIncomingStreams:               16,
-			MaxIncomingUniStreams:            16,
-			EnableDatagrams:                  true,
-			EnableStreamResetPartialDelivery: true,
-			KeepAlivePeriod:                  5 * time.Second,
-		},
-	}
-
-	dialCtx, dialCancel := context.WithTimeout(context.Background(), 5*time.Second)
-	defer dialCancel()
-
-	rsp, sess, err := d.Dial(dialCtx, url, nil)
+	})
 	if err != nil {
 		t.Fatalf("Dial: %v", err)
 	}
-	if rsp.StatusCode != 200 {
-		t.Fatalf("status: %d", rsp.StatusCode)
-	}
-	defer func() { _ = sess.CloseWithError(0, "test done") }()
+	return c
+}
 
-	str, err := sess.OpenStreamSync(dialCtx)
+// echoSessionHandler runs concurrent per-channel echo loops on the
+// server side. Used by the round-trip tests to verify that bytes
+// written into a given channel come back unchanged.
+//
+// Direction matrix per §3.3.3:
+//
+//	control     — client opens, server accepts → echo back
+//	events      — server opens, client receives → server writes
+//	                preset bytes, then echoes whatever client writes
+//	agent-bytes — server opens uni → server writes preset bytes, closes
+//	catch-up    — client opens, server accepts → echo back
+//	datagram    — server echoes datagram payloads back with the tag
+func echoSessionHandler(events []byte, agentBytes []byte) func(*Session) {
+	return func(sess *Session) {
+		ctx := sess.Context()
+		var wg sync.WaitGroup
+
+		// control: accept + echo (loop, but only one expected per session
+		// in tests — use a single accept).
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			str, err := sess.Control(ctx)
+			if err != nil {
+				return
+			}
+			defer str.Close()
+			_, _ = io.Copy(str, str)
+		}()
+
+		// events: server opens, writes preset bytes, then echoes anything
+		// the client writes back.
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			openCtx, cancel := context.WithTimeout(ctx, 3*time.Second)
+			defer cancel()
+			str, err := sess.Events(openCtx)
+			if err != nil {
+				return
+			}
+			defer str.Close()
+			if len(events) > 0 {
+				_, _ = str.Write(events)
+			}
+			_, _ = io.Copy(str, str)
+		}()
+
+		// agent-bytes: server opens uni, writes preset bytes, closes.
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			openCtx, cancel := context.WithTimeout(ctx, 3*time.Second)
+			defer cancel()
+			w, err := sess.OpenAgentBytes(openCtx)
+			if err != nil {
+				return
+			}
+			defer w.Close()
+			if len(agentBytes) > 0 {
+				_, _ = w.Write(agentBytes)
+			}
+		}()
+
+		// catch-up: accept + echo.
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			str, err := sess.AcceptCatchUp(ctx)
+			if err != nil {
+				return
+			}
+			defer str.Close()
+			_, _ = io.Copy(str, str)
+		}()
+
+		// datagram: echo loop. Receives one, sends it back.
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for {
+				select {
+				case <-ctx.Done():
+					return
+				default:
+				}
+				dgCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+				payload, err := sess.RecvDatagram(dgCtx)
+				cancel()
+				if err != nil {
+					return
+				}
+				_ = sess.SendDatagram(payload)
+			}
+		}()
+
+		wg.Wait()
+	}
+}
+
+// TestChannel_ControlRoundTrip — control channel: client opens, sends
+// payload, server echoes back.
+func TestChannel_ControlRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	url, pool, cancel := bootTestServer(t, echoSessionHandler(nil, nil))
+	defer cancel()
+
+	ctx, ctxCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer ctxCancel()
+
+	cli := dialClient(t, ctx, url, pool)
+	defer cli.Close()
+
+	str, err := cli.OpenControl(ctx)
 	if err != nil {
-		t.Fatalf("OpenStreamSync: %v", err)
+		t.Fatalf("OpenControl: %v", err)
 	}
-
-	type helloEnv struct {
-		Hello string `json:"hello"`
-		ID    int    `json:"id"`
-	}
-	send := helloEnv{Hello: "world", ID: 42}
-	payload, err := json.Marshal(send)
-	if err != nil {
-		t.Fatalf("marshal: %v", err)
-	}
-
+	payload := []byte("hello-control")
 	if _, err := str.Write(payload); err != nil {
 		t.Fatalf("Write: %v", err)
 	}
-	// Half-close so the server's io.Copy returns and we can read the
-	// echoed bytes off the receive side.
 	if err := str.Close(); err != nil {
 		t.Fatalf("Close: %v", err)
 	}
-
 	got, err := io.ReadAll(str)
 	if err != nil && !errors.Is(err, io.EOF) {
 		t.Fatalf("ReadAll: %v", err)
 	}
-
-	var back helloEnv
-	if err := json.Unmarshal(got, &back); err != nil {
-		t.Fatalf("unmarshal echoed bytes %q: %v", got, err)
+	if string(got) != string(payload) {
+		t.Fatalf("control echo: got %q want %q", got, payload)
 	}
-	if back != send {
-		t.Fatalf("echo mismatch: sent=%+v got=%+v", send, back)
+}
+
+// TestChannel_EventsRoundTrip — server opens events bidi, writes a
+// preset payload + echoes whatever the client writes.
+func TestChannel_EventsRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	preset := []byte("server-events-preset")
+	url, pool, cancel := bootTestServer(t, echoSessionHandler(preset, nil))
+	defer cancel()
+
+	ctx, ctxCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer ctxCancel()
+
+	cli := dialClient(t, ctx, url, pool)
+	defer cli.Close()
+
+	str, err := cli.AcceptEvents(ctx)
+	if err != nil {
+		t.Fatalf("AcceptEvents: %v", err)
+	}
+
+	// First read the server-pushed preset.
+	got := make([]byte, len(preset))
+	if _, err := io.ReadFull(str, got); err != nil {
+		t.Fatalf("ReadFull preset: %v", err)
+	}
+	if string(got) != string(preset) {
+		t.Fatalf("events preset: got %q want %q", got, preset)
+	}
+
+	// Now write something and verify echo.
+	payload := []byte("client-events-roundtrip")
+	if _, err := str.Write(payload); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	if err := str.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	rest, err := io.ReadAll(str)
+	if err != nil && !errors.Is(err, io.EOF) {
+		t.Fatalf("ReadAll: %v", err)
+	}
+	if string(rest) != string(payload) {
+		t.Fatalf("events echo: got %q want %q", rest, payload)
+	}
+}
+
+// TestChannel_AgentBytesUni — server pushes a uni-stream tagged
+// agent-bytes; client receives and reads to EOF.
+func TestChannel_AgentBytesUni(t *testing.T) {
+	t.Parallel()
+
+	preset := []byte("server-pty-bytes-stream")
+	url, pool, cancel := bootTestServer(t, echoSessionHandler(nil, preset))
+	defer cancel()
+
+	ctx, ctxCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer ctxCancel()
+
+	cli := dialClient(t, ctx, url, pool)
+	defer cli.Close()
+
+	str, err := cli.AcceptAgentBytes(ctx)
+	if err != nil {
+		t.Fatalf("AcceptAgentBytes: %v", err)
+	}
+	got, err := io.ReadAll(str)
+	if err != nil && !errors.Is(err, io.EOF) {
+		t.Fatalf("ReadAll: %v", err)
+	}
+	if string(got) != string(preset) {
+		t.Fatalf("agent-bytes: got %q want %q", got, preset)
+	}
+}
+
+// TestChannel_CatchUpRoundTrip — client opens catch-up, server echoes.
+func TestChannel_CatchUpRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	url, pool, cancel := bootTestServer(t, echoSessionHandler(nil, nil))
+	defer cancel()
+
+	ctx, ctxCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer ctxCancel()
+
+	cli := dialClient(t, ctx, url, pool)
+	defer cli.Close()
+
+	str, err := cli.OpenCatchUp(ctx)
+	if err != nil {
+		t.Fatalf("OpenCatchUp: %v", err)
+	}
+	payload := []byte("catchup-replay-please")
+	if _, err := str.Write(payload); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	if err := str.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	got, err := io.ReadAll(str)
+	if err != nil && !errors.Is(err, io.EOF) {
+		t.Fatalf("ReadAll: %v", err)
+	}
+	if string(got) != string(payload) {
+		t.Fatalf("catch-up echo: got %q want %q", got, payload)
+	}
+}
+
+// TestChannel_DatagramRoundTrip — datagram with channel-id prefix.
+func TestChannel_DatagramRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	url, pool, cancel := bootTestServer(t, echoSessionHandler(nil, nil))
+	defer cancel()
+
+	ctx, ctxCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer ctxCancel()
+
+	cli := dialClient(t, ctx, url, pool)
+	defer cli.Close()
+
+	payload := []byte("ping-12345")
+	if err := cli.SendDatagram(payload); err != nil {
+		t.Fatalf("SendDatagram: %v", err)
+	}
+	got, err := cli.RecvDatagram(ctx)
+	if err != nil {
+		t.Fatalf("RecvDatagram: %v", err)
+	}
+	if string(got) != string(payload) {
+		t.Fatalf("datagram echo: got %q want %q", got, payload)
+	}
+}
+
+// TestChannel_MixedConcurrent — open control + catch-up concurrently;
+// receive events; verify the demux picked them apart correctly.
+func TestChannel_MixedConcurrent(t *testing.T) {
+	t.Parallel()
+
+	preset := []byte("events-stream-mixed")
+	url, pool, cancel := bootTestServer(t, echoSessionHandler(preset, nil))
+	defer cancel()
+
+	ctx, ctxCancel := context.WithTimeout(context.Background(), 8*time.Second)
+	defer ctxCancel()
+
+	cli := dialClient(t, ctx, url, pool)
+	defer cli.Close()
+
+	var wg sync.WaitGroup
+	var ctrlGot, catchupGot, eventsGot []byte
+	var ctrlErr, catchupErr, eventsErr error
+
+	// control
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		str, err := cli.OpenControl(ctx)
+		if err != nil {
+			ctrlErr = fmt.Errorf("OpenControl: %w", err)
+			return
+		}
+		_, _ = str.Write([]byte("ctrl-mix"))
+		_ = str.Close()
+		ctrlGot, _ = io.ReadAll(str)
+	}()
+
+	// catch-up
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		str, err := cli.OpenCatchUp(ctx)
+		if err != nil {
+			catchupErr = fmt.Errorf("OpenCatchUp: %w", err)
+			return
+		}
+		_, _ = str.Write([]byte("catch-mix"))
+		_ = str.Close()
+		catchupGot, _ = io.ReadAll(str)
+	}()
+
+	// events (server-initiated)
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		str, err := cli.AcceptEvents(ctx)
+		if err != nil {
+			eventsErr = fmt.Errorf("AcceptEvents: %w", err)
+			return
+		}
+		buf := make([]byte, len(preset))
+		if _, err := io.ReadFull(str, buf); err != nil {
+			eventsErr = fmt.Errorf("ReadFull events: %w", err)
+			return
+		}
+		eventsGot = buf
+	}()
+
+	wg.Wait()
+
+	if ctrlErr != nil {
+		t.Errorf("control: %v", ctrlErr)
+	}
+	if catchupErr != nil {
+		t.Errorf("catch-up: %v", catchupErr)
+	}
+	if eventsErr != nil {
+		t.Errorf("events: %v", eventsErr)
+	}
+	if string(ctrlGot) != "ctrl-mix" {
+		t.Errorf("control mixed echo: got %q", ctrlGot)
+	}
+	if string(catchupGot) != "catch-mix" {
+		t.Errorf("catch-up mixed echo: got %q", catchupGot)
+	}
+	if string(eventsGot) != string(preset) {
+		t.Errorf("events mixed preset: got %q", eventsGot)
+	}
+}
+
+// TestChannel_BadChannelID — open a stream with a bogus tag (0x06).
+// Server must reset the offending stream but keep the session alive
+// so a follow-up well-formed control stream still works.
+func TestChannel_BadChannelID(t *testing.T) {
+	t.Parallel()
+
+	var sessionLive atomic.Bool
+	handler := func(sess *Session) {
+		sessionLive.Store(true)
+		// Run the standard control echo so the follow-up stream proves
+		// the session is still healthy.
+		ctx := sess.Context()
+		for {
+			str, err := sess.Control(ctx)
+			if err != nil {
+				return
+			}
+			go func(s io.ReadWriteCloser) {
+				defer s.Close()
+				_, _ = io.Copy(s, s)
+			}(str)
+		}
+	}
+	url, pool, cancel := bootTestServer(t, handler)
+	defer cancel()
+
+	ctx, ctxCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer ctxCancel()
+
+	cli := dialClient(t, ctx, url, pool)
+	defer cli.Close()
+
+	// Open a stream with a bad tag (0x06 — not a known channel).
+	bad, err := cli.OpenRawTagged(ctx, 0x06)
+	if err != nil {
+		t.Fatalf("OpenRawTagged: %v", err)
+	}
+	// Write some payload too — the server should reset before reading
+	// it. We just want the read to fail (eventually).
+	_, _ = bad.Write([]byte("garbage"))
+	_ = bad.Close()
+	// The read on the offending stream should error out (not echo).
+	got, err := io.ReadAll(bad)
+	if err == nil && len(got) > 0 {
+		t.Errorf("bad-id stream returned data %q (want reset)", got)
+	}
+
+	// Session must still be healthy: open a real control and round-trip.
+	good, err := cli.OpenControl(ctx)
+	if err != nil {
+		t.Fatalf("post-bad OpenControl: %v", err)
+	}
+	if _, err := good.Write([]byte("still-alive")); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	_ = good.Close()
+	echoed, err := io.ReadAll(good)
+	if err != nil && !errors.Is(err, io.EOF) {
+		t.Fatalf("ReadAll: %v", err)
+	}
+	if string(echoed) != "still-alive" {
+		t.Fatalf("post-bad control echo: got %q", echoed)
+	}
+	if !sessionLive.Load() {
+		t.Errorf("session handler never ran")
 	}
 }
 
@@ -203,7 +564,6 @@ func TestServer_CloseIdempotent(t *testing.T) {
 		_ = srv.ServeListener(ctx, udp)
 	}()
 
-	// Close twice — both must succeed without panicking.
 	if err := srv.Close(); err != nil {
 		t.Errorf("first Close: %v", err)
 	}

--- a/internal/transport/wt/session.go
+++ b/internal/transport/wt/session.go
@@ -1,41 +1,92 @@
-// session.go — Session wraps a webtransport.Session.
+// session.go — server-side Session with §3.3.3 channel demux.
 //
-// In slice #1 the Session exposes only the control + events stream
-// accessors + a close primitive. The other 3 channels from §3.3.3
-// (agent-bytes, catch-up, datagram) are deliberately NOT yet
-// surfaced; slice #2 will add them.
+// Slice #2 replaces slice #1's "first-stream-is-control echo" with a
+// real router: a per-Session goroutine accepts every incoming bidi /
+// uni stream, reads the leading channel-id byte, and hands the stream
+// to a per-channel queue. Callers consume via channel-typed accessors
+// (Control, AcceptCatchUp, AcceptAgentBytes...). Server-initiated
+// channels (events, agent-bytes) are written by Open* helpers that
+// prepend the channel-id before returning the stream to the caller.
 //
-// API note: webtransport-go returns its own `*webtransport.Stream`
-// type for bidi streams (it is NOT the same as `quic.Stream`, despite
-// having a near-identical interface). We expose `*webtransport.Stream`
-// directly here rather than wrap it — the spec talks about WT streams
-// at the v0.1 abstraction level, and adding our own wrapper before
-// the dispatch slice is decided would be premature.
+// API shape on the server side (mirror on Client):
+//
+//	control     — Control(ctx) blocks until the client opens it.
+//	events      — Events(ctx) opens it server→client.
+//	agent-bytes — OpenAgentBytes(ctx) opens a uni-stream server→client.
+//	catch-up    — AcceptCatchUp(ctx) accepts the client-initiated bidi.
+//	datagram    — SendDatagram / RecvDatagram wrap the WT primitives
+//	              with the 1-byte tag.
+//
+// Bad channel-id (leading byte ∉ {0x01..0x05}, or 0x05 on a stream):
+// the offending stream is reset with streamErrorCodeBadChannelID and
+// the accept loop continues. The session itself is NOT torn down; one
+// bad stream from a buggy client should not kill an otherwise-healthy
+// session.
 
 package wt
 
 import (
 	"context"
 	"errors"
+	"fmt"
+	"io"
 	"log"
 	"sync"
 
 	"github.com/quic-go/webtransport-go"
 )
 
-// Session is the daemon-side handle on a single connected client. One
-// WT session per connected client device; multiple bidi streams (the
-// 5-channel model in §3.3.3) are multiplexed inside one session
-// natively by WebTransport.
+// streamCapacity caps the per-channel accept queue. A backed-up
+// consumer just stalls new accepts on that channel, which is the right
+// behavior — control / catch-up streams should never burst high enough
+// to need real buffering.
+const streamCapacity = 16
+
+// Session is the daemon-side handle on a single connected client.
+//
+// Lifetime: created by Server.handleUpgrade, runs until either the
+// peer closes the WT session or Server.Close fires. The accept loop
+// goroutine demuxes incoming streams onto per-channel queues for the
+// lifetime of the session.
 type Session struct {
 	raw    *webtransport.Session
 	logger *log.Logger
 
-	mu          sync.Mutex
-	controlOpen bool
-	eventsOpen  bool
+	// per-channel bidi accept queues. Buffered; a slow consumer just
+	// pauses new accepts on that channel.
+	bidiQ map[ChannelID]chan *webtransport.Stream
 
+	// per-channel uni accept queues (only ChannelAgentBytes uses uni
+	// streams in v0.1, but the table is keyed for symmetry).
+	uniQ map[ChannelID]chan *webtransport.ReceiveStream
+
+	mu     sync.Mutex
 	closed bool
+
+	// closeQueues is closed once when the accept loop exits, signaling
+	// callers blocked on a per-channel queue to give up.
+	closeQueues sync.Once
+	queuesDone  chan struct{}
+}
+
+// newSession wires a fresh Session around an upgraded
+// *webtransport.Session and starts the accept loop. The accept loop
+// goroutine runs until the WT session ends.
+func newSession(wts *webtransport.Session, logger *log.Logger) *Session {
+	s := &Session{
+		raw:        wts,
+		logger:     logger,
+		bidiQ:      make(map[ChannelID]chan *webtransport.Stream, 4),
+		uniQ:       make(map[ChannelID]chan *webtransport.ReceiveStream, 1),
+		queuesDone: make(chan struct{}),
+	}
+	for _, c := range []ChannelID{ChannelControl, ChannelEvents, ChannelCatchUp} {
+		s.bidiQ[c] = make(chan *webtransport.Stream, streamCapacity)
+	}
+	s.uniQ[ChannelAgentBytes] = make(chan *webtransport.ReceiveStream, streamCapacity)
+	go s.acceptBidiLoop()
+	go s.acceptUniLoop()
+	return s
 }
 
 // Context returns a context that is cancelled when the session closes.
@@ -44,80 +95,88 @@ func (s *Session) Context() context.Context { return s.raw.Context() }
 // RemoteAddr returns the client's UDP address.
 func (s *Session) RemoteAddr() string { return s.raw.RemoteAddr().String() }
 
-// Control is the convenience accessor for the control bidi stream
-// (§3.3.3 stream 1: session.* / control.* / input.*). Slice #1 echoes
-// it; slice #2 will route envelopes off it.
-//
-// Convention: the CLIENT opens the control stream first; the server
-// accepts it. Calling Control() on the server therefore blocks until
-// the client opens its first stream.
+// Control accepts the client-initiated control bidi stream. The
+// channel-id byte has already been consumed by the accept loop; what
+// the caller gets is the post-prefix payload stream.
 func (s *Session) Control(ctx context.Context) (*webtransport.Stream, error) {
-	return s.acceptControlStreamCtx(ctx)
+	return s.acceptBidi(ctx, ChannelControl)
 }
 
-// Events is the convenience accessor for the events bidi stream
-// (§3.3.3 stream 2: output.agent-event / output.hook-event). Server
-// opens this one (server → client direction is the dominant traffic
-// flow).
+// Events opens the events bidi stream server → client. The
+// channel-id byte is written before the stream is handed back, so the
+// caller can begin sending payload immediately.
 //
-// Slice #2 will rewire so the events stream is a server-initiated
-// uni-stream (it's only ever server→client per the spec); for slice
-// #1 we keep it as a bidi for symmetry with the echo smoke.
+// Direction matches slice #1: server opens, client accepts (events
+// flow is dominantly server→client, server-initiated keeps the API
+// shape stable across slices).
 func (s *Session) Events(ctx context.Context) (*webtransport.Stream, error) {
-	s.mu.Lock()
-	if s.closed {
-		s.mu.Unlock()
-		return nil, errors.New("wt: session closed")
-	}
-	if s.eventsOpen {
-		s.mu.Unlock()
-		return nil, errors.New("wt: events stream already opened")
-	}
-	s.eventsOpen = true
-	s.mu.Unlock()
-
-	str, err := s.raw.OpenStreamSync(ctx)
-	if err != nil {
-		s.mu.Lock()
-		s.eventsOpen = false
-		s.mu.Unlock()
-		return nil, err
-	}
-	return str, nil
+	return s.openBidi(ctx, ChannelEvents)
 }
 
-// acceptControlStream is the package-internal "accept the first stream
-// the client opens" helper. The control stream is always client-
-// initiated by convention.
-func (s *Session) acceptControlStream() (*webtransport.Stream, error) {
-	return s.acceptControlStreamCtx(s.raw.Context())
+// OpenAgentBytes opens a server-initiated unidirectional stream for
+// PTY agent bytes (§3.3.3 stream 3). v0.1 doesn't actually consume
+// this remotely (D-14) but the channel exists so the wire stays
+// stable.
+//
+// The returned WriteCloser writes payload bytes; the channel-id byte
+// has already been written.
+func (s *Session) OpenAgentBytes(ctx context.Context) (io.WriteCloser, error) {
+	return s.openUni(ctx, ChannelAgentBytes)
 }
 
-func (s *Session) acceptControlStreamCtx(ctx context.Context) (*webtransport.Stream, error) {
-	s.mu.Lock()
-	if s.closed {
-		s.mu.Unlock()
-		return nil, errors.New("wt: session closed")
-	}
-	if s.controlOpen {
-		s.mu.Unlock()
-		return nil, errors.New("wt: control stream already accepted")
-	}
-	s.controlOpen = true
-	s.mu.Unlock()
-
-	str, err := s.raw.AcceptStream(ctx)
-	if err != nil {
-		s.mu.Lock()
-		s.controlOpen = false
-		s.mu.Unlock()
-		return nil, err
-	}
-	return str, nil
+// AcceptCatchUp accepts the client-initiated catch-up bidi stream
+// (§3.3.3 stream 4). Multiple catch-up streams over the lifetime of a
+// session are allowed; each call returns the next one.
+func (s *Session) AcceptCatchUp(ctx context.Context) (*webtransport.Stream, error) {
+	return s.acceptBidi(ctx, ChannelCatchUp)
 }
 
-// closeWithError tears the session down with a WebTransport-level
-// session error code + message.
+// SendDatagram sends a datagram tagged with ChannelDatagram. The 1-
+// byte tag is prepended to the payload so the receiving side's
+// RecvDatagram can validate + strip it.
+func (s *Session) SendDatagram(payload []byte) error {
+	return sendTaggedDatagram(s.raw, ChannelDatagram, payload)
+}
+
+// RecvDatagram blocks until a datagram arrives, validates the channel-
+// id prefix, and returns the payload (without the tag byte).
+//
+// A datagram with a bad / wrong tag returns errBadChannelID; callers
+// can choose to log + retry vs treat as fatal. Datagrams are by spec
+// unreliable, so a single dropped/garbled one is recoverable.
+func (s *Session) RecvDatagram(ctx context.Context) ([]byte, error) {
+	return recvTaggedDatagram(s.raw, ctx, ChannelDatagram)
+}
+
+// AcceptAgentBytes accepts a server-initiated uni-stream tagged with
+// ChannelAgentBytes. Used by the client-side mirror; on the server
+// side it would be unusual (server is the writer) but kept for
+// symmetry with the Client API.
+func (s *Session) AcceptAgentBytes(ctx context.Context) (*webtransport.ReceiveStream, error) {
+	return s.acceptUni(ctx, ChannelAgentBytes)
+}
+
+// AcceptEvents accepts a server-initiated events bidi stream. On the
+// server itself this is rarely used (server opens, client accepts);
+// kept for symmetry / multi-server pairing scenarios.
+func (s *Session) AcceptEvents(ctx context.Context) (*webtransport.Stream, error) {
+	return s.acceptBidi(ctx, ChannelEvents)
+}
+
+// OpenControl opens a control bidi stream client → server. Server-side
+// callers normally use Control (accept). This exists so a future
+// server-initiated control RPC can use the same prefix.
+func (s *Session) OpenControl(ctx context.Context) (*webtransport.Stream, error) {
+	return s.openBidi(ctx, ChannelControl)
+}
+
+// OpenCatchUp opens a catch-up bidi stream client → server. Server-
+// side callers normally use AcceptCatchUp.
+func (s *Session) OpenCatchUp(ctx context.Context) (*webtransport.Stream, error) {
+	return s.openBidi(ctx, ChannelCatchUp)
+}
+
+// closeWithError tears the session down. Idempotent.
 func (s *Session) closeWithError(code webtransport.SessionErrorCode, msg string) error {
 	s.mu.Lock()
 	if s.closed {
@@ -126,5 +185,206 @@ func (s *Session) closeWithError(code webtransport.SessionErrorCode, msg string)
 	}
 	s.closed = true
 	s.mu.Unlock()
-	return s.raw.CloseWithError(code, msg)
+	err := s.raw.CloseWithError(code, msg)
+	s.closeQueues.Do(func() { close(s.queuesDone) })
+	return err
+}
+
+// acceptBidi consumes from the per-channel bidi queue.
+func (s *Session) acceptBidi(ctx context.Context, c ChannelID) (*webtransport.Stream, error) {
+	q, ok := s.bidiQ[c]
+	if !ok {
+		return nil, fmt.Errorf("wt: no bidi queue for %s", c)
+	}
+	select {
+	case str, ok := <-q:
+		if !ok {
+			return nil, errors.New("wt: session closed")
+		}
+		return str, nil
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	case <-s.queuesDone:
+		return nil, errors.New("wt: session closed")
+	case <-s.raw.Context().Done():
+		return nil, errors.New("wt: session closed")
+	}
+}
+
+// acceptUni consumes from the per-channel uni queue.
+func (s *Session) acceptUni(ctx context.Context, c ChannelID) (*webtransport.ReceiveStream, error) {
+	q, ok := s.uniQ[c]
+	if !ok {
+		return nil, fmt.Errorf("wt: no uni queue for %s", c)
+	}
+	select {
+	case str, ok := <-q:
+		if !ok {
+			return nil, errors.New("wt: session closed")
+		}
+		return str, nil
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	case <-s.queuesDone:
+		return nil, errors.New("wt: session closed")
+	case <-s.raw.Context().Done():
+		return nil, errors.New("wt: session closed")
+	}
+}
+
+// openBidi opens a server-initiated bidi stream and writes the
+// channel-id prefix before returning.
+func (s *Session) openBidi(ctx context.Context, c ChannelID) (*webtransport.Stream, error) {
+	str, err := s.raw.OpenStreamSync(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if _, err := str.Write([]byte{byte(c)}); err != nil {
+		_ = str.Close()
+		return nil, fmt.Errorf("wt: write %s tag: %w", c, err)
+	}
+	return str, nil
+}
+
+// openUni opens a server-initiated uni-stream and writes the
+// channel-id prefix before returning.
+func (s *Session) openUni(ctx context.Context, c ChannelID) (io.WriteCloser, error) {
+	str, err := s.raw.OpenUniStreamSync(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if _, err := str.Write([]byte{byte(c)}); err != nil {
+		_ = str.Close()
+		return nil, fmt.Errorf("wt: write %s tag: %w", c, err)
+	}
+	return str, nil
+}
+
+// acceptBidiLoop pulls bidi streams off the WT session, reads their
+// 1-byte channel-id, and routes them to the matching queue. Bad
+// channel-ids are logged + the stream reset; the loop continues.
+//
+// Termination: returns when the WT session context closes or
+// AcceptStream returns an error. On exit, closes per-channel queues
+// so blocked callers wake up with "session closed".
+func (s *Session) acceptBidiLoop() {
+	defer s.closeQueues.Do(func() { close(s.queuesDone) })
+	for {
+		str, err := s.raw.AcceptStream(s.raw.Context())
+		if err != nil {
+			return
+		}
+		go s.routeIncomingBidi(str)
+	}
+}
+
+// acceptUniLoop is the uni-stream equivalent.
+func (s *Session) acceptUniLoop() {
+	for {
+		str, err := s.raw.AcceptUniStream(s.raw.Context())
+		if err != nil {
+			return
+		}
+		go s.routeIncomingUni(str)
+	}
+}
+
+// routeIncomingBidi reads one byte of channel-id then enqueues to the
+// matching per-channel queue. Bad byte → reset stream + log.
+func (s *Session) routeIncomingBidi(str *webtransport.Stream) {
+	tag, err := readChannelID(str)
+	if err != nil {
+		s.logger.Printf("wt: bidi stream tag read: %v", err)
+		str.CancelRead(streamErrorCodeBadChannelID)
+		str.CancelWrite(streamErrorCodeBadChannelID)
+		return
+	}
+	if !tag.streamCapable() {
+		s.logger.Printf("wt: bidi stream rejected: %s (datagram-only or unknown)", tag)
+		str.CancelRead(streamErrorCodeBadChannelID)
+		str.CancelWrite(streamErrorCodeBadChannelID)
+		return
+	}
+	q, ok := s.bidiQ[tag]
+	if !ok {
+		s.logger.Printf("wt: bidi stream %s arrived but no queue (server-only channel?)", tag)
+		str.CancelRead(streamErrorCodeBadChannelID)
+		str.CancelWrite(streamErrorCodeBadChannelID)
+		return
+	}
+	select {
+	case q <- str:
+	case <-s.raw.Context().Done():
+		str.CancelRead(streamErrorCodeBadChannelID)
+		str.CancelWrite(streamErrorCodeBadChannelID)
+	}
+}
+
+// routeIncomingUni mirrors routeIncomingBidi for uni-streams.
+func (s *Session) routeIncomingUni(str *webtransport.ReceiveStream) {
+	tag, err := readChannelID(str)
+	if err != nil {
+		s.logger.Printf("wt: uni stream tag read: %v", err)
+		str.CancelRead(streamErrorCodeBadChannelID)
+		return
+	}
+	if !tag.streamCapable() {
+		s.logger.Printf("wt: uni stream rejected: %s", tag)
+		str.CancelRead(streamErrorCodeBadChannelID)
+		return
+	}
+	q, ok := s.uniQ[tag]
+	if !ok {
+		s.logger.Printf("wt: uni stream %s arrived but no queue", tag)
+		str.CancelRead(streamErrorCodeBadChannelID)
+		return
+	}
+	select {
+	case q <- str:
+	case <-s.raw.Context().Done():
+		str.CancelRead(streamErrorCodeBadChannelID)
+	}
+}
+
+// readChannelID reads exactly one byte from r and validates it as a
+// known channel-id. The returned ChannelID may still be ChannelDatagram
+// — caller must check streamCapable().
+func readChannelID(r io.Reader) (ChannelID, error) {
+	var buf [1]byte
+	if _, err := io.ReadFull(r, buf[:]); err != nil {
+		return 0, err
+	}
+	c := ChannelID(buf[0])
+	if !c.valid() {
+		return c, fmt.Errorf("%w: 0x%02x", errBadChannelID, buf[0])
+	}
+	return c, nil
+}
+
+// sendTaggedDatagram prepends the channel-id byte before SendDatagram.
+// Allocates a single-shot buffer; datagrams are tiny (health-probe
+// payloads <100B) so the alloc is in the noise.
+func sendTaggedDatagram(raw *webtransport.Session, c ChannelID, payload []byte) error {
+	buf := make([]byte, 1+len(payload))
+	buf[0] = byte(c)
+	copy(buf[1:], payload)
+	return raw.SendDatagram(buf)
+}
+
+// recvTaggedDatagram is the inverse of sendTaggedDatagram. The expected
+// channel-id is supplied so a stray tag returns a typed error rather
+// than silently mis-routing.
+func recvTaggedDatagram(raw *webtransport.Session, ctx context.Context, expect ChannelID) ([]byte, error) {
+	b, err := raw.ReceiveDatagram(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if len(b) < 1 {
+		return nil, fmt.Errorf("%w: empty datagram", errBadChannelID)
+	}
+	got := ChannelID(b[0])
+	if got != expect {
+		return nil, fmt.Errorf("%w: got %s, want %s", errBadChannelID, got, expect)
+	}
+	return b[1:], nil
 }


### PR DESCRIPTION
## Summary

WT block **slice #2** — layers the spec §3.3.3 5-channel multiplex onto
PR #49's listener skeleton.

- 1-byte **channel-id** prefix (`0x01` control / `0x02` events / `0x03`
  agent-bytes / `0x04` catch-up / `0x05` datagram) on every stream +
  datagram. Per-`Session` accept loop demuxes incoming streams onto
  per-channel queues.
- Per-channel `Session` API: `Control(ctx)`, `Events(ctx)`,
  `OpenAgentBytes(ctx)`, `AcceptCatchUp(ctx)`, `SendDatagram(payload)`,
  `RecvDatagram(ctx)`, plus symmetric `Open*`/`Accept*` counterparts.
- Exported Go-side **`Client`** mirroring the same wire convention
  (used by tests + future internal callers).
- Watchdog-supervised **`wtSubsystem`** in `internal/daemon`, opt-in
  via `daemon.Config.WTListenAddr` or `cmd/tether daemon --wt-addr`.
  Default empty so v0.1 surface is identical to pre-slice-#2 (UDS
  attach remains the local path).

## Wire convention

Stream / datagram:

```
[channel-id : 1 byte] [payload …]
```

The receiver reads the leading byte off any newly-accepted stream and
routes it to the per-channel queue. Bad / unknown tags trigger a
stream-level reset (`streamErrorCodeBadChannelID = 0x01`); the session
itself is **not** torn down — one buggy / hostile stream cannot poison
a healthy session.

## Architectural decisions

- **1-byte channel-id (not varint)** — 5 channels today, 251 spare;
  fixed width keeps the read path allocation-free and matches the
  spec's "stream / datagram tag" framing.
- **Bad tag → stream reset, not session close.** Failure unit is the
  stream, matching QUIC.
- **Server runs the accept loop, callers consume from queues.** Per-
  channel queue capacity = 16 (small constant; no v0.1 channel needs
  deep buffering).
- **Default session handler is "sit on session"** — envelope dispatch
  is slice #3. Tests inject channel-aware echo handlers via
  `Config.SessionHandler`.
- **`agent-bytes` is uni only (server → client).** Per spec / D-14;
  the channel exists so the wire stays stable even though v0.1 has
  no remote consumer.
- **Go-side `Client` is exported.** Required for the test surface +
  future internal callers (cross-host pairing, internal probes). The
  Tauri / mobile clients re-implement the wire convention
  natively.
- **`wtSubsystem` is opt-in.** `WTListenAddr == "" && WTListener ==
  nil` means the watchdog never spawns it. v0.1 default surface is
  unchanged.

## Stream-tag eviction (deferred)

A misbehaving client that opens a stream and never writes the 1-byte
tag would pin a routing goroutine until the session-level context
closes. v0.1 trusts paired peers; the constant
`defaultChannelIDDeadline = 5 * time.Second` is reserved for slice #4
(auth) which will tighten this with `SetReadDeadline(now + budget)`.
Documented in `internal/transport/wt/README.md` "Known gotchas".

## webtransport-go gotchas worth flagging

- `EnableDatagrams: true` MUST be on both server `quic.Config` and
  client `quic.Config`; forgetting it on a custom client silently
  no-ops `SendDatagram`.
- `Session.Context()` is the right cancel signal — accept loops bail
  on `<-s.raw.Context().Done()` rather than relying on `ctx` chains.
- `OpenStreamSync` returns `*webtransport.Stream` (NOT `quic.Stream`);
  the API is similar but distinct, and we expose `*webtransport.Stream`
  directly rather than wrap it (slice #3 will revisit when envelope
  framing lands).

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test -race -count=10 ./internal/transport/wt/...` clean (each
      of the 5 channels round-trips; mixed concurrent test; bad
      channel-id reset; daemon `wtSubsystem` start/stop)
- [x] `go test -race -count=1 ./...` full repo green

## Remaining slices

| Slice | Scope |
|---|---|
| **#3 — envelope dispatch** | Decode §3.3.1 wire envelopes off the events channel, replay window + dedup LRU, route to per-session pubsub. JSON-NL framing on top of the channel bytes. |
| **#4 — pairing + auth** | X25519 ECDH handshake from `internal/crypto`, per-session keys, refuse unauthenticated upgrades, origin pinning, stream-tag deadline tightening. |
| **#5 — replace UDS attach** | Switch desktop / mobile clients off the local Unix socket onto WT entirely; local `tether attach` shell stays on UDS by design. |

🤖 Generated with [Claude Code](https://claude.com/claude-code)