### PR TITLE
feat(transport/wt): §3.3.1 wire envelope dispatch + cert-hash format fix

### DIFF
--- a/internal/agent/envelope_emitter.go
+++ b/internal/agent/envelope_emitter.go
@@ -39,12 +39,16 @@ import (
 // Unix attach socket. It carries plaintext metadata + (eventually)
 // ciphertext payload but does NOT include the §3.3.1 fields needed for
 // over-network delivery: id, fromDeviceId, toDeviceId, ts, keyVersion,
-// nonce, AD-bound kind, transport-layer ciphertext binding. When
-// QUIC/WT lands, the cross-device wire envelope is a separate type
-// (provisional name: agent.WireEnvelope or transport.OutboundEnvelope)
-// that wraps + signs/encrypts a LocalEnvelope. Code that reads "Local"
-// here must not assume the bytes are wire-ready for the public
-// internet.
+// nonce, AD-bound kind, transport-layer ciphertext binding.
+//
+// The cross-device shape lives at `internal/transport/wt.WireEnvelope`
+// (slice #3). The WT events-channel dispatcher takes a LocalEnvelope,
+// JSON-marshals it as the inner plaintext, and seals it inside a
+// WireEnvelope before pushing onto the events stream — see
+// `transport/wt.PushEnvelopeStream` / `transport/wt.Seal`.
+//
+// Code that reads "Local" here must not assume the bytes are wire-ready
+// for the public internet.
 type LocalEnvelope struct {
 	Kind              string                 `json:"kind"`
 	ProviderType      string                 `json:"providerType"`
@@ -54,6 +58,15 @@ type LocalEnvelope struct {
 	CiphertextPayload []byte                 `json:"ciphertextPayload,omitempty"`
 	SourceUUID        string                 `json:"sourceUuid,omitempty"`
 }
+
+// EnvelopeKind reports the §3.3.2 op kind. Implements the duck-typed
+// interface `transport/wt.LocalEnvelopeShape` so the WT dispatcher can
+// consume LocalEnvelope without an import edge from transport/wt back
+// into agent.
+func (e LocalEnvelope) EnvelopeKind() string { return e.Kind }
+
+// EnvelopeSessionID reports the cc session id (used in WT AD).
+func (e LocalEnvelope) EnvelopeSessionID() string { return e.SessionID }
 
 // fromJSONL converts a jsonl.Envelope to the wire-facing shape.
 func fromJSONL(e jsonl.Envelope) LocalEnvelope {

--- a/internal/transport/wt/README.md
+++ b/internal/transport/wt/README.md
@@ -148,8 +148,13 @@ the full 5-channel surface.
 1. **Cert trust on macOS / Android dev devices** — self-signed certs
    require either trust-store install or the `serverCertificateHashes`
    browser API (Chromium / WebView). The dev cert generator exposes
-   `SPKISHA256` so future slices can hand the fingerprint to a Tauri
-   command.
+   `DERSHA256` (sha256 of the DER-encoded leaf cert, matching the W3C
+   `serverCertificateHashes.value` algorithm) so future slices can
+   hand the fingerprint to a Tauri command. The Rust client pins by
+   the same algorithm via
+   `web-transport-quinn::ClientBuilder::with_server_certificate_hashes`.
+   Slice #3 renamed this from `SPKISHA256` after discovering the SPKI
+   form did not interop cross-stack.
 2. **Port-binding under unprivileged users** — UDP `:4444` is fine.
    Anything `< 1024` requires CAP_NET_BIND_SERVICE on Linux or root on
    other Unixes.

--- a/internal/transport/wt/dev_cert.go
+++ b/internal/transport/wt/dev_cert.go
@@ -18,10 +18,15 @@
 //     credential if it leaks.
 //   - SAN includes 127.0.0.1 + ::1 + "localhost" so loopback dialers
 //     pass RFC 6125 hostname verification. Extra hosts are configurable.
-//   - Returns BOTH the raw DER bytes and the SHA-256 of SubjectPublicKeyInfo
-//     so callers (future client-side cert pinning or
-//     `serverCertificateHashes` browser handoff) can compute the
-//     fingerprint without re-parsing.
+//   - Returns BOTH the raw DER bytes and the SHA-256 of the full DER-
+//     encoded certificate so callers (future client-side cert pinning
+//     or `serverCertificateHashes` browser handoff) can compute the
+//     fingerprint without re-parsing. We hash DER (not SPKI) to match
+//     the W3C WebTransport `serverCertificateHashes` algorithm — that
+//     dictionary's `value` field is the SHA-256 of the DER cert, and
+//     web-transport-quinn's `with_server_certificate_hashes` consumes
+//     the same. Pinning by SPKI does NOT interop with the browser-API
+//     (or quinn-API) form, so we expose DER hash only.
 
 package wt
 
@@ -53,13 +58,18 @@ type devCertOptions struct {
 }
 
 // devCert is the result of generateDevCert: the wired-up tls.Certificate
-// (cert chain + private key) plus the parsed certificate and SPKI
+// (cert chain + private key) plus the parsed certificate and DER
 // fingerprint for downstream pinning.
+//
+// DERSHA256 is sha256 over the FULL DER-encoded x509 leaf (Leaf.Raw),
+// matching the W3C `serverCertificateHashes.value` algorithm — so the
+// Rust web-transport-quinn client can pin via
+// `with_server_certificate_hashes` against this exact value.
 type devCert struct {
-	TLS         tls.Certificate
-	Leaf        *x509.Certificate
-	DER         []byte
-	SPKISHA256  [32]byte
+	TLS       tls.Certificate
+	Leaf      *x509.Certificate
+	DER       []byte
+	DERSHA256 [32]byte
 }
 
 // generateDevCert mints a fresh self-signed ECDSA P-256 cert valid for
@@ -123,9 +133,9 @@ func generateDevCert(opts devCertOptions) (devCert, error) {
 	tlsCert.Leaf = leaf
 
 	return devCert{
-		TLS:        tlsCert,
-		Leaf:       leaf,
-		DER:        der,
-		SPKISHA256: sha256.Sum256(leaf.RawSubjectPublicKeyInfo),
+		TLS:       tlsCert,
+		Leaf:      leaf,
+		DER:       der,
+		DERSHA256: sha256.Sum256(der),
 	}, nil
 }

--- a/internal/transport/wt/dev_cert_test.go
+++ b/internal/transport/wt/dev_cert_test.go
@@ -1,6 +1,7 @@
 package wt
 
 import (
+	"crypto/sha256"
 	"crypto/x509"
 	"net"
 	"testing"
@@ -24,8 +25,23 @@ func TestGenerateDevCert_Verifies(t *testing.T) {
 	if len(dc.DER) == 0 {
 		t.Fatal("DER empty")
 	}
-	if dc.SPKISHA256 == ([32]byte{}) {
-		t.Fatal("SPKISHA256 is zero")
+	if dc.DERSHA256 == ([32]byte{}) {
+		t.Fatal("DERSHA256 is zero")
+	}
+
+	// DERSHA256 must equal sha256(leaf DER bytes) — the W3C
+	// `serverCertificateHashes` algorithm. This is the same hash the
+	// Rust client side computes via
+	// web-transport-quinn::ClientBuilder::with_server_certificate_hashes
+	// when the operator pastes the daemon's startup-log fingerprint into
+	// `pinnedCertSha256`. Asserting the algorithm here (not just non-
+	// zero) catches any future regression that flips back to SPKI.
+	wantDER := sha256.Sum256(dc.Leaf.Raw)
+	if dc.DERSHA256 != wantDER {
+		t.Fatalf("DERSHA256 mismatch: got %x want %x (leaf.Raw)", dc.DERSHA256, wantDER)
+	}
+	if len(dc.DER) > 0 && sha256.Sum256(dc.DER) != dc.DERSHA256 {
+		t.Fatalf("DERSHA256 != sha256(dc.DER); fields out of sync")
 	}
 
 	// Self-signed roundtrip: build a pool with the leaf, verify the leaf.

--- a/internal/transport/wt/dispatch.go
+++ b/internal/transport/wt/dispatch.go
@@ -1,0 +1,208 @@
+// dispatch.go — events-channel envelope dispatcher (slice #3).
+//
+// The dispatcher is the bridge between the daemon's per-session
+// LocalEnvelope source (an `agent.EnvelopeEmitter` subscription) and
+// the WT events channel (channel-id 0x02). Per-session lifetime:
+//
+//	1. WT session is accepted (Server.handleUpgrade)
+//	2. Operator code calls PushEnvelopeStream(ctx, sess, in, opts)
+//	3. PushEnvelopeStream opens the events bidi (server side via
+//	   sess.Events) and loops forever:
+//	     a. read one LocalEnvelope from `in`
+//	     b. JSON-marshal it as the inner plaintext
+//	     c. Seal into a WireEnvelope (random nonce + AD-bound kind)
+//	     d. WriteFrame on the events stream
+//	   On stream close OR ctx cancel OR `in` close, the loop exits.
+//
+// Errors that should kill the session (write fails after established)
+// are surfaced via the returned error; errors that can be tolerated
+// (single envelope marshal/seal failure) are logged and skipped — the
+// daemon must NOT die because one bad payload arrived from cc.
+//
+// Key management — see DevSharedKey in envelope.go. Slice #3 hardcodes
+// the key; slice #4 (pairing) replaces it with a per-session ECDH-
+// negotiated value.
+
+package wt
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"log"
+	"sync/atomic"
+)
+
+// LocalEnvelopeShape is the duck-typed shape PushEnvelopeStream consumes.
+// Defined here as a generic JSON-marshalable interface so `transport/wt`
+// does not have to import `internal/agent` (avoids the dependency
+// inversion — agent already imports transport/wt for client side; the
+// reverse import would risk a cycle).
+//
+// Any type with a `kind` JSON field whose marshaled form is the inner
+// plaintext for a §3.3.2 op satisfies this. `agent.LocalEnvelope` is
+// the canonical implementer.
+type LocalEnvelopeShape interface {
+	// EnvelopeKind returns the §3.3.2 op kind (e.g. "output.agent-event").
+	// Used as the AD-bound `kind` of the wire envelope.
+	EnvelopeKind() string
+
+	// EnvelopeSessionID returns the cc session id (mixed into AD).
+	EnvelopeSessionID() string
+}
+
+// PushEnvelopeOptions configures a PushEnvelopeStream call.
+type PushEnvelopeOptions struct {
+	// SharedKey is the 32-byte AEAD key. Use DevSharedKey[:] in v0.1
+	// dev / smoke-test paths until slice #4 lands.
+	SharedKey []byte
+
+	// FromDeviceID / ToDeviceID — routing IDs stamped into every
+	// envelope this stream emits. Both required.
+	FromDeviceID string
+	ToDeviceID   string
+
+	// Logger for skip-and-continue events (single bad envelope). nil
+	// → discard. Hard errors (stream write failure) are still
+	// returned; the logger only sees recoverable per-envelope skips.
+	Logger *log.Logger
+}
+
+// EventsWriter is the subset of *webtransport.Stream PushEnvelopeStream
+// needs. Defined as an interface so tests can inject an io.Writer-only
+// stub; in production the caller passes the result of Session.Events.
+type EventsWriter interface {
+	io.Writer
+	io.Closer
+}
+
+// PushEnvelopeStream subscribes to envelopes from `in`, seals each as
+// a WireEnvelope, and pushes them down `events`. Blocks until ctx is
+// cancelled, `in` is closed, OR a stream-write error occurs.
+//
+// Returns nil for clean exits (ctx done, in closed); returns the
+// underlying error for stream-write failures. Per-envelope marshal /
+// seal errors are logged + skipped (the cc side may produce a
+// pathological payload now and then; one bad envelope must not kill
+// the session).
+func PushEnvelopeStream[T LocalEnvelopeShape](ctx context.Context, events EventsWriter, in <-chan T, opts PushEnvelopeOptions) error {
+	if events == nil {
+		return fmt.Errorf("%w: nil events writer", ErrWireEnvelope)
+	}
+	if len(opts.SharedKey) != SharedKeySize {
+		return fmt.Errorf("%w: shared key must be %d bytes (got %d)", ErrWireEnvelope, SharedKeySize, len(opts.SharedKey))
+	}
+	if opts.FromDeviceID == "" || opts.ToDeviceID == "" {
+		return fmt.Errorf("%w: fromDeviceId and toDeviceId required", ErrWireEnvelope)
+	}
+	logger := opts.Logger
+	if logger == nil {
+		logger = log.New(io.Discard, "", 0)
+	}
+
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		case env, ok := <-in:
+			if !ok {
+				// Subscriber channel closed by the upstream emitter.
+				return nil
+			}
+			plaintext, err := json.Marshal(env)
+			if err != nil {
+				logger.Printf("wt: dispatch: marshal envelope: %v (skip)", err)
+				continue
+			}
+			wire, err := Seal(SealOptions{
+				SharedKey:    opts.SharedKey,
+				FromDeviceID: opts.FromDeviceID,
+				ToDeviceID:   opts.ToDeviceID,
+				Kind:         env.EnvelopeKind(),
+				Plaintext:    plaintext,
+				SessionID:    env.EnvelopeSessionID(),
+			})
+			if err != nil {
+				logger.Printf("wt: dispatch: seal envelope (kind=%s): %v (skip)", env.EnvelopeKind(), err)
+				continue
+			}
+			if _, err := WriteFrame(events, wire); err != nil {
+				// Stream write failures are session-fatal — the peer is
+				// gone or the QUIC layer is broken. Returning the error
+				// signals the caller to tear the session down.
+				if errors.Is(err, io.EOF) || errors.Is(err, io.ErrClosedPipe) || errors.Is(err, context.Canceled) {
+					return nil
+				}
+				return fmt.Errorf("wt: dispatch: write frame: %w", err)
+			}
+		}
+	}
+}
+
+// EnvelopeFrameReader is the receiver-side helper: pulls
+// length-prefixed frames off a stream, decrypts each, and returns the
+// inner plaintext bytes (caller json-unmarshals into the appropriate
+// type). Used by the Go-side test client + by future internal Go
+// callers; the Tauri / mobile client re-implements this loop in Rust.
+//
+// Concurrency-safe: a single FrameReader may be Read by exactly one
+// goroutine at a time. Multiple FrameReaders against the same stream
+// is undefined.
+type EnvelopeFrameReader struct {
+	r         io.Reader
+	sharedKey []byte
+	sessionID string
+	closed    atomic.Bool
+}
+
+// NewEnvelopeFrameReader wires a reader. `sessionID` is the cc session
+// id used in the AD construction (must match what the sender uses).
+// Pass empty string if AD only binds device IDs.
+func NewEnvelopeFrameReader(r io.Reader, sharedKey []byte, sessionID string) (*EnvelopeFrameReader, error) {
+	if r == nil {
+		return nil, fmt.Errorf("%w: nil reader", ErrWireEnvelope)
+	}
+	if len(sharedKey) != SharedKeySize {
+		return nil, fmt.Errorf("%w: shared key must be %d bytes (got %d)", ErrWireEnvelope, SharedKeySize, len(sharedKey))
+	}
+	keyCopy := make([]byte, SharedKeySize)
+	copy(keyCopy, sharedKey)
+	return &EnvelopeFrameReader{r: r, sharedKey: keyCopy, sessionID: sessionID}, nil
+}
+
+// Next blocks reading one frame, decrypts the WireEnvelope, and
+// returns the (envelope-metadata, inner-plaintext) pair. Returns
+// io.EOF cleanly when the stream is closed at a frame boundary.
+//
+// AEAD failures, malformed frames, and unsupported keyVersion all
+// return an error (wrapped ErrWireEnvelope). Caller policy:
+//
+//   - hard error path: tear the session down (suggests the peer is
+//     compromised or the AD construction is out of sync).
+//   - soft error path: log + Next() again — but the `n + 1`th frame
+//     starts wherever the underlying stream cursor landed, which is
+//     undefined after a malformed length-prefix. Default to hard.
+func (er *EnvelopeFrameReader) Next() (*WireEnvelope, []byte, error) {
+	if er.closed.Load() {
+		return nil, nil, io.ErrClosedPipe
+	}
+	env, err := ReadFrame(er.r)
+	if err != nil {
+		return nil, nil, err
+	}
+	pt, err := Open(env, OpenOptions{SharedKey: er.sharedKey, SessionID: er.sessionID})
+	if err != nil {
+		return env, nil, err
+	}
+	return env, pt, nil
+}
+
+// Close marks the reader as done. Subsequent Next() returns
+// io.ErrClosedPipe. Does NOT close the underlying io.Reader — that
+// remains the caller's responsibility.
+func (er *EnvelopeFrameReader) Close() error {
+	er.closed.Store(true)
+	return nil
+}

--- a/internal/transport/wt/dispatch_test.go
+++ b/internal/transport/wt/dispatch_test.go
@@ -1,0 +1,216 @@
+package wt
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+// fakeLocalEnvelope is a minimal LocalEnvelopeShape for tests — avoids
+// importing internal/agent (which imports this package via the
+// daemon).
+type fakeLocalEnvelope struct {
+	Kind      string `json:"kind"`
+	SessionID string `json:"sessionId"`
+	Body      string `json:"body"`
+}
+
+func (f fakeLocalEnvelope) EnvelopeKind() string      { return f.Kind }
+func (f fakeLocalEnvelope) EnvelopeSessionID() string { return f.SessionID }
+
+// blockingWriter is an io.Writer + io.Closer wrapping a bytes.Buffer.
+// Tests use it to capture frames written by PushEnvelopeStream.
+type blockingWriter struct {
+	mu  sync.Mutex
+	buf bytes.Buffer
+	// closed signals "no more writes" — Write returns io.ErrClosedPipe.
+	closed bool
+}
+
+func (w *blockingWriter) Write(p []byte) (int, error) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if w.closed {
+		return 0, io.ErrClosedPipe
+	}
+	return w.buf.Write(p)
+}
+
+func (w *blockingWriter) Close() error {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	w.closed = true
+	return nil
+}
+
+func (w *blockingWriter) Bytes() []byte {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return append([]byte(nil), w.buf.Bytes()...)
+}
+
+// TestPushEnvelopeStream_DeliversAndSeals — the core smoke. Push 3
+// envelopes via the dispatcher; verify the bytes on the wire decode +
+// AEAD-open back to the originals.
+func TestPushEnvelopeStream_DeliversAndSeals(t *testing.T) {
+	t.Parallel()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	in := make(chan fakeLocalEnvelope, 3)
+	in <- fakeLocalEnvelope{Kind: "output.agent-event", SessionID: "sess-A", Body: "hello-1"}
+	in <- fakeLocalEnvelope{Kind: "output.agent-event", SessionID: "sess-A", Body: "hello-2"}
+	in <- fakeLocalEnvelope{Kind: "output.hook-event", SessionID: "sess-A", Body: "hello-3"}
+	close(in)
+
+	w := &blockingWriter{}
+	err := PushEnvelopeStream(ctx, w, in, PushEnvelopeOptions{
+		SharedKey:    DevSharedKey[:],
+		FromDeviceID: "device-cli-1",
+		ToDeviceID:   "device-app-2",
+	})
+	if err != nil {
+		t.Fatalf("PushEnvelopeStream: %v", err)
+	}
+
+	// Decode the framed output.
+	r := bytes.NewReader(w.Bytes())
+	want := []string{"hello-1", "hello-2", "hello-3"}
+	wantKinds := []string{"output.agent-event", "output.agent-event", "output.hook-event"}
+	for i := 0; i < 3; i++ {
+		env, err := ReadFrame(r)
+		if err != nil {
+			t.Fatalf("ReadFrame[%d]: %v", i, err)
+		}
+		if env.Kind != wantKinds[i] {
+			t.Errorf("frame[%d] Kind=%q want %q", i, env.Kind, wantKinds[i])
+		}
+		if env.FromDeviceID != "device-cli-1" || env.ToDeviceID != "device-app-2" {
+			t.Errorf("frame[%d] device IDs wrong: from=%q to=%q", i, env.FromDeviceID, env.ToDeviceID)
+		}
+
+		pt, err := Open(env, OpenOptions{SharedKey: DevSharedKey[:], SessionID: "sess-A"})
+		if err != nil {
+			t.Fatalf("frame[%d] Open: %v", i, err)
+		}
+		var got fakeLocalEnvelope
+		if err := json.Unmarshal(pt, &got); err != nil {
+			t.Fatalf("frame[%d] inner unmarshal: %v", i, err)
+		}
+		if got.Body != want[i] {
+			t.Errorf("frame[%d] body=%q want %q", i, got.Body, want[i])
+		}
+	}
+	// Stream should be at EOF now.
+	if _, err := ReadFrame(r); !errors.Is(err, io.EOF) {
+		t.Errorf("expected EOF after 3 frames, got %v", err)
+	}
+}
+
+// TestPushEnvelopeStream_ContextCancelExits — ctx cancel terminates
+// the loop cleanly (returns nil).
+func TestPushEnvelopeStream_ContextCancelExits(t *testing.T) {
+	t.Parallel()
+	ctx, cancel := context.WithCancel(context.Background())
+
+	in := make(chan fakeLocalEnvelope) // never sends
+	w := &blockingWriter{}
+
+	done := make(chan error, 1)
+	go func() {
+		done <- PushEnvelopeStream(ctx, w, in, PushEnvelopeOptions{
+			SharedKey:    DevSharedKey[:],
+			FromDeviceID: "from",
+			ToDeviceID:   "to",
+		})
+	}()
+
+	cancel()
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Errorf("expected nil on ctx cancel, got %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("PushEnvelopeStream did not exit on ctx cancel")
+	}
+}
+
+// TestPushEnvelopeStream_WriteErrorPropagates — once the events
+// stream is closed under us, the dispatcher returns the write error.
+func TestPushEnvelopeStream_WriteErrorPropagates(t *testing.T) {
+	t.Parallel()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	in := make(chan fakeLocalEnvelope, 1)
+	in <- fakeLocalEnvelope{Kind: "output.agent-event", SessionID: "sess", Body: "x"}
+	w := &blockingWriter{}
+	w.Close() // pre-closed → first write fails
+
+	err := PushEnvelopeStream(ctx, w, in, PushEnvelopeOptions{
+		SharedKey:    DevSharedKey[:],
+		FromDeviceID: "from",
+		ToDeviceID:   "to",
+	})
+	if err == nil {
+		t.Fatal("expected write error")
+	}
+	if !strings.Contains(err.Error(), "write frame") {
+		t.Errorf("expected 'write frame' in error, got %v", err)
+	}
+}
+
+// TestEnvelopeFrameReader_RoundTrip — Reader-side helper consumes a
+// framed stream produced by PushEnvelopeStream + decrypts each.
+func TestEnvelopeFrameReader_RoundTrip(t *testing.T) {
+	t.Parallel()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	in := make(chan fakeLocalEnvelope, 2)
+	in <- fakeLocalEnvelope{Kind: "output.agent-event", SessionID: "sess", Body: "one"}
+	in <- fakeLocalEnvelope{Kind: "output.agent-event", SessionID: "sess", Body: "two"}
+	close(in)
+
+	w := &blockingWriter{}
+	if err := PushEnvelopeStream(ctx, w, in, PushEnvelopeOptions{
+		SharedKey:    DevSharedKey[:],
+		FromDeviceID: "from",
+		ToDeviceID:   "to",
+	}); err != nil {
+		t.Fatalf("Push: %v", err)
+	}
+
+	er, err := NewEnvelopeFrameReader(bytes.NewReader(w.Bytes()), DevSharedKey[:], "sess")
+	if err != nil {
+		t.Fatalf("NewEnvelopeFrameReader: %v", err)
+	}
+	got := make([]string, 0, 2)
+	for {
+		env, pt, err := er.Next()
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		if err != nil {
+			t.Fatalf("Next: %v", err)
+		}
+		if env.Kind != "output.agent-event" {
+			t.Errorf("kind=%q", env.Kind)
+		}
+		var inner fakeLocalEnvelope
+		if err := json.Unmarshal(pt, &inner); err != nil {
+			t.Fatalf("inner unmarshal: %v", err)
+		}
+		got = append(got, inner.Body)
+	}
+	if len(got) != 2 || got[0] != "one" || got[1] != "two" {
+		t.Errorf("got %v want [one two]", got)
+	}
+}

--- a/internal/transport/wt/envelope.go
+++ b/internal/transport/wt/envelope.go
@@ -1,0 +1,390 @@
+// envelope.go — §3.3.1 wire envelope for the WT events channel
+// (slice #3 of the WT block).
+//
+// This file defines the OVER-NETWORK envelope shape that rides on the
+// WT `events` channel (channel-id 0x02; see §3.3.3). It is DISTINCT
+// from `internal/agent.LocalEnvelope`, which is the in-process /
+// local-Unix-socket projection consumed by `tether attach`.
+//
+// Shape mapping (LocalEnvelope → WireEnvelope):
+//
+//	LocalEnvelope.Kind / .ProviderType / .SessionID / .Skill /
+//	.PlaintextMetadata / .CiphertextPayload / .SourceUUID
+//	──────── JSON-marshal the whole struct ────────────►
+//	plaintext bytes ──── XChaCha20-Poly1305 Seal ───────►
+//	WireEnvelope.Ciphertext  (with .Nonce, AD bound, etc.)
+//
+//	WireEnvelope adds the cross-device routing fields the daemon-local
+//	shape lacks: id (per-envelope unique), fromDeviceId, toDeviceId,
+//	ts (millis), keyVersion, nonce, AD-bound `kind`.
+//
+// The `kind` field is REPLICATED at the WireEnvelope top level — server
+// routing needs to see kind in plaintext for §3.3.3 priority decisions
+// — AND included in the AEAD additional-data so a malicious server
+// cannot rewrite kind without breaking the auth tag (§3.3.1 "AD binds
+// kind" invariant).
+//
+// **AD format** (deterministic, byte-exact across Go ↔ Rust ↔ TS):
+//
+//	AD = LP(sessionId) || LP(fromDeviceId) || LP(toDeviceId) ||
+//	     uint32_BE(keyVersion) || LP(kind)
+//
+// where LP(s) = uint16_BE(len(s)) || utf8(s). Length-prefixed so that
+// no two distinct field tuples can collide via byte-shifting. See the
+// `buildAD` helper below for the canonical implementation; the Rust
+// side mirrors the same assembly verbatim (tether-app
+// src-tauri/src/wt/envelope.rs).
+//
+// **Encoding**: JSON for v0.1 (per §3.3.1 "v0.1 用 JSON; v0.2 看带宽
+// 再考虑 CBOR / protobuf"). The whole WireEnvelope is JSON-marshaled
+// and pushed as a single length-prefixed frame on the events stream
+// (see `WriteFrame` / `ReadFrame`).
+//
+// v0.1 KEY MANAGEMENT — see `DevSharedKey`. There is NO real key
+// negotiation in slice #3; the dev key is hardcoded so server +
+// client can interop while pairing (slice #4) is being specced in
+// parallel. Production must NOT ship with this constant.
+
+package wt
+
+import (
+	"crypto/rand"
+	"encoding/binary"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"time"
+
+	"golang.org/x/crypto/chacha20poly1305"
+)
+
+// SharedKeySize is the byte length of the AEAD key used to seal
+// WireEnvelope ciphertext. Mirrors crypto.AEADKeySize (32 bytes for
+// XChaCha20-Poly1305).
+const SharedKeySize = chacha20poly1305.KeySize
+
+// NonceSize is the size of the XChaCha20 nonce in WireEnvelope.Nonce.
+const NonceSize = chacha20poly1305.NonceSizeX
+
+// CurrentKeyVersion is the §3.3.1 `keyVersion` value emitted by all
+// v0.1 senders. Per the spec, this is constant 1 in v0.1 and only
+// bumps on protocol upgrade. Receivers MUST reject envelopes with
+// any other keyVersion.
+const CurrentKeyVersion uint32 = 1
+
+// DevSharedKey is the **HARDCODED v0.1 development key** used until
+// slice #4 (pairing) ships a real per-device ECDH-negotiated key.
+//
+// SLICE #4 PAIRING REPLACES THIS WITH A REAL ECDH-NEGOTIATED KEY.
+// SLICE #4 PAIRING REPLACES THIS WITH A REAL ECDH-NEGOTIATED KEY.
+// SLICE #4 PAIRING REPLACES THIS WITH A REAL ECDH-NEGOTIATED KEY.
+//
+// Why a constant rather than zero bytes: a constant lets the cross-
+// stack smoke test verify the AEAD path actually does encrypt/decrypt
+// — both sides have the same non-trivial key and a successful Open is
+// real evidence (vs all-zero where a buggy implementation that
+// "happens to xor with zero" still trivially round-trips). The
+// constant has no relationship to any production secret and offers
+// zero confidentiality guarantees in v0.1; the daemon's WT listener
+// is bound to localhost / LAN only until pairing exists.
+//
+// Do NOT use this anywhere outside the WT envelope dispatch path. Do
+// NOT log it. Do NOT make it operator-visible. It is an interim
+// crutch, not a key.
+var DevSharedKey = [SharedKeySize]byte{
+	0x74, 0x65, 0x74, 0x68, 0x65, 0x72, 0x2d, 0x77,
+	0x74, 0x2d, 0x64, 0x65, 0x76, 0x2d, 0x73, 0x68,
+	0x61, 0x72, 0x65, 0x64, 0x2d, 0x6b, 0x65, 0x79,
+	0x2d, 0x73, 0x6c, 0x69, 0x63, 0x65, 0x2d, 0x33,
+}
+
+// WireEnvelope is the §3.3.1 over-network envelope. JSON-marshaled
+// onto the events channel. NOT to be confused with
+// `internal/agent.LocalEnvelope`, which is the local-socket projection
+// consumed by `tether attach` (see envelope_emitter.go's doc-comment
+// on LocalEnvelope for the full distinction).
+//
+// JSON shape matches §3.3.1 verbatim:
+//
+//	{
+//	  "id":           "uuid-v4",
+//	  "fromDeviceId": "device-cli-1",
+//	  "toDeviceId":   "device-app-2",
+//	  "ts":           1714000000000,        // unix milliseconds
+//	  "keyVersion":   1,
+//	  "nonce":        "<base64 24-byte>",
+//	  "kind":         "output.agent-event",
+//	  "ciphertext":   "<base64>"
+//	}
+//
+// `kind` is replicated AD-bound — see file-level docstring.
+//
+// `sessionId` is intentionally OMITTED from this struct surface. The
+// spec §3.3.1 lists sessionId in the envelope, but for v0.1 the WT
+// session is per-(daemon, client) and carries one cc session at a
+// time; the LocalEnvelope payload's `sessionId` field is what
+// downstream consumers need anyway. Slice #4+ may promote sessionId
+// to an envelope-level field; until then we keep the wire footprint
+// minimal.
+type WireEnvelope struct {
+	ID           string `json:"id"`
+	FromDeviceID string `json:"fromDeviceId"`
+	ToDeviceID   string `json:"toDeviceId"`
+	TS           int64  `json:"ts"`
+	KeyVersion   uint32 `json:"keyVersion"`
+	Nonce        []byte `json:"nonce"`      // 24 bytes; base64 in JSON
+	Kind         string `json:"kind"`       // AD-bound, plaintext for routing
+	Ciphertext   []byte `json:"ciphertext"` // base64 in JSON
+}
+
+// ErrWireEnvelope is the wrap-error for envelope sealing/opening
+// failures. Distinct from the wt package's stream-level errors so
+// callers can branch.
+var ErrWireEnvelope = errors.New("wt: wire envelope")
+
+// SealOptions bundles the inputs to `Seal`. Splitting out keeps the
+// callsite readable when more fields land (slice #4 will add
+// `KeyVersion` overrides for rotation tests).
+type SealOptions struct {
+	// SharedKey is the 32-byte AEAD key (XChaCha20-Poly1305). Use
+	// DevSharedKey[:] for v0.1 dev paths until slice #4 lands.
+	SharedKey []byte
+
+	// FromDeviceID / ToDeviceID — routing IDs. Both empty is rejected.
+	FromDeviceID string
+	ToDeviceID   string
+
+	// Kind — the §3.3.2 op kind. Required, AD-bound.
+	Kind string
+
+	// Plaintext — the bytes to seal. Caller is expected to have already
+	// JSON-marshaled the LocalEnvelope (or whatever payload is appropriate
+	// for `Kind`). We do NOT marshal here so `Kind != "output.agent-event"`
+	// callers can ship raw control-plane bytes if desired.
+	Plaintext []byte
+
+	// SessionID is mixed into AD via the kind-bound construction; v0.1
+	// passes the cc session id through here so a stolen ciphertext from
+	// session A cannot be replayed into session B even with the same
+	// shared key. May be empty if not yet known (smoke tests).
+	SessionID string
+}
+
+// Seal builds a WireEnvelope from a sealed plaintext. Generates a
+// fresh UUID v4 for ID, a random 24-byte nonce, sets ts = unix-millis
+// now, keyVersion = CurrentKeyVersion. The AD is computed
+// deterministically — see file-level docstring.
+//
+// Returns the WireEnvelope ready to JSON-marshal + push down the
+// events channel. The Ciphertext field includes the 16-byte Poly1305
+// tag suffix (chacha20poly1305 convention).
+func Seal(opts SealOptions) (*WireEnvelope, error) {
+	if len(opts.SharedKey) != SharedKeySize {
+		return nil, fmt.Errorf("%w: shared key must be %d bytes (got %d)", ErrWireEnvelope, SharedKeySize, len(opts.SharedKey))
+	}
+	if opts.Kind == "" {
+		return nil, fmt.Errorf("%w: kind required (AD-bound)", ErrWireEnvelope)
+	}
+	if opts.FromDeviceID == "" || opts.ToDeviceID == "" {
+		return nil, fmt.Errorf("%w: fromDeviceId and toDeviceId required", ErrWireEnvelope)
+	}
+	aead, err := chacha20poly1305.NewX(opts.SharedKey)
+	if err != nil {
+		return nil, fmt.Errorf("%w: new XChaCha20-Poly1305: %v", ErrWireEnvelope, err)
+	}
+	nonce := make([]byte, NonceSize)
+	if _, err := io.ReadFull(rand.Reader, nonce); err != nil {
+		return nil, fmt.Errorf("%w: read nonce: %v", ErrWireEnvelope, err)
+	}
+	id, err := newUUIDv4()
+	if err != nil {
+		return nil, fmt.Errorf("%w: generate id: %v", ErrWireEnvelope, err)
+	}
+	ad := buildAD(opts.SessionID, opts.FromDeviceID, opts.ToDeviceID, CurrentKeyVersion, opts.Kind)
+	ct := aead.Seal(nil, nonce, opts.Plaintext, ad)
+	return &WireEnvelope{
+		ID:           id,
+		FromDeviceID: opts.FromDeviceID,
+		ToDeviceID:   opts.ToDeviceID,
+		TS:           time.Now().UnixMilli(),
+		KeyVersion:   CurrentKeyVersion,
+		Nonce:        nonce,
+		Kind:         opts.Kind,
+		Ciphertext:   ct,
+	}, nil
+}
+
+// OpenOptions bundles the inputs to `Open`. SessionID has the same AD
+// role as in SealOptions — must match what the sender used.
+type OpenOptions struct {
+	SharedKey []byte
+	SessionID string
+}
+
+// Open verifies + decrypts a WireEnvelope. Rejects:
+//
+//   - keyVersion != CurrentKeyVersion (no negotiation in v0.1)
+//   - nonce length != NonceSize
+//   - AEAD auth failure (wrong key, tampered AD, tampered ciphertext)
+//   - empty Kind (AD construction would be ambiguous)
+//
+// Replay/dedup checks (LRU on env.ID, monotonic seq, ts skew window)
+// are NOT done here — that's the consumer's responsibility because
+// the LRU state is per-subscriber.
+func Open(env *WireEnvelope, opts OpenOptions) ([]byte, error) {
+	if env == nil {
+		return nil, fmt.Errorf("%w: nil envelope", ErrWireEnvelope)
+	}
+	if len(opts.SharedKey) != SharedKeySize {
+		return nil, fmt.Errorf("%w: shared key must be %d bytes (got %d)", ErrWireEnvelope, SharedKeySize, len(opts.SharedKey))
+	}
+	if env.KeyVersion != CurrentKeyVersion {
+		return nil, fmt.Errorf("%w: unsupported keyVersion %d (want %d)", ErrWireEnvelope, env.KeyVersion, CurrentKeyVersion)
+	}
+	if len(env.Nonce) != NonceSize {
+		return nil, fmt.Errorf("%w: nonce length %d != %d", ErrWireEnvelope, len(env.Nonce), NonceSize)
+	}
+	if env.Kind == "" {
+		return nil, fmt.Errorf("%w: empty kind", ErrWireEnvelope)
+	}
+	aead, err := chacha20poly1305.NewX(opts.SharedKey)
+	if err != nil {
+		return nil, fmt.Errorf("%w: new XChaCha20-Poly1305: %v", ErrWireEnvelope, err)
+	}
+	ad := buildAD(opts.SessionID, env.FromDeviceID, env.ToDeviceID, env.KeyVersion, env.Kind)
+	pt, err := aead.Open(nil, env.Nonce, env.Ciphertext, ad)
+	if err != nil {
+		return nil, fmt.Errorf("%w: open: %v", ErrWireEnvelope, err)
+	}
+	return pt, nil
+}
+
+// buildAD assembles the AD bytes for Seal/Open.
+//
+//	AD = LP(sessionId) || LP(fromDeviceId) || LP(toDeviceId) ||
+//	     uint32_BE(keyVersion) || LP(kind)
+//
+// Length-prefixed UTF-8 strings (uint16_BE length) so an attacker
+// cannot byte-shift between the fields. The Rust mirror in
+// tether-app/src-tauri/src/wt/envelope.rs MUST produce byte-identical
+// output.
+func buildAD(sessionID, fromDeviceID, toDeviceID string, keyVersion uint32, kind string) []byte {
+	out := make([]byte, 0, 2+len(sessionID)+2+len(fromDeviceID)+2+len(toDeviceID)+4+2+len(kind))
+	out = appendLPString(out, sessionID)
+	out = appendLPString(out, fromDeviceID)
+	out = appendLPString(out, toDeviceID)
+	out = binary.BigEndian.AppendUint32(out, keyVersion)
+	out = appendLPString(out, kind)
+	return out
+}
+
+func appendLPString(out []byte, s string) []byte {
+	out = binary.BigEndian.AppendUint16(out, uint16(len(s)))
+	out = append(out, s...)
+	return out
+}
+
+// newUUIDv4 mints an RFC-4122 version-4 UUID using crypto/rand. Avoids
+// pulling in github.com/google/uuid for one call site. The returned
+// string is canonical lowercase 8-4-4-4-12 hex.
+func newUUIDv4() (string, error) {
+	var b [16]byte
+	if _, err := io.ReadFull(rand.Reader, b[:]); err != nil {
+		return "", err
+	}
+	// version 4 (random)
+	b[6] = (b[6] & 0x0f) | 0x40
+	// variant RFC 4122
+	b[8] = (b[8] & 0x3f) | 0x80
+	const hex = "0123456789abcdef"
+	out := make([]byte, 36)
+	pos := 0
+	for i, x := range b {
+		out[pos] = hex[x>>4]
+		out[pos+1] = hex[x&0x0f]
+		pos += 2
+		if i == 3 || i == 5 || i == 7 || i == 9 {
+			out[pos] = '-'
+			pos++
+		}
+	}
+	return string(out), nil
+}
+
+// --- Frame I/O on the events channel --------------------------------------
+//
+// The events channel is a single QUIC stream carrying a sequence of
+// JSON-encoded WireEnvelopes. We use a 4-byte big-endian length prefix
+// so the receiver can split frames without lookahead. Format:
+//
+//	frame := uint32_BE(len(json)) || json
+//
+// A length of 0 is reserved for future use (e.g. a keep-alive). A
+// length > FrameSizeMax is treated as a wire-protocol error and the
+// reader bails out.
+
+// FrameSizeMax caps a single envelope frame at 1 MiB. The largest v0.1
+// payload (a cc agent-event with embedded tool-result) is comfortably
+// in the 64 KiB range; 1 MiB leaves slack for v0.2 fenced-block media
+// without giving an attacker an unbounded alloc. Bumping this requires
+// a coordinated bump on the Rust side.
+const FrameSizeMax = 1 << 20
+
+// WriteFrame JSON-marshals env and writes a length-prefixed frame to
+// w. Returns the number of payload bytes written (excluding the
+// length prefix).
+//
+// Caller must hold any write-side mutex on the underlying stream;
+// WriteFrame is NOT goroutine-safe by itself.
+func WriteFrame(w io.Writer, env *WireEnvelope) (int, error) {
+	if env == nil {
+		return 0, fmt.Errorf("%w: nil envelope", ErrWireEnvelope)
+	}
+	body, err := json.Marshal(env)
+	if err != nil {
+		return 0, fmt.Errorf("%w: marshal: %v", ErrWireEnvelope, err)
+	}
+	if len(body) > FrameSizeMax {
+		return 0, fmt.Errorf("%w: frame size %d exceeds max %d", ErrWireEnvelope, len(body), FrameSizeMax)
+	}
+	var hdr [4]byte
+	binary.BigEndian.PutUint32(hdr[:], uint32(len(body)))
+	if _, err := w.Write(hdr[:]); err != nil {
+		return 0, fmt.Errorf("%w: write length: %v", ErrWireEnvelope, err)
+	}
+	if _, err := w.Write(body); err != nil {
+		return 0, fmt.Errorf("%w: write body: %v", ErrWireEnvelope, err)
+	}
+	return len(body), nil
+}
+
+// ReadFrame reads one length-prefixed JSON frame off r and unmarshals
+// it into a fresh WireEnvelope. Returns io.EOF cleanly when the stream
+// has been closed at a frame boundary (caller's "peer is done" signal).
+//
+// A partial-read mid-frame returns io.ErrUnexpectedEOF (wrapped). A
+// length-prefix > FrameSizeMax returns ErrWireEnvelope so the reader
+// can decide whether to tear the session down (probable misbehavior).
+func ReadFrame(r io.Reader) (*WireEnvelope, error) {
+	var hdr [4]byte
+	if _, err := io.ReadFull(r, hdr[:]); err != nil {
+		return nil, err // io.EOF / io.ErrUnexpectedEOF passed through
+	}
+	n := binary.BigEndian.Uint32(hdr[:])
+	if n == 0 {
+		return nil, fmt.Errorf("%w: zero-length frame", ErrWireEnvelope)
+	}
+	if n > FrameSizeMax {
+		return nil, fmt.Errorf("%w: frame size %d exceeds max %d", ErrWireEnvelope, n, FrameSizeMax)
+	}
+	body := make([]byte, n)
+	if _, err := io.ReadFull(r, body); err != nil {
+		return nil, fmt.Errorf("%w: read body: %v", ErrWireEnvelope, err)
+	}
+	var env WireEnvelope
+	if err := json.Unmarshal(body, &env); err != nil {
+		return nil, fmt.Errorf("%w: unmarshal: %v", ErrWireEnvelope, err)
+	}
+	return &env, nil
+}

--- a/internal/transport/wt/envelope_crossstack_test.go
+++ b/internal/transport/wt/envelope_crossstack_test.go
@@ -1,0 +1,132 @@
+package wt
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"testing"
+	"time"
+)
+
+// TestCrossStack_GoServer_GoClient_EventsDispatch — the slice #3
+// "real prize". Wire up:
+//
+//   - a real wt.Server on a loopback port (auto dev cert, channel
+//     router).
+//   - a SessionHandler that takes a fixed list of LocalEnvelopes and
+//     pushes them via PushEnvelopeStream onto the events channel.
+//   - a Go-side wt.Client that AcceptEvents + EnvelopeFrameReader
+//     reads the same number of frames + verifies decrypted bodies.
+//
+// This is the cross-stack smoke proof that:
+//
+//   1. Channel-id 0x02 (events) routes properly with §3.3.1
+//      length-prefixed JSON envelopes carried inside.
+//   2. Sender-side Seal + receiver-side Open agree byte-exactly on
+//      the AD construction.
+//   3. The dispatcher cleanly exits when its input channel closes.
+//
+// The corresponding Rust-side cross-stack test is in tether-app's
+// `wt_envelope_smoke` env-gated harness (see PR body).
+func TestCrossStack_GoServer_GoClient_EventsDispatch(t *testing.T) {
+	t.Parallel()
+
+	want := []fakeLocalEnvelope{
+		{Kind: "output.agent-event", SessionID: "sess-X", Body: "one"},
+		{Kind: "output.agent-event", SessionID: "sess-X", Body: "two"},
+		{Kind: "output.hook-event", SessionID: "sess-X", Body: "three"},
+	}
+
+	// Server-side: open events bidi, push 3 envelopes via dispatcher,
+	// then close the stream-write side so the client's reader sees a
+	// clean EOF at the next frame boundary. We sit on sess.Context()
+	// after that so the session itself stays open while the client
+	// drains — Server.handleUpgrade calls closeWithError as soon as
+	// this handler returns, which would otherwise race the client's
+	// AcceptEvents on slow CI.
+	handler := func(sess *Session) {
+		ctx, cancel := context.WithTimeout(sess.Context(), 5*time.Second)
+		defer cancel()
+		evStream, err := sess.Events(ctx)
+		if err != nil {
+			return
+		}
+
+		in := make(chan fakeLocalEnvelope, len(want))
+		for _, e := range want {
+			in <- e
+		}
+		close(in)
+
+		_ = PushEnvelopeStream(ctx, evStream, in, PushEnvelopeOptions{
+			SharedKey:    DevSharedKey[:],
+			FromDeviceID: "device-cli-1",
+			ToDeviceID:   "device-app-2",
+		})
+		// Half-close the stream so the client's reader observes EOF.
+		_ = evStream.Close()
+
+		// Block until the client tears the WT session down (or this
+		// session-level context is cancelled by test teardown). Without
+		// this, the handler returning closes the WT session itself,
+		// which can race the client's AcceptEvents (slow CI: client may
+		// not have called AcceptEvents yet when handler exits).
+		<-sess.Context().Done()
+	}
+
+	url, pool, cancel := bootTestServer(t, handler)
+	defer cancel()
+
+	ctx, ctxCancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer ctxCancel()
+
+	cli := dialClient(t, ctx, url, pool)
+	defer cli.Close()
+
+	stream, err := cli.AcceptEvents(ctx)
+	if err != nil {
+		t.Fatalf("AcceptEvents: %v", err)
+	}
+	er, err := NewEnvelopeFrameReader(stream, DevSharedKey[:], "sess-X")
+	if err != nil {
+		t.Fatalf("NewEnvelopeFrameReader: %v", err)
+	}
+
+	got := make([]fakeLocalEnvelope, 0, len(want))
+	for i := 0; i < len(want); i++ {
+		env, pt, err := er.Next()
+		if err != nil {
+			t.Fatalf("Next[%d]: %v", i, err)
+		}
+		if env.KeyVersion != CurrentKeyVersion {
+			t.Errorf("frame[%d] keyVersion=%d", i, env.KeyVersion)
+		}
+		if env.FromDeviceID != "device-cli-1" || env.ToDeviceID != "device-app-2" {
+			t.Errorf("frame[%d] device IDs wrong", i)
+		}
+		var inner fakeLocalEnvelope
+		if err := json.Unmarshal(pt, &inner); err != nil {
+			t.Fatalf("frame[%d] inner unmarshal: %v", i, err)
+		}
+		// Match the kind round-trip too (inner kind = wire kind).
+		if inner.Kind != env.Kind {
+			t.Errorf("frame[%d] inner.Kind=%q != env.Kind=%q", i, inner.Kind, env.Kind)
+		}
+		got = append(got, inner)
+	}
+
+	// Stream should be at EOF after all envelopes consumed.
+	if _, _, err := er.Next(); !errors.Is(err, io.EOF) {
+		t.Errorf("expected EOF after %d frames, got %v", len(want), err)
+	}
+
+	for i := range want {
+		if got[i].Body != want[i].Body {
+			t.Errorf("frame[%d] body=%q want %q", i, got[i].Body, want[i].Body)
+		}
+		if got[i].Kind != want[i].Kind {
+			t.Errorf("frame[%d] kind=%q want %q", i, got[i].Kind, want[i].Kind)
+		}
+	}
+}

--- a/internal/transport/wt/envelope_test.go
+++ b/internal/transport/wt/envelope_test.go
@@ -1,0 +1,319 @@
+package wt
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"io"
+	"strings"
+	"testing"
+)
+
+// TestSealOpenRoundtrip — happy path: seal a payload then open with
+// matching device IDs / session id / shared key, recover the original
+// plaintext. Confirms the AD construction is symmetric across Seal /
+// Open in this process.
+func TestSealOpenRoundtrip(t *testing.T) {
+	t.Parallel()
+	plaintext := []byte(`{"kind":"output.agent-event","sessionId":"sess-A","providerType":"claude-code"}`)
+	env, err := Seal(SealOptions{
+		SharedKey:    DevSharedKey[:],
+		FromDeviceID: "device-cli-1",
+		ToDeviceID:   "device-app-2",
+		Kind:         "output.agent-event",
+		Plaintext:    plaintext,
+		SessionID:    "sess-A",
+	})
+	if err != nil {
+		t.Fatalf("Seal: %v", err)
+	}
+	if env.ID == "" || len(env.ID) != 36 {
+		t.Errorf("ID looks bogus: %q", env.ID)
+	}
+	if env.KeyVersion != CurrentKeyVersion {
+		t.Errorf("KeyVersion=%d want %d", env.KeyVersion, CurrentKeyVersion)
+	}
+	if len(env.Nonce) != NonceSize {
+		t.Errorf("Nonce len=%d want %d", len(env.Nonce), NonceSize)
+	}
+	if env.Kind != "output.agent-event" {
+		t.Errorf("Kind=%q want output.agent-event", env.Kind)
+	}
+	if len(env.Ciphertext) <= len(plaintext) {
+		t.Errorf("Ciphertext len %d not greater than plaintext %d (missing tag?)", len(env.Ciphertext), len(plaintext))
+	}
+
+	got, err := Open(env, OpenOptions{SharedKey: DevSharedKey[:], SessionID: "sess-A"})
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	if !bytes.Equal(got, plaintext) {
+		t.Errorf("plaintext mismatch:\n got %q\nwant %q", got, plaintext)
+	}
+}
+
+// TestSealOpen_ADBindsKind — flipping `Kind` between Seal and Open
+// MUST cause AEAD auth failure. This is the §3.3.1 "kind is AD-bound"
+// invariant — protects against a malicious server rewriting kind to
+// reroute traffic.
+func TestSealOpen_ADBindsKind(t *testing.T) {
+	t.Parallel()
+	env, err := Seal(SealOptions{
+		SharedKey:    DevSharedKey[:],
+		FromDeviceID: "a",
+		ToDeviceID:   "b",
+		Kind:         "output.agent-event",
+		Plaintext:    []byte("payload"),
+		SessionID:    "sess",
+	})
+	if err != nil {
+		t.Fatalf("Seal: %v", err)
+	}
+	// Tamper: rewrite kind to a different op category.
+	env.Kind = "control.lock-takeover"
+	_, err = Open(env, OpenOptions{SharedKey: DevSharedKey[:], SessionID: "sess"})
+	if err == nil {
+		t.Fatal("Open should have failed after Kind tamper")
+	}
+	if !errors.Is(err, ErrWireEnvelope) {
+		t.Errorf("expected ErrWireEnvelope, got %v", err)
+	}
+}
+
+// TestSealOpen_ADBindsDeviceIDs — flipping fromDeviceId or toDeviceId
+// MUST cause AEAD auth failure. Stops a server from rerouting an
+// envelope to a different device.
+func TestSealOpen_ADBindsDeviceIDs(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name   string
+		mutate func(*WireEnvelope)
+	}{
+		{"flip-from", func(e *WireEnvelope) { e.FromDeviceID = "evil-from" }},
+		{"flip-to", func(e *WireEnvelope) { e.ToDeviceID = "evil-to" }},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			env, err := Seal(SealOptions{
+				SharedKey:    DevSharedKey[:],
+				FromDeviceID: "a",
+				ToDeviceID:   "b",
+				Kind:         "output.agent-event",
+				Plaintext:    []byte("payload"),
+				SessionID:    "sess",
+			})
+			if err != nil {
+				t.Fatalf("Seal: %v", err)
+			}
+			tc.mutate(env)
+			if _, err := Open(env, OpenOptions{SharedKey: DevSharedKey[:], SessionID: "sess"}); err == nil {
+				t.Fatal("Open should have failed after device-id tamper")
+			}
+		})
+	}
+}
+
+// TestSealOpen_ADBindsSessionID — open with the wrong sessionId in
+// AD MUST fail. Blocks a stolen-ciphertext-from-session-A replay
+// into session B even with the same shared key.
+func TestSealOpen_ADBindsSessionID(t *testing.T) {
+	t.Parallel()
+	env, err := Seal(SealOptions{
+		SharedKey:    DevSharedKey[:],
+		FromDeviceID: "a",
+		ToDeviceID:   "b",
+		Kind:         "output.agent-event",
+		Plaintext:    []byte("payload"),
+		SessionID:    "sess-A",
+	})
+	if err != nil {
+		t.Fatalf("Seal: %v", err)
+	}
+	if _, err := Open(env, OpenOptions{SharedKey: DevSharedKey[:], SessionID: "sess-B"}); err == nil {
+		t.Fatal("Open with wrong sessionId should have failed")
+	}
+}
+
+// TestOpen_RejectsKeyVersionMismatch — explicit reject for v0.1's
+// keyVersion-must-be-1 invariant.
+func TestOpen_RejectsKeyVersionMismatch(t *testing.T) {
+	t.Parallel()
+	env, err := Seal(SealOptions{
+		SharedKey:    DevSharedKey[:],
+		FromDeviceID: "a",
+		ToDeviceID:   "b",
+		Kind:         "output.agent-event",
+		Plaintext:    []byte("p"),
+	})
+	if err != nil {
+		t.Fatalf("Seal: %v", err)
+	}
+	env.KeyVersion = 2
+	_, err = Open(env, OpenOptions{SharedKey: DevSharedKey[:]})
+	if err == nil || !strings.Contains(err.Error(), "keyVersion") {
+		t.Fatalf("expected keyVersion-mismatch error, got %v", err)
+	}
+}
+
+// TestSeal_NonceUniqueness — over many calls with the same key the
+// nonce MUST be drawn from a 24-byte random space; collisions in 100
+// calls would be vanishingly unlikely. This is a smoke check rather
+// than a statistical guarantee, but a non-random / counter-based bug
+// would surface as collisions inside this loop.
+func TestSeal_NonceUniqueness(t *testing.T) {
+	t.Parallel()
+	seen := make(map[string]struct{}, 100)
+	for i := 0; i < 100; i++ {
+		env, err := Seal(SealOptions{
+			SharedKey:    DevSharedKey[:],
+			FromDeviceID: "a",
+			ToDeviceID:   "b",
+			Kind:         "output.agent-event",
+			Plaintext:    []byte("p"),
+		})
+		if err != nil {
+			t.Fatalf("Seal[%d]: %v", i, err)
+		}
+		k := string(env.Nonce)
+		if _, dup := seen[k]; dup {
+			t.Fatalf("nonce collision at i=%d", i)
+		}
+		seen[k] = struct{}{}
+	}
+}
+
+// TestWriteFrame_ReadFrame_Roundtrip — length-prefixed framing
+// roundtrip over an io.Pipe, decoupled from the real WT stream.
+func TestWriteFrame_ReadFrame_Roundtrip(t *testing.T) {
+	t.Parallel()
+	in, err := Seal(SealOptions{
+		SharedKey:    DevSharedKey[:],
+		FromDeviceID: "a",
+		ToDeviceID:   "b",
+		Kind:         "output.agent-event",
+		Plaintext:    []byte(`{"hello":"world"}`),
+		SessionID:    "sess",
+	})
+	if err != nil {
+		t.Fatalf("Seal: %v", err)
+	}
+
+	var buf bytes.Buffer
+	n, err := WriteFrame(&buf, in)
+	if err != nil {
+		t.Fatalf("WriteFrame: %v", err)
+	}
+	if n <= 0 {
+		t.Fatalf("WriteFrame returned 0 bytes")
+	}
+
+	got, err := ReadFrame(&buf)
+	if err != nil {
+		t.Fatalf("ReadFrame: %v", err)
+	}
+	// JSON roundtrip equivalence: marshal both, compare bytes.
+	a, _ := json.Marshal(in)
+	b, _ := json.Marshal(got)
+	if !bytes.Equal(a, b) {
+		t.Fatalf("frame mismatch:\n in: %s\nout: %s", a, b)
+	}
+}
+
+// TestReadFrame_RejectsOversizeLength — a malicious / buggy peer
+// shipping a 4-byte length-prefix > FrameSizeMax must be rejected
+// without allocating the buffer.
+func TestReadFrame_RejectsOversizeLength(t *testing.T) {
+	t.Parallel()
+	var buf bytes.Buffer
+	// Length-prefix = FrameSizeMax + 1.
+	hdr := []byte{0, 0x10, 0, 1} // 0x100001 > 1 << 20 (which is 0x100000)
+	buf.Write(hdr)
+	_, err := ReadFrame(&buf)
+	if err == nil {
+		t.Fatal("ReadFrame should have rejected oversize length")
+	}
+	if !errors.Is(err, ErrWireEnvelope) {
+		t.Errorf("expected ErrWireEnvelope, got %v", err)
+	}
+}
+
+// TestReadFrame_EOFAtBoundary — an empty stream returns io.EOF cleanly.
+func TestReadFrame_EOFAtBoundary(t *testing.T) {
+	t.Parallel()
+	_, err := ReadFrame(bytes.NewReader(nil))
+	if !errors.Is(err, io.EOF) {
+		t.Fatalf("expected io.EOF, got %v", err)
+	}
+}
+
+// TestSeal_RejectsBadInputs — required-field validation.
+func TestSeal_RejectsBadInputs(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name string
+		opts SealOptions
+		want string
+	}{
+		{
+			name: "bad-key-len",
+			opts: SealOptions{SharedKey: []byte("short"), FromDeviceID: "a", ToDeviceID: "b", Kind: "x", Plaintext: []byte("p")},
+			want: "shared key",
+		},
+		{
+			name: "missing-kind",
+			opts: SealOptions{SharedKey: DevSharedKey[:], FromDeviceID: "a", ToDeviceID: "b", Kind: "", Plaintext: []byte("p")},
+			want: "kind",
+		},
+		{
+			name: "missing-from",
+			opts: SealOptions{SharedKey: DevSharedKey[:], FromDeviceID: "", ToDeviceID: "b", Kind: "x", Plaintext: []byte("p")},
+			want: "DeviceId",
+		},
+		{
+			name: "missing-to",
+			opts: SealOptions{SharedKey: DevSharedKey[:], FromDeviceID: "a", ToDeviceID: "", Kind: "x", Plaintext: []byte("p")},
+			want: "DeviceId",
+		},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			_, err := Seal(tc.opts)
+			if err == nil {
+				t.Fatal("expected error")
+			}
+			if !strings.Contains(err.Error(), tc.want) {
+				t.Errorf("want substring %q in error %q", tc.want, err.Error())
+			}
+		})
+	}
+}
+
+// TestNewUUIDv4_Format — sanity-check the homemade UUID generator:
+// canonical 8-4-4-4-12 form, version 4 + RFC 4122 variant bits.
+func TestNewUUIDv4_Format(t *testing.T) {
+	t.Parallel()
+	for i := 0; i < 50; i++ {
+		s, err := newUUIDv4()
+		if err != nil {
+			t.Fatalf("newUUIDv4[%d]: %v", i, err)
+		}
+		if len(s) != 36 {
+			t.Fatalf("len=%d want 36 (%q)", len(s), s)
+		}
+		// Version nibble at index 14, variant nibble at index 19.
+		if s[8] != '-' || s[13] != '-' || s[18] != '-' || s[23] != '-' {
+			t.Fatalf("bad dashes: %q", s)
+		}
+		if s[14] != '4' {
+			t.Fatalf("version nibble != 4: %q", s)
+		}
+		v := s[19]
+		if v != '8' && v != '9' && v != 'a' && v != 'b' {
+			t.Fatalf("variant nibble not RFC 4122: %q", s)
+		}
+	}
+}

--- a/internal/transport/wt/server.go
+++ b/internal/transport/wt/server.go
@@ -183,7 +183,7 @@ func New(_ context.Context, cfg Config) (*Server, error) {
 		}
 		srv.cert = dc.TLS
 		srv.devCert = &dc
-		logger.Printf("wt: dev cert auto-generated (SPKI sha256=%x)", dc.SPKISHA256)
+		logger.Printf("wt: dev cert auto-generated (DER sha256=%x)", dc.DERSHA256)
 	default:
 		return nil, errors.New("wt: Cert and Key must both be set or both be empty")
 	}
@@ -233,15 +233,28 @@ func New(_ context.Context, cfg Config) (*Server, error) {
 // the post-bind addr; tests use the ServeListener path below.
 func (s *Server) Addr() string { return s.addr }
 
-// DevCertSPKISHA256 returns the SPKI fingerprint of the auto-generated
-// dev cert, or zero value if the server was constructed with operator-
-// supplied certs. Useful for tests + future browser handoff via
-// `serverCertificateHashes`.
-func (s *Server) DevCertSPKISHA256() [32]byte {
+// DevCertDERSHA256 returns the SHA-256 of the auto-generated dev
+// cert's full DER-encoded x509 leaf, or zero value if the server was
+// constructed with operator-supplied certs.
+//
+// This value matches the W3C WebTransport
+// `serverCertificateHashes.value` algorithm (sha256 of the DER cert,
+// NOT the SPKI block), so it is what the Rust client side
+// (web-transport-quinn::ClientBuilder::with_server_certificate_hashes)
+// — and the browser API — actually consume. Pinning by SPKI here would
+// silently fail the TLS handshake on the Rust side; we hash DER so the
+// dev-cert fingerprint the operator copies out of the daemon log can
+// be pasted into the app's `pinnedCertSha256` config and Just Work.
+//
+// Bug-fix history: this method was originally named DevCertSPKISHA256
+// and returned sha256(leaf.RawSubjectPublicKeyInfo) — verifiable
+// against the cert but useless for cross-stack pinning. Slice #3
+// renamed it + switched the algorithm to match the Rust client.
+func (s *Server) DevCertDERSHA256() [32]byte {
 	if s.devCert == nil {
 		return [32]byte{}
 	}
-	return s.devCert.SPKISHA256
+	return s.devCert.DERSHA256
 }
 
 // TLSCertificate returns a copy of the server's TLS certificate.


### PR DESCRIPTION
## Summary

WT block slice #3 — Go-side envelope dispatch over the events channel + a small cert-hash format bug from slice #1 fixed in the same PR.

Companion: **tether-app#TBD** (Rust decrypt + `recvEnvelope` Tauri command).

### Part A — Cert hash format fix

Slice #1 (PR #49) exposed `Server.DevCertSPKISHA256()` — SHA-256 of the cert's SubjectPublicKeyInfo. But [W3C WebTransport spec](https://www.w3.org/TR/webtransport/#dictdef-webtransporthash) requires SHA-256 of the **full DER-encoded cert**. Slice #2's Rust client (PR #17) correctly pins via DER cert hash. Copy-pasting the SPKI fingerprint from Go startup logs into Rust's `pinnedCertSha256` would have caused TLS handshake to fail silently.

**Fix**: `DevCertSPKISHA256() → DevCertDERSHA256()`, hash now `sha256.Sum256(cert.Raw)`. `dev_cert_test.go` asserts the algorithm-level invariant.

### Part B — Wire envelope dispatch (the meat)

| File | Role |
|---|---|
| `internal/transport/wt/envelope.go` | `WireEnvelope` struct + `Seal`/`Open` (XChaCha20-Poly1305) + `WriteFrame`/`ReadFrame` (4B BE length-prefix, 1 MiB cap) + UUID v4 + `DevSharedKey` const |
| `internal/transport/wt/dispatch.go` | `PushEnvelopeStream[T]` generic dispatcher + `EnvelopeFrameReader` |
| `internal/agent/envelope_emitter.go` | `LocalEnvelope.EnvelopeKind()` / `EnvelopeSessionID()` to satisfy the dispatcher's constraint without an import cycle |

**AD format** (length-prefixed, byte-identical to Rust side):
```
LP(sessionId) || LP(fromDeviceId) || LP(toDeviceId) || u32_BE(keyVersion) || LP(kind)
```
Pinned by `ad_byte_layout_stable` golden test on both sides.

**`DevSharedKey`** is a hardcoded 32-byte ASCII constant `tether-wt-dev-shared-key-slice-3`, byte-identical to the Rust side. Three repeated TODO banners point at slice #4 ECDH replacement. Cross-stack smoke would catch any divergence (vs all-zero, where buggy xor-with-zero AEAD would still trivially round-trip).

### Architectural decisions

| Decision | Choice | Why |
|---|---|---|
| `WireEnvelope` location | `internal/transport/wt/` | Wire shape is transport concern; LocalEnvelope stays in `agent`. Avoids agent → transport import edge. |
| Decrypt location (Tauri side) | Rust | Defense-in-depth: ciphertext never crosses IPC boundary toward webview JS. |
| AD format | Length-prefixed concat | Prevents byte-shifting collisions between adjacent fields. Order matches §3.3.1. |
| Framing | 4-byte BE length prefix + JSON, 1 MiB cap | §3.3.1 v0.1 = JSON. Cap blocks unbounded alloc on hostile input. |
| `sessionId` | NOT in wire struct; mixed into AD | v0.1 has 1 cc session per WT session. Wire footprint minimal. Wire-level sessionId deferred. |
| KeyVersion | Hardcoded 1; receivers reject otherwise | Per §3.3.1. Slice #4 introduces negotiation. |

### Tests (race-clean, count=10)

- `envelope_test.go` (12 tests): roundtrip, AD-binds-kind, AD-binds-deviceIDs, AD-binds-sessionID, keyVersion reject, nonce uniqueness, frame roundtrip, oversize-frame reject, EOF-at-boundary, bad-input matrix, UUID format, dev key length sanity
- `dispatch_test.go` (4 tests): delivers-and-seals, ctx-cancel exit, write-error propagation, frame-reader roundtrip
- `envelope_crossstack_test.go` (1 test): real `wt.Server` + Go `wt.Client` over loopback UDP, push 3 envelopes through events channel (channel-id 0x02), client decrypts via `EnvelopeFrameReader`, asserts kinds/bodies match

### What this slice does NOT do

- **Slice #4** — real pairing (replaces `DevSharedKey` via ECDH; spec landed in tether-doc#11)
- **Slice #5** — replace UDS attach in AppShell with WT path
- daemon `Run()` doesn't auto-spawn an envelope dispatcher yet — `PushEnvelopeStream` is the seam future wiring will use

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test -race -count=10 ./internal/transport/wt/... ./internal/agent/... ./internal/crypto/...` → green
- [x] `go test -race -count=1 ./...` → green (except pre-existing `TestStderrCap` flake; unrelated, no shared state)

Refs spec §3.3.1, §3.3.3 events channel, tether-doc#11 (pair protocol).