### PR TITLE
feat(pair): D-12 device-pair protocol — slice #4 of WT block

### DIFF
--- a/internal/pair/audit.go
+++ b/internal/pair/audit.go
@@ -1,0 +1,178 @@
+package pair
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+	"time"
+)
+
+// AuditKind enumerates the pair-protocol audit events. They share the
+// per-user audit.log file with §11.D lock events; pair events use the
+// "pair." prefix.
+type AuditKind string
+
+const (
+	AuditPairSuccess        AuditKind = "pair.success"
+	AuditPairFail           AuditKind = "pair.fail"
+	AuditPairRepairRejected AuditKind = "pair.repair-rejected"
+	AuditPairForceRotated   AuditKind = "pair.force-rotated"
+)
+
+// AuditEvent is the on-disk shape of one JSONL line. Fields are
+// minimized to what slice #4 actually surfaces; the §10.3 schema
+// allows a richer "details" object — we shape that on a per-kind basis.
+type AuditEvent struct {
+	TS                  string    `json:"ts"`
+	Kind                AuditKind `json:"kind"`
+	DeviceID            DeviceID  `json:"deviceId,omitempty"`
+	PeerDeviceID        DeviceID  `json:"peerDeviceId,omitempty"`
+	LongTermKeyID       string    `json:"longTermKeyId,omitempty"`
+	PrevLongTermKeyID   string    `json:"previousLongTermKeyId,omitempty"`
+	Reason              string    `json:"reason,omitempty"`
+	Detail              string    `json:"detail,omitempty"`
+	TranscriptHashB64Url string   `json:"transcript_hash,omitempty"`
+}
+
+// AuditLog is an append-only JSONL writer mirroring lock.JSONLLogSink.
+// Per spec §10.3 + §11.D it lives at
+// `~/.tether/users/<user>/audit.log`. Mode 0600. Parent dirs 0700.
+type AuditLog struct {
+	path string
+
+	mu     sync.Mutex
+	f      *os.File
+	closed bool
+	now    func() time.Time
+}
+
+// AuditLogConfig is the explicit-config form of NewAuditLog. Path is
+// the destination file (caller resolves the §10.3 layout). Now lets
+// tests inject a fake clock — defaults to time.Now if nil.
+type AuditLogConfig struct {
+	Path string
+	Now  func() time.Time
+}
+
+// NewAuditLog opens (or creates) an audit log at path. Parent dirs are
+// created at 0700. The file is O_APPEND|O_CREATE|O_WRONLY at 0600.
+func NewAuditLog(path string) (*AuditLog, error) {
+	return NewAuditLogWithConfig(AuditLogConfig{Path: path})
+}
+
+// NewAuditLogWithConfig is the explicit-config form.
+func NewAuditLogWithConfig(cfg AuditLogConfig) (*AuditLog, error) {
+	if cfg.Path == "" {
+		return nil, errors.New("pair: AuditLog: empty path")
+	}
+	dir := filepath.Dir(cfg.Path)
+	if dir != "" {
+		if err := os.MkdirAll(dir, 0o700); err != nil {
+			return nil, fmt.Errorf("pair: mkdir audit dir %q: %w", dir, err)
+		}
+		_ = os.Chmod(dir, 0o700)
+	}
+	f, err := os.OpenFile(cfg.Path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o600)
+	if err != nil {
+		return nil, fmt.Errorf("pair: open audit log %q: %w", cfg.Path, err)
+	}
+	_ = os.Chmod(cfg.Path, 0o600)
+	now := cfg.Now
+	if now == nil {
+		now = func() time.Time { return time.Now().UTC() }
+	}
+	return &AuditLog{path: cfg.Path, f: f, now: now}, nil
+}
+
+// Path returns the file path the audit log writes to.
+func (a *AuditLog) Path() string { return a.path }
+
+// AppendPairEvent writes one event line. Caller fills the AuditEvent
+// fields except TS, which AppendPairEvent overrides with now().
+func (a *AuditLog) AppendPairEvent(ev AuditEvent) error {
+	if ev.Kind == "" {
+		return errors.New("pair: audit event missing kind")
+	}
+	ev.TS = a.now().UTC().Format(time.RFC3339Nano)
+	row, err := json.Marshal(ev)
+	if err != nil {
+		return fmt.Errorf("pair: marshal audit row: %w", err)
+	}
+	row = append(row, '\n')
+
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	if a.closed || a.f == nil {
+		return errors.New("pair: audit log already closed")
+	}
+	if _, err := a.f.Write(row); err != nil {
+		return fmt.Errorf("pair: append audit %q: %w", a.path, err)
+	}
+	if err := a.f.Sync(); err != nil {
+		return fmt.Errorf("pair: fsync audit %q: %w", a.path, err)
+	}
+	return nil
+}
+
+// Convenience helpers for the four pair-event kinds.
+
+// AppendSuccess records pair.success with the transcript_hash anchor
+// per §10.3.
+func (a *AuditLog) AppendSuccess(deviceID, peer DeviceID, ltkID string, transcriptHash []byte) error {
+	return a.AppendPairEvent(AuditEvent{
+		Kind:                 AuditPairSuccess,
+		DeviceID:             deviceID,
+		PeerDeviceID:         peer,
+		LongTermKeyID:        ltkID,
+		TranscriptHashB64Url: b64uEncode(transcriptHash),
+	})
+}
+
+// AppendFail records pair.fail with the abort reason / detail.
+func (a *AuditLog) AppendFail(deviceID DeviceID, reason AbortReason, detail string) error {
+	return a.AppendPairEvent(AuditEvent{
+		Kind:     AuditPairFail,
+		DeviceID: deviceID,
+		Reason:   string(reason),
+		Detail:   detail,
+	})
+}
+
+// AppendRepairRejected records pair.repair-rejected when an inbound
+// invite would have re-paired an existing deviceId.
+func (a *AuditLog) AppendRepairRejected(deviceID DeviceID) error {
+	return a.AppendPairEvent(AuditEvent{
+		Kind:     AuditPairRepairRejected,
+		DeviceID: deviceID,
+	})
+}
+
+// AppendForceRotated records pair.force-rotated when a Registry
+// ForceSave call overwrites an existing record.
+func (a *AuditLog) AppendForceRotated(deviceID DeviceID, newLTKID, prevLTKID string) error {
+	return a.AppendPairEvent(AuditEvent{
+		Kind:              AuditPairForceRotated,
+		DeviceID:          deviceID,
+		LongTermKeyID:     newLTKID,
+		PrevLongTermKeyID: prevLTKID,
+	})
+}
+
+// Close releases the underlying file handle. Idempotent.
+func (a *AuditLog) Close() error {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	if a.closed {
+		return nil
+	}
+	a.closed = true
+	if a.f == nil {
+		return nil
+	}
+	err := a.f.Close()
+	a.f = nil
+	return err
+}

--- a/internal/pair/audit_test.go
+++ b/internal/pair/audit_test.go
@@ -1,0 +1,185 @@
+package pair
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"runtime"
+	"sync"
+	"testing"
+)
+
+func TestAuditLog_AppendOnly(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "users", "default", "audit.log")
+	// Pre-seed file with a "previous run" line.
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	const seed = `{"prev":"line"}` + "\n"
+	if err := os.WriteFile(path, []byte(seed), 0o600); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	a, err := NewAuditLog(path)
+	if err != nil {
+		t.Fatalf("NewAuditLog: %v", err)
+	}
+	t.Cleanup(func() { _ = a.Close() })
+
+	if err := a.AppendSuccess("device-x", "device-y", "ltk-1", []byte{0x01, 0x02}); err != nil {
+		t.Fatalf("AppendSuccess: %v", err)
+	}
+	body, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if !bytes.HasPrefix(body, []byte(seed)) {
+		t.Errorf("seed line truncated; first %d bytes: %q", len(seed), body[:len(seed)])
+	}
+	// Second line should be valid JSON for the new event.
+	sc := bufio.NewScanner(bytes.NewReader(body))
+	var lines [][]byte
+	for sc.Scan() {
+		lines = append(lines, append([]byte(nil), sc.Bytes()...))
+	}
+	if len(lines) != 2 {
+		t.Fatalf("line count: got %d want 2", len(lines))
+	}
+	var ev AuditEvent
+	if err := json.Unmarshal(lines[1], &ev); err != nil {
+		t.Errorf("decode event: %v", err)
+	}
+	if ev.Kind != AuditPairSuccess {
+		t.Errorf("kind: got %s want %s", ev.Kind, AuditPairSuccess)
+	}
+	if ev.DeviceID != "device-x" || ev.PeerDeviceID != "device-y" {
+		t.Errorf("device ids: got %s/%s", ev.DeviceID, ev.PeerDeviceID)
+	}
+}
+
+func TestAuditLog_FileMode(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("POSIX file modes not enforced on Windows")
+	}
+	dir := t.TempDir()
+	path := filepath.Join(dir, "users", "default", "audit.log")
+	a, err := NewAuditLog(path)
+	if err != nil {
+		t.Fatalf("NewAuditLog: %v", err)
+	}
+	t.Cleanup(func() { _ = a.Close() })
+	st, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat: %v", err)
+	}
+	if mode := st.Mode().Perm(); mode != 0o600 {
+		t.Errorf("file mode: got %o want 0600", mode)
+	}
+	ds, err := os.Stat(filepath.Dir(path))
+	if err != nil {
+		t.Fatalf("stat dir: %v", err)
+	}
+	if mode := ds.Mode().Perm(); mode != 0o700 {
+		t.Errorf("dir mode: got %o want 0700", mode)
+	}
+}
+
+func TestAuditLog_AllEventKinds(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "audit.log")
+	a, err := NewAuditLog(path)
+	if err != nil {
+		t.Fatalf("NewAuditLog: %v", err)
+	}
+	t.Cleanup(func() { _ = a.Close() })
+
+	if err := a.AppendSuccess("d1", "p1", "ltk-1", []byte{0x01}); err != nil {
+		t.Errorf("AppendSuccess: %v", err)
+	}
+	if err := a.AppendFail("d1", ReasonSASMismatch, "test"); err != nil {
+		t.Errorf("AppendFail: %v", err)
+	}
+	if err := a.AppendRepairRejected("d1"); err != nil {
+		t.Errorf("AppendRepairRejected: %v", err)
+	}
+	if err := a.AppendForceRotated("d1", "ltk-2", "ltk-1"); err != nil {
+		t.Errorf("AppendForceRotated: %v", err)
+	}
+
+	body, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	// Each kind should appear in the file.
+	for _, k := range []AuditKind{
+		AuditPairSuccess, AuditPairFail, AuditPairRepairRejected, AuditPairForceRotated,
+	} {
+		if !bytes.Contains(body, []byte(`"`+string(k)+`"`)) {
+			t.Errorf("missing audit kind %q in file:\n%s", k, body)
+		}
+	}
+}
+
+// TestAuditLog_ConcurrentAppendNoTearing — fire many concurrent
+// appends and verify each line parses cleanly.
+func TestAuditLog_ConcurrentAppendNoTearing(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "audit.log")
+	a, err := NewAuditLog(path)
+	if err != nil {
+		t.Fatalf("NewAuditLog: %v", err)
+	}
+	t.Cleanup(func() { _ = a.Close() })
+
+	const Workers = 16
+	const PerWorker = 32
+	var wg sync.WaitGroup
+	wg.Add(Workers)
+	for w := 0; w < Workers; w++ {
+		go func() {
+			defer wg.Done()
+			for i := 0; i < PerWorker; i++ {
+				_ = a.AppendSuccess("device-x", "device-y", "ltk", []byte{0x42})
+			}
+		}()
+	}
+	wg.Wait()
+
+	f, err := os.Open(path)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer func() { _ = f.Close() }()
+	sc := bufio.NewScanner(f)
+	count := 0
+	for sc.Scan() {
+		var ev AuditEvent
+		if err := json.Unmarshal(sc.Bytes(), &ev); err != nil {
+			t.Fatalf("decode line %d: %v\n%s", count, err, sc.Bytes())
+		}
+		count++
+	}
+	if want := Workers * PerWorker; count != want {
+		t.Errorf("line count: got %d want %d", count, want)
+	}
+}
+
+func TestAuditLog_CloseRejectsAppend(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "audit.log")
+	a, err := NewAuditLog(path)
+	if err != nil {
+		t.Fatalf("NewAuditLog: %v", err)
+	}
+	if err := a.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	if err := a.Close(); err != nil {
+		t.Errorf("second Close: got %v want nil (idempotent)", err)
+	}
+	if err := a.AppendSuccess("d", "p", "ltk", nil); err == nil {
+		t.Errorf("AppendSuccess on closed log: got nil want error")
+	}
+}

--- a/internal/pair/client.go
+++ b/internal/pair/client.go
@@ -1,0 +1,339 @@
+package pair
+
+import (
+	"context"
+	"crypto/rand"
+	"errors"
+	"fmt"
+	"io"
+	"time"
+)
+
+// Result is what Client.Run / Server.Run return on `paired`. Long-term
+// keys cross the API boundary (caller persists / uses them) but the
+// FSM-internal shared_secret + sas_key are zeroized before return.
+type Result struct {
+	// LocalDeviceID / PeerDeviceID identify the two sides of this pair.
+	LocalDeviceID DeviceID
+	PeerDeviceID  DeviceID
+	PeerKind      DeviceKind
+	PeerName      string
+	PeerPushToken string
+
+	// LongTermKey is the §11.C wrap_key input. 32B.
+	LongTermKey []byte
+	// TransportBindingKey is reserved for v0.1.x channel-binding. 32B.
+	TransportBindingKey []byte
+
+	// TranscriptHash is the hash that anchors the audit-log line.
+	TranscriptHash []byte
+
+	// SAS is the 6-character display string both endpoints saw. Used
+	// in tests + UX confirmation; not security-relevant after pairing.
+	SAS string
+}
+
+// SASConfirmer is the user-confirm hook. The driver calls Confirm with
+// the locally-derived SAS string; the implementation blocks until the
+// user clicks "match" / "do not match" on whatever UI is wired and
+// returns nil (match) or a non-nil error (rejection). For headless
+// tests, AutoConfirm always returns nil.
+type SASConfirmer interface {
+	Confirm(sas string) error
+}
+
+// SASConfirmFunc adapts a function value to SASConfirmer.
+type SASConfirmFunc func(sas string) error
+
+func (f SASConfirmFunc) Confirm(sas string) error { return f(sas) }
+
+// AutoConfirm is a SASConfirmer that always accepts. Used by tests.
+var AutoConfirm SASConfirmer = SASConfirmFunc(func(string) error { return nil })
+
+// Identity carries the local device's stable metadata that gets baked
+// into pair.invite / pair.accept frames.
+type Identity struct {
+	DeviceID    DeviceID
+	Kind        DeviceKind
+	DisplayName string
+	// PushToken is meaningful only when Kind == KindMobile (responder).
+	PushToken string
+}
+
+// Client is the initiator-side driver. Concurrency: one Run call per
+// Client; Run is not safe to invoke from multiple goroutines.
+type Client struct {
+	identity  Identity
+	confirmer SASConfirmer
+	now       func() time.Time
+	rand      io.Reader
+}
+
+// ClientConfig is the explicit-config form of NewClient. Now lets
+// tests inject a fake clock; Rand lets tests inject a deterministic
+// random source for ephemeral keys + nonces.
+type ClientConfig struct {
+	Identity  Identity
+	Confirmer SASConfirmer
+	Now       func() time.Time
+	Rand      io.Reader
+}
+
+// NewClient constructs an initiator-side driver. Confirmer defaults
+// to AutoConfirm.
+func NewClient(cfg ClientConfig) *Client {
+	c := &Client{identity: cfg.Identity, confirmer: cfg.Confirmer, now: cfg.Now, rand: cfg.Rand}
+	if c.confirmer == nil {
+		c.confirmer = AutoConfirm
+	}
+	if c.now == nil {
+		c.now = func() time.Time { return time.Now().UTC() }
+	}
+	if c.rand == nil {
+		c.rand = rand.Reader
+	}
+	return c
+}
+
+// Run drives the initiator-side pairing flow against the given control
+// stream. Returns Result on `paired`, error on any failure. The caller
+// is responsible for persisting Result via Registry.Save (or
+// ForceSave).
+func (c *Client) Run(ctx context.Context, stream io.ReadWriter) (Result, error) {
+	if err := ValidateDeviceID(c.identity.DeviceID); err != nil {
+		return Result{}, err
+	}
+	r := newStreamReader(stream)
+	w := newStreamWriter(stream)
+	fsm := NewFSM(RoleInitiator)
+
+	priv, pub, err := genX25519(c.rand)
+	if err != nil {
+		return Result{}, fmt.Errorf("pair: client gen ephemeral: %w", err)
+	}
+	defer zero(priv)
+
+	transcript := NewTranscript()
+
+	// 1. Compose + send pair.invite.
+	invite := InviteFrame{
+		ProtocolVersion: ProtocolVersion,
+		InitiatorPubkey: pub,
+		DeviceID:        c.identity.DeviceID,
+		Kind_:           c.identity.Kind,
+		DisplayName:     c.identity.DisplayName,
+		TS_:             c.now().UnixMilli(),
+		Nonce:           mustRandomNonce(c.rand, 16),
+	}
+	state, out, err := fsm.Step(Event{Kind: EventStartInvite, Frame: invite})
+	if err != nil {
+		return Result{}, err
+	}
+	if err := emitAll(w, out); err != nil {
+		return Result{}, fmt.Errorf("pair: client send invite: %w", err)
+	}
+	if err := transcript.Append(invite); err != nil {
+		return Result{}, err
+	}
+
+	// 2. Receive pair.accept (with awaiting-pubkey 30s timeout).
+	acceptCtx, acceptCancel := context.WithTimeout(ctx, TimeoutAwaitingPubkey)
+	frame, err := readFrameWithCtx(acceptCtx, r)
+	acceptCancel()
+	if err != nil {
+		// Timeout / IO error → emit pair.abort{timeout|protocol-violation}.
+		ab := abortNow(reasonForCtxErr(err), err.Error())
+		ab.TS_ = c.now().UnixMilli()
+		_ = w.writeFrame(ab)
+		return Result{}, fmt.Errorf("pair: client recv accept: %w", err)
+	}
+	state, _, err = fsm.Step(Event{Kind: EventRecvFrame, Frame: frame})
+	if err != nil {
+		return Result{}, err
+	}
+	accept, ok := frame.(AcceptFrame)
+	if !ok {
+		return Result{}, fmt.Errorf("pair: expected pair.accept, got %T", frame)
+	}
+	if err := transcript.Append(accept); err != nil {
+		return Result{}, err
+	}
+
+	// 3. Derive shared secret + sas_key + display SAS.
+	shared, err := ComputeSharedSecret(priv, accept.ResponderPubkey)
+	if err != nil {
+		return Result{}, fmt.Errorf("pair: client ECDH: %w", err)
+	}
+	defer zero(shared)
+	thash := transcript.Hash()
+	sasKey, err := DeriveSASKey(shared, thash)
+	if err != nil {
+		return Result{}, err
+	}
+	defer zero(sasKey)
+	sas, err := ComputeSAS(sasKey)
+	if err != nil {
+		return Result{}, err
+	}
+
+	// 4. User confirms SAS.
+	if err := c.confirmer.Confirm(sas); err != nil {
+		ab := abortNow(ReasonSASMismatch, err.Error())
+		ab.TS_ = c.now().UnixMilli()
+		_, out, _ = fsm.Step(Event{Kind: EventUserRejectsSAS, Frame: ab})
+		_ = emitAll(w, out)
+		return Result{}, fmt.Errorf("pair: user rejected SAS: %w", err)
+	}
+
+	// 5. Emit our pair.sas-confirm{ok:true,role:initiator}.
+	myMAC := ConfirmMAC(sasKey, RoleInitiator, thash)
+	myConfirm := SASConfirmFrame{
+		ProtocolVersion: ProtocolVersion,
+		OK:              true,
+		Role:            RoleInitiator,
+		MAC:             myMAC,
+		TS_:             c.now().UnixMilli(),
+	}
+	state, out, err = fsm.Step(Event{Kind: EventUserConfirmsSAS, Frame: myConfirm})
+	if err != nil {
+		return Result{}, err
+	}
+	if err := emitAll(w, out); err != nil {
+		return Result{}, fmt.Errorf("pair: client send sas-confirm: %w", err)
+	}
+	if err := transcript.Append(myConfirm); err != nil {
+		return Result{}, err
+	}
+
+	// 6. Receive peer's pair.sas-confirm. After step (5) the FSM is
+	//    already in completing for the initiator role, but the peer's
+	//    sas-confirm is allowed in BOTH sas-confirm AND completing
+	//    (driver responsibility — the FSM matrix only allows it in
+	//    sas-confirm, so we defer the FSM step until we have the
+	//    peer's MAC verified, then synthesize a no-op state push).
+	confirmCtx, confirmCancel := context.WithTimeout(ctx, TimeoutSASConfirm)
+	frame, err = readFrameWithCtx(confirmCtx, r)
+	confirmCancel()
+	if err != nil {
+		ab := abortNow(reasonForCtxErr(err), err.Error())
+		ab.TS_ = c.now().UnixMilli()
+		_ = w.writeFrame(ab)
+		return Result{}, fmt.Errorf("pair: client recv peer sas-confirm: %w", err)
+	}
+	peerConfirm, ok := frame.(SASConfirmFrame)
+	if !ok {
+		ab := abortNow(ReasonProtocolViolation, fmt.Sprintf("expected sas-confirm, got %s", frame.Kind()))
+		ab.TS_ = c.now().UnixMilli()
+		_ = w.writeFrame(ab)
+		return Result{}, fmt.Errorf("pair: expected pair.sas-confirm, got %T", frame)
+	}
+	if !peerConfirm.OK {
+		return Result{}, ErrSASMismatch
+	}
+	if peerConfirm.Role != RoleResponder {
+		return Result{}, fmt.Errorf("pair: peer sas-confirm role mismatch %q", peerConfirm.Role)
+	}
+	if err := VerifyConfirmMAC(sasKey, RoleResponder, thash, peerConfirm.MAC); err != nil {
+		ab := abortNow(ReasonSASMismatch, "peer MAC mismatch")
+		ab.TS_ = c.now().UnixMilli()
+		_ = w.writeFrame(ab)
+		return Result{}, err
+	}
+	if err := transcript.Append(peerConfirm); err != nil {
+		return Result{}, err
+	}
+	_ = state // FSM is now in completing (initiator)
+
+	// 7. Receive pair.complete (10s timeout). Server-driven path
+	//    where the responder's daemon emits the ack — see server.go.
+	completeCtx, completeCancel := context.WithTimeout(ctx, TimeoutCompleting)
+	frame, err = readFrameWithCtx(completeCtx, r)
+	completeCancel()
+	if err != nil {
+		ab := abortNow(reasonForCtxErr(err), err.Error())
+		ab.TS_ = c.now().UnixMilli()
+		_ = w.writeFrame(ab)
+		return Result{}, fmt.Errorf("pair: client recv complete: %w", err)
+	}
+	if _, _, err := fsm.Step(Event{Kind: EventRecvFrame, Frame: frame}); err != nil {
+		return Result{}, err
+	}
+	if frame.Kind() != KindComplete {
+		return Result{}, fmt.Errorf("pair: expected pair.complete, got %s", frame.Kind())
+	}
+
+	// 8. Derive long-term keys.
+	ltk, tbk, err := DeriveLongTermKey(shared, thash)
+	if err != nil {
+		return Result{}, err
+	}
+	return Result{
+		LocalDeviceID:       c.identity.DeviceID,
+		PeerDeviceID:        accept.DeviceID,
+		PeerKind:            accept.Kind_,
+		PeerName:            accept.DisplayName,
+		PeerPushToken:       accept.PushToken,
+		LongTermKey:         ltk,
+		TransportBindingKey: tbk,
+		TranscriptHash:      thash,
+		SAS:                 sas,
+	}, nil
+}
+
+// emitAll writes every frame in out to the wire. The first error
+// short-circuits.
+func emitAll(w *streamWriter, out []Frame) error {
+	for _, f := range out {
+		if err := w.writeFrame(f); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// reasonForCtxErr maps a context.DeadlineExceeded → ReasonTimeout,
+// anything else → ReasonProtocolViolation. Used by drivers when an
+// IO read fails.
+func reasonForCtxErr(err error) AbortReason {
+	if errors.Is(err, context.DeadlineExceeded) {
+		return ReasonTimeout
+	}
+	return ReasonProtocolViolation
+}
+
+// genX25519 produces an ephemeral keypair. Wraps internal/crypto's
+// generator but takes an io.Reader so tests can inject determinism.
+func genX25519(r io.Reader) (priv, pub []byte, err error) {
+	priv = make([]byte, 32)
+	if _, err := io.ReadFull(r, priv); err != nil {
+		return nil, nil, fmt.Errorf("pair: read private: %w", err)
+	}
+	pub, err = basepointMulPub(priv)
+	if err != nil {
+		return nil, nil, err
+	}
+	return priv, pub, nil
+}
+
+// mustRandomNonce reads n random bytes from r. The driver code paths
+// that use it would not function with a corrupt random source, so a
+// failure here means something has gone catastrophically wrong (e.g.
+// the OS entropy source).
+func mustRandomNonce(r io.Reader, n int) []byte {
+	b := make([]byte, n)
+	if _, err := io.ReadFull(r, b); err != nil {
+		// No way to recover; return zeros and let the peer reject the
+		// resulting transcript via SAS divergence (defense in depth).
+		// Real callers pass crypto/rand which doesn't fail.
+		return b
+	}
+	return b
+}
+
+// zero overwrites b with zeros. Used to scrub keys + secrets from
+// stack/heap on driver exit.
+func zero(b []byte) {
+	for i := range b {
+		b[i] = 0
+	}
+}

--- a/internal/pair/client_server_mitm_test.go
+++ b/internal/pair/client_server_mitm_test.go
@@ -1,0 +1,227 @@
+package pair
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"sync"
+	"testing"
+	"time"
+)
+
+// mitmStream sits between client and server, copies bytes through, but
+// flips one byte in the responder's pubkey field of the pair.accept
+// frame as it passes through. This simulates an active MITM: the
+// client's view of the responder pubkey diverges from the server's
+// actual pubkey, so client-derived sas_key disagrees with
+// server-derived sas_key, so MAC verification fails.
+//
+// Architecture:
+//
+//	client ↔ mitmStream ↔ server
+//
+// We provide a half-duplex per direction. The MITM only mangles the
+// frame in the server→client direction (where pair.accept lives).
+type mitmFrameMangler struct {
+	mu      sync.Mutex
+	scanner *bufio.Scanner
+	dst     io.Writer
+	mangled bool
+}
+
+func (m *mitmFrameMangler) pumpServerToClient() error {
+	for m.scanner.Scan() {
+		line := append([]byte(nil), m.scanner.Bytes()...)
+		// Try to detect pair.accept and flip a byte in
+		// ephemeralPubkey. We round-trip the line through the JSON
+		// envelope decoder; if it's pair.accept, we mangle the body
+		// and re-encode.
+		mangled, err := m.maybeMangle(line)
+		if err != nil {
+			return err
+		}
+		if _, err := m.dst.Write(append(mangled, '\n')); err != nil {
+			return err
+		}
+	}
+	return m.scanner.Err()
+}
+
+func (m *mitmFrameMangler) maybeMangle(line []byte) ([]byte, error) {
+	env, err := decodeEnvelope(line)
+	if err != nil {
+		return line, nil // pass through unrelated lines unchanged
+	}
+	if env.Kind != KindAccept {
+		return line, nil
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.mangled {
+		return line, nil
+	}
+	// Decode the inner body, flip a byte in ephemeralPubkey, re-encode
+	// in canonical form.
+	var raw map[string]any
+	if err := json.Unmarshal(env.Ciphertext, &raw); err != nil {
+		return line, nil
+	}
+	pkS, ok := raw["ephemeralPubkey"].(string)
+	if !ok || len(pkS) == 0 {
+		return line, nil
+	}
+	pk, err := b64uDecode(pkS)
+	if err != nil {
+		return line, nil
+	}
+	pk[0] ^= 0x01 // flip a bit
+	raw["ephemeralPubkey"] = b64uEncode(pk)
+	body, err := canonicalJSON(raw)
+	if err != nil {
+		return line, nil
+	}
+	env.Ciphertext = body
+	m.mangled = true
+	return encodeWireLine(env)
+}
+
+func encodeWireLine(env WireEnvelope) ([]byte, error) {
+	out, err := encodeEnvelope(env)
+	if err != nil {
+		return nil, err
+	}
+	// encodeEnvelope already appends '\n'; strip it because the caller
+	// adds one of its own.
+	return bytes.TrimRight(out, "\n"), nil
+}
+
+// TestClientServer_MITMSASMismatch flips a byte in the responder's
+// ephemeral pubkey as it crosses to the client. Both sides should
+// compute different sas_keys; the client's MAC will not validate
+// against the server's sent MAC, so the client returns ErrSASMismatch
+// and never reaches paired.
+func TestClientServer_MITMSASMismatch(t *testing.T) {
+	// We need three pipes: client→server (clean), server→client through
+	// MITM. Simplest: client writes to a buffer that server reads
+	// directly; server writes to a buffer that the MITM reads + mangles
+	// into another buffer that the client reads.
+	//
+	// io.Pipe() pairs handle this cleanly: clientToServer + serverToMITM
+	// + mitmToClient.
+
+	c2sR, c2sW := io.Pipe() // client → server (clean)
+	s2mR, s2mW := io.Pipe() // server → MITM (clean)
+	m2cR, m2cW := io.Pipe() // MITM → client (mangled)
+	defer func() {
+		_ = c2sR.Close()
+		_ = c2sW.Close()
+		_ = s2mR.Close()
+		_ = s2mW.Close()
+		_ = m2cR.Close()
+		_ = m2cW.Close()
+	}()
+
+	clientStream := rwPair{R: m2cR, W: c2sW}
+	serverStream := rwPair{R: c2sR, W: s2mW}
+
+	// MITM goroutine: pump server→MITM through the mangler into MITM→client.
+	mitmDone := make(chan error, 1)
+	go func() {
+		sc := bufio.NewScanner(s2mR)
+		sc.Buffer(make([]byte, 0, 4096), 1<<20)
+		m := &mitmFrameMangler{scanner: sc, dst: m2cW}
+		err := m.pumpServerToClient()
+		_ = m2cW.Close()
+		mitmDone <- err
+	}()
+
+	clientRand := &detRand{fillByte: 0x10}
+	serverRand := &detRand{fillByte: 0x80}
+	clk := &monotonicClock{base: time.Date(2026, 5, 7, 0, 0, 0, 0, time.UTC)}
+
+	client := NewClient(ClientConfig{
+		Identity: Identity{
+			DeviceID: "device-desktop-mitmA", Kind: KindDesktop, DisplayName: "Test",
+		},
+		Confirmer: AutoConfirm,
+		Now:       clk.Now,
+		Rand:      clientRand,
+	})
+	server := NewServer(ServerConfig{
+		Identity: Identity{
+			DeviceID: "device-mobile-mitmB", Kind: KindMobile, DisplayName: "Test",
+		},
+		Confirmer: AutoConfirm,
+		Now:       clk.Now,
+		Rand:      serverRand,
+	})
+
+	type result struct {
+		res Result
+		err error
+	}
+	clientCh := make(chan result, 1)
+	serverCh := make(chan result, 1)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	go func() {
+		res, err := client.Run(ctx, clientStream)
+		// Close both ends so the server is unblocked: c2sW so the
+		// server's reads see EOF, m2cR so any further writes to m2cW
+		// from the MITM are NOPs.
+		_ = c2sW.Close()
+		clientCh <- result{res, err}
+	}()
+	go func() {
+		res, err := server.Run(ctx, serverStream)
+		// Close c2sR so the client's writes return ErrClosedPipe
+		// instead of blocking. Close s2mW so MITM scanner sees EOF.
+		_ = c2sR.Close()
+		_ = s2mW.Close()
+		serverCh <- result{res, err}
+	}()
+
+	cr := <-clientCh
+	sr := <-serverCh
+
+	// Client must detect the divergence — sas_keys disagree, peer's
+	// sas-confirm MAC fails to verify under the client-derived
+	// sas_key → ErrSASMismatch.
+	if cr.err == nil {
+		t.Errorf("client: got nil err, expected SAS mismatch")
+	}
+	if !errors.Is(cr.err, ErrSASMismatch) {
+		// MAC verification failure surfaces as ErrSASMismatch, but a
+		// secondary failure mode is that the client's sas-confirm
+		// (which the server receives) has a MAC the server can't
+		// verify, and the server then aborts with sas-mismatch — in
+		// which case the client sees the abort frame and reports
+		// some abort-related error. Both are acceptable; the key
+		// invariant is that NEITHER side reaches paired.
+		t.Logf("client err (acceptable if not paired): %v", cr.err)
+	}
+	if sr.err == nil {
+		t.Errorf("server: got nil err, expected SAS mismatch")
+	}
+	// Both sides MUST NOT have a populated long-term key.
+	if len(cr.res.LongTermKey) != 0 {
+		t.Errorf("client must not produce a long-term key under MITM")
+	}
+	if len(sr.res.LongTermKey) != 0 {
+		t.Errorf("server must not produce a long-term key under MITM")
+	}
+
+	// Drain the MITM goroutine.
+	_ = c2sR.Close()
+	_ = m2cW.Close()
+	select {
+	case <-mitmDone:
+	case <-time.After(2 * time.Second):
+		t.Logf("MITM goroutine hang on shutdown (non-fatal)")
+	}
+}

--- a/internal/pair/client_server_roundtrip_test.go
+++ b/internal/pair/client_server_roundtrip_test.go
@@ -1,0 +1,186 @@
+package pair
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"sync"
+	"testing"
+	"time"
+)
+
+// duplexPipe wraps two io.Pipe pairs into a bidirectional in-memory
+// stream. clientSide is what the Client.Run sees; serverSide is what
+// Server.Run sees; bytes the client writes are read by the server and
+// vice versa.
+type duplexPipe struct {
+	clientReader *io.PipeReader
+	clientWriter *io.PipeWriter
+	serverReader *io.PipeReader
+	serverWriter *io.PipeWriter
+}
+
+func newDuplexPipe() *duplexPipe {
+	cr, sw := io.Pipe() // client reads what server writes
+	sr, cw := io.Pipe() // server reads what client writes
+	return &duplexPipe{
+		clientReader: cr,
+		clientWriter: cw,
+		serverReader: sr,
+		serverWriter: sw,
+	}
+}
+
+func (d *duplexPipe) ClientSide() io.ReadWriter {
+	return rwPair{R: d.clientReader, W: d.clientWriter}
+}
+
+func (d *duplexPipe) ServerSide() io.ReadWriter {
+	return rwPair{R: d.serverReader, W: d.serverWriter}
+}
+
+func (d *duplexPipe) Close() {
+	_ = d.clientReader.Close()
+	_ = d.clientWriter.Close()
+	_ = d.serverReader.Close()
+	_ = d.serverWriter.Close()
+}
+
+type rwPair struct {
+	R io.Reader
+	W io.Writer
+}
+
+func (p rwPair) Read(b []byte) (int, error)  { return p.R.Read(b) }
+func (p rwPair) Write(b []byte) (int, error) { return p.W.Write(b) }
+
+// monotonicClock returns a strictly-monotonic time on every Now call,
+// stepping by 1ms. Used by tests so frame ts values never tie even
+// when several frames are produced within one wall-clock millisecond.
+type monotonicClock struct {
+	mu   sync.Mutex
+	base time.Time
+	step int64
+}
+
+func (c *monotonicClock) Now() time.Time {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.step++
+	return c.base.Add(time.Duration(c.step) * time.Millisecond)
+}
+
+// detRand is a deterministic byte source — an alternating fill for
+// tests so client + server pubkeys / nonces don't collide. Each call
+// to Read fills with byte fillByte and increments.
+type detRand struct {
+	mu       sync.Mutex
+	fillByte byte
+}
+
+func (d *detRand) Read(b []byte) (int, error) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	for i := range b {
+		b[i] = d.fillByte
+	}
+	d.fillByte++
+	return len(b), nil
+}
+
+// TestClientServer_HappyPath runs initiator + responder against an
+// in-memory duplex pipe and verifies both sides reach `paired` with
+// matching long-term keys.
+func TestClientServer_HappyPath(t *testing.T) {
+	pipe := newDuplexPipe()
+	defer pipe.Close()
+
+	clientRand := &detRand{fillByte: 0x10}
+	serverRand := &detRand{fillByte: 0x80}
+	// Shared monotonic clock — every call advances by 1ms. This keeps
+	// each frame's ts strictly monotonic without depending on wall-clock
+	// resolution (test machines may run multiple Step calls inside one
+	// millisecond).
+	clk := &monotonicClock{base: time.Date(2026, 5, 7, 0, 0, 0, 0, time.UTC)}
+	now := clk.Now
+
+	client := NewClient(ClientConfig{
+		Identity: Identity{
+			DeviceID:    "device-desktop-aaa1",
+			Kind:        KindDesktop,
+			DisplayName: "Test Desktop",
+		},
+		Confirmer: AutoConfirm,
+		Now:       now,
+		Rand:      clientRand,
+	})
+	server := NewServer(ServerConfig{
+		Identity: Identity{
+			DeviceID:    "device-mobile-bbb2",
+			Kind:        KindMobile,
+			DisplayName: "Test Phone",
+			PushToken:   "fcm-token-test",
+		},
+		Confirmer: AutoConfirm,
+		Now:       now,
+		Rand:      serverRand,
+	})
+
+	type result struct {
+		res Result
+		err error
+	}
+	clientCh := make(chan result, 1)
+	serverCh := make(chan result, 1)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	go func() {
+		res, err := client.Run(ctx, pipe.ClientSide())
+		// Close client's outbound pipe so server reads see EOF when
+		// we exit (defensive — happy path doesn't trigger this).
+		_ = pipe.clientWriter.Close()
+		clientCh <- result{res, err}
+	}()
+	go func() {
+		res, err := server.Run(ctx, pipe.ServerSide())
+		// Close server's outbound pipe so client reads see EOF.
+		_ = pipe.serverWriter.Close()
+		serverCh <- result{res, err}
+	}()
+
+	cr := <-clientCh
+	sr := <-serverCh
+
+	if cr.err != nil {
+		t.Fatalf("client: %v", cr.err)
+	}
+	if sr.err != nil {
+		t.Fatalf("server: %v", sr.err)
+	}
+
+	if !bytes.Equal(cr.res.LongTermKey, sr.res.LongTermKey) {
+		t.Errorf("long-term keys diverge:\n client: %x\n server: %x",
+			cr.res.LongTermKey, sr.res.LongTermKey)
+	}
+	if !bytes.Equal(cr.res.TransportBindingKey, sr.res.TransportBindingKey) {
+		t.Errorf("transport binding keys diverge")
+	}
+	if !bytes.Equal(cr.res.TranscriptHash, sr.res.TranscriptHash) {
+		t.Errorf("transcript hashes diverge:\n client: %x\n server: %x",
+			cr.res.TranscriptHash, sr.res.TranscriptHash)
+	}
+	if cr.res.SAS != sr.res.SAS {
+		t.Errorf("SAS values diverge: client=%q server=%q", cr.res.SAS, sr.res.SAS)
+	}
+	if cr.res.SAS == "" {
+		t.Errorf("empty SAS")
+	}
+	if sr.res.PeerName != "Test Desktop" {
+		t.Errorf("server PeerName: got %q want %q", sr.res.PeerName, "Test Desktop")
+	}
+	if cr.res.PeerPushToken != "fcm-token-test" {
+		t.Errorf("client PeerPushToken: got %q want fcm-token-test", cr.res.PeerPushToken)
+	}
+}

--- a/internal/pair/doc.go
+++ b/internal/pair/doc.go
@@ -1,0 +1,84 @@
+// Package pair implements the device-pair protocol specified in
+// `tether-doc/wiki/specs/2026-05-07-pairing-protocol.md` (§11.AB of the
+// main design doc). This is the slice-#4 implementation that turns the
+// spec's prose into a concrete state machine + frame codec + persistence
+// layer.
+//
+// # Scope
+//
+// Two devices that have never met (e.g. user's desktop + user's phone)
+// run this protocol over the control channel of a WebTransport session
+// and emerge with:
+//
+//   - A 32-byte long-term key (the input to §11.C envelope encryption's
+//     wrap_key role)
+//   - A 32-byte transport-binding key (reserved for v0.1.x channel
+//     binding; derived now to avoid future on-disk migration)
+//   - A persisted device record at
+//     `~/.tether/users/<user>/devices/<deviceId>.json` (mode 0600)
+//
+// Active-MITM resistance during the pair window is provided by a Short
+// Authentication String (SAS) that the user compares out-of-band — both
+// endpoints derive the same 6-character base32 code only if the same
+// X25519 ephemeral pubkeys and transcript reached both sides.
+//
+// # Layering
+//
+//	┌────────────────────────────────────────────────────────────────────┐
+//	│ pair.go            Frame structs + envelope wrapping (§3.3.1).     │
+//	│ fsm.go             Pure Mealy state machine: (state, event) →      │
+//	│                    (newState, outFrames). No I/O. Anti-replay      │
+//	│                    (per-direction strictly-monotonic ts) + per-    │
+//	│                    state allowed-frame matrix from spec §6.        │
+//	│ sas.go             SAS derivation (HKDF → 30 bits → base32        │
+//	│                    alphabet) + ConfirmMAC + LongTermKey            │
+//	│                    derivation. Pinned algorithm per spec §4 / §8.  │
+//	│ transcript.go      Append-only running-SHA256 over canonicalized   │
+//	│                    frames. JCS (RFC 8785) + 4-byte big-endian      │
+//	│                    length prefix per concatenated frame.           │
+//	│ client.go          Initiator-side driver — runs the FSM against an │
+//	│                    io.ReadWriter control stream, returns a Result  │
+//	│                    on `paired`.                                    │
+//	│ server.go          Daemon/responder-side driver — same shape.      │
+//	│ registry.go        Persistence: per-device JSON files at 0600,     │
+//	│                    parent dirs at 0700, atomic write via tmp +     │
+//	│                    rename. Re-pair default = reject (Q2).          │
+//	│ audit.go           Append-only JSONL audit log at                  │
+//	│                    `~/.tether/users/<user>/audit.log` for          │
+//	│                    pair.success / pair.fail / pair.repair-rejected │
+//	│                    / pair.force-rotated events.                    │
+//	└────────────────────────────────────────────────────────────────────┘
+//
+// # Design choices
+//
+//   - Canonical frame encoding for transcript: deterministic JSON (sorted
+//     keys, no whitespace, UTF-8) per RFC 8785 / JCS, length-prefixed by
+//     4-byte big-endian. Implemented inline rather than pulling a JCS
+//     library because our frame fields are flat and well-typed; sorted-
+//     key marshaling is one pass over a map[string]any.
+//
+//   - HKDF info strings (one per derived key, all distinct, all pinned
+//     in code with comments matching the spec):
+//
+//     * "tether-sas-v1"            — sas_key (also MAC key)
+//     * "tether-sas-display-v1"    — sas_bits (30 bits → 6 base32 chars)
+//     * "tether-pair-confirm-v1|"  — HMAC label prefix for SAS-confirm
+//     * "tether-ltk-v1"            — long_term_key (32B)
+//     * "tether-tbk-v1"            — transport_binding_key (32B)
+//
+//   - Re-pair default = reject (spec §14 Q2 ratification): Registry.Save
+//     returns ErrAlreadyPaired if a record for the deviceId exists.
+//     Operators must explicitly call ForceSave to overwrite, which also
+//     emits a pair.force-rotated audit-log line.
+//
+//   - Audit log: shares the §11.D file at
+//     `~/.tether/users/<user>/audit.log`. Append-only JSONL, file mode
+//     0600. Pair events use the kinds documented on AuditKind below.
+//
+// # Out of scope (handled by separate slices)
+//
+//   - Daemon integration (dispatch of pair.* envelopes into Run()).
+//   - WT transport details (the io.ReadWriter parameter is the seam).
+//   - UI / Tauri side.
+//   - FCM/APNs token sending (v0.1 stores the token verbatim only).
+package pair

--- a/internal/pair/fsm.go
+++ b/internal/pair/fsm.go
@@ -1,0 +1,330 @@
+package pair
+
+import (
+	"errors"
+	"fmt"
+)
+
+// State is the FSM state per spec §2. Idle is the start state; Paired
+// and Failed are terminal.
+type State int
+
+const (
+	StateIdle State = iota
+	StateInviting
+	StateAwaitingPubkey
+	StateSASConfirm
+	StateCompleting
+	StatePaired
+	StateFailed
+)
+
+func (s State) String() string {
+	switch s {
+	case StateIdle:
+		return "idle"
+	case StateInviting:
+		return "inviting"
+	case StateAwaitingPubkey:
+		return "awaiting-pubkey"
+	case StateSASConfirm:
+		return "sas-confirm"
+	case StateCompleting:
+		return "completing"
+	case StatePaired:
+		return "paired"
+	case StateFailed:
+		return "failed"
+	default:
+		return fmt.Sprintf("state(%d)", int(s))
+	}
+}
+
+// EventKind discriminates the kinds of events that drive Step.
+type EventKind int
+
+const (
+	// EventRecvFrame: peer sent us a frame (frame is in Event.Frame).
+	EventRecvFrame EventKind = iota
+	// EventUserConfirmsSAS: user clicked "match" on the local UI; FSM
+	// emits a pair.sas-confirm{ok:true,mac:...}.
+	EventUserConfirmsSAS
+	// EventUserRejectsSAS: user clicked "do not match"; FSM emits
+	// pair.abort{sas-mismatch}.
+	EventUserRejectsSAS
+	// EventUserCancel: user cancelled; FSM emits pair.abort{user-cancel}.
+	EventUserCancel
+	// EventTimeout: the timer for the current state expired.
+	EventTimeout
+	// EventStartInvite: initiator-side trigger to leave Idle and emit
+	// the invite. Frame field carries the populated InviteFrame.
+	EventStartInvite
+)
+
+// Event is what Step consumes. Exactly one of (Frame, populated by
+// EventRecvFrame / EventStartInvite) is meaningful per Kind.
+type Event struct {
+	Kind  EventKind
+	Frame Frame
+}
+
+// FSM holds per-pairing state. It is intentionally minimal — it does
+// NO crypto, NO IO. Drivers (client.go / server.go) own the keys and
+// the io.ReadWriter; the FSM just decides which frames are legal in
+// which state and tracks anti-replay timestamps.
+type FSM struct {
+	role  Role
+	state State
+
+	// lastSeenTS tracks per-direction strictly-monotonic ts (spec §6.1).
+	// For an FSM running as the initiator, this is the responder's last
+	// ts; for responder, the initiator's. Daemon-emitted frames go
+	// through the same field — there is only one inbound peer per FSM
+	// instance for v0.1 (the daemon mediates but presents as a single
+	// inbound stream to each endpoint).
+	lastSeenTS int64
+}
+
+// NewFSM returns a fresh FSM for the given role, starting at Idle.
+func NewFSM(role Role) *FSM {
+	return &FSM{role: role, state: StateIdle}
+}
+
+// State returns the current state. Read-only.
+func (f *FSM) State() State { return f.state }
+
+// Role returns the role this FSM was created for. Read-only.
+func (f *FSM) Role() Role { return f.role }
+
+// Errors that Step may surface.
+var (
+	// ErrUnexpectedFrame is returned when an inbound frame's kind is
+	// not in the §6.2 allowed-frame set for the current state.
+	ErrUnexpectedFrame = errors.New("pair: unexpected frame for state")
+	// ErrReplay is returned when an inbound frame's ts is <= the
+	// previously-seen ts from the same direction (spec §6.1).
+	ErrReplay = errors.New("pair: replay (non-monotonic ts)")
+	// ErrTerminal is returned when Step is called after the FSM has
+	// reached a terminal state.
+	ErrTerminal = errors.New("pair: FSM in terminal state")
+	// ErrVersionIncompatible is returned when an inbound frame's
+	// protocolVersion is not 1.
+	ErrVersionIncompatible = errors.New("pair: version-incompatible")
+)
+
+// allowedInbound encodes the §6.2 per-state allowed-inbound-frame
+// matrix. The boolean tells whether `kind` is allowed in `state` for
+// the given `role`.
+func allowedInbound(role Role, state State, kind FrameKind) bool {
+	switch state {
+	case StateIdle:
+		// Initiator does not receive in idle; responder accepts only
+		// pair.invite.
+		return role == RoleResponder && kind == KindInvite
+	case StateInviting:
+		// Inviting (initiator only) accepts only pair.abort.
+		return kind == KindAbort
+	case StateAwaitingPubkey:
+		// Initiator: pair.accept or pair.abort. Responder: nothing
+		// inbound (the responder transitions through this state by
+		// emitting an outbound pair.accept; any inbound frame here is
+		// a violation).
+		if role == RoleInitiator {
+			return kind == KindAccept || kind == KindAbort
+		}
+		return false
+	case StateSASConfirm:
+		return kind == KindSASConfirm || kind == KindAbort
+	case StateCompleting:
+		return kind == KindComplete || kind == KindAbort
+	case StatePaired, StateFailed:
+		return false
+	}
+	return false
+}
+
+// Step is the pure transition function. It returns the new state, any
+// outbound frames the FSM wants emitted, and an error.
+//
+// Drivers MUST NOT mutate the returned outbound frame slice (or the
+// FSM's internal state); Step has already advanced the FSM by the time
+// it returns. On error the state is updated to StateFailed and the
+// outbound slice carries the appropriate pair.abort frame, so the
+// driver can emit it before tearing down.
+//
+// Note on EventStartInvite + EventUserConfirmsSAS: these don't carry a
+// fully-populated frame from the FSM's perspective — the driver
+// composes the InviteFrame / SASConfirmFrame (with its keys, nonces,
+// MAC) and passes it in via Event.Frame. The FSM appends it to the
+// outbound list and advances state. This keeps crypto out of the FSM.
+func (f *FSM) Step(ev Event) (State, []Frame, error) {
+	if f.state == StatePaired || f.state == StateFailed {
+		// §6.2: paired silently drops; failed silently drops. Spec
+		// says "log warning, do NOT transition". Return the existing
+		// state with no outbound frames and ErrTerminal so the caller
+		// knows to stop pumping.
+		return f.state, nil, ErrTerminal
+	}
+
+	switch ev.Kind {
+	case EventRecvFrame:
+		return f.stepRecvFrame(ev.Frame)
+
+	case EventStartInvite:
+		if f.state != StateIdle || f.role != RoleInitiator {
+			return f.fail("start-invite outside idle")
+		}
+		invite, ok := ev.Frame.(InviteFrame)
+		if !ok {
+			return f.fail("start-invite without InviteFrame")
+		}
+		f.state = StateAwaitingPubkey
+		return f.state, []Frame{invite}, nil
+
+	case EventUserConfirmsSAS:
+		if f.state != StateSASConfirm {
+			return f.fail("user-confirms-sas outside sas-confirm")
+		}
+		conf, ok := ev.Frame.(SASConfirmFrame)
+		if !ok {
+			return f.fail("user-confirms-sas without SASConfirmFrame")
+		}
+		// Spec §2.1 (initiator) / §2.2 (responder): on user-confirms,
+		// emit our own sas-confirm{ok:true} and step to completing if
+		// initiator (initiator is the side that gates progress); for
+		// responder we stay in sas-confirm until peer also confirms,
+		// then completing on pair.complete arrival.
+		if f.role == RoleInitiator {
+			f.state = StateCompleting
+		}
+		return f.state, []Frame{conf}, nil
+
+	case EventUserRejectsSAS:
+		// Both roles: emit pair.abort{sas-mismatch} and fail.
+		ab, ok := ev.Frame.(AbortFrame)
+		if !ok {
+			return f.fail("user-rejects-sas without AbortFrame")
+		}
+		f.state = StateFailed
+		return f.state, []Frame{ab}, nil
+
+	case EventUserCancel:
+		ab, ok := ev.Frame.(AbortFrame)
+		if !ok {
+			return f.fail("user-cancel without AbortFrame")
+		}
+		f.state = StateFailed
+		return f.state, []Frame{ab}, nil
+
+	case EventTimeout:
+		ab, ok := ev.Frame.(AbortFrame)
+		if !ok {
+			return f.fail("timeout without AbortFrame")
+		}
+		f.state = StateFailed
+		return f.state, []Frame{ab}, nil
+	}
+
+	return f.fail(fmt.Sprintf("unhandled event kind %d", ev.Kind))
+}
+
+func (f *FSM) stepRecvFrame(frame Frame) (State, []Frame, error) {
+	if frame == nil {
+		return f.fail("recv-frame with nil frame")
+	}
+
+	// §6.1 anti-replay: per-direction strictly-monotonic ts. ts <=
+	// last-seen → ErrReplay (treated as protocol-violation per spec).
+	if frame.TS() <= f.lastSeenTS {
+		f.state = StateFailed
+		return f.state, []Frame{abortNow(ReasonProtocolViolation, "ts not strictly monotonic")}, ErrReplay
+	}
+
+	// §6.2 allowed-inbound matrix.
+	if !allowedInbound(f.role, f.state, frame.Kind()) {
+		f.state = StateFailed
+		return f.state, []Frame{abortNow(ReasonProtocolViolation, fmt.Sprintf("frame %s not allowed in state %s/%s", frame.Kind(), f.role, f.state))}, ErrUnexpectedFrame
+	}
+
+	// Update last-seen ts BEFORE the kind-specific dispatch (spec §6.1
+	// updates after acceptance; our acceptance is the matrix pass).
+	f.lastSeenTS = frame.TS()
+
+	switch frame.Kind() {
+	case KindInvite:
+		// Responder, idle → awaiting-pubkey.
+		inv, ok := frame.(InviteFrame)
+		if !ok {
+			return f.fail("invite kind with wrong concrete type")
+		}
+		if inv.ProtocolVersion != ProtocolVersion {
+			f.state = StateFailed
+			return f.state, []Frame{abortNow(ReasonVersionIncompatible, fmt.Sprintf("invite v=%d unsupported", inv.ProtocolVersion))}, ErrVersionIncompatible
+		}
+		f.state = StateAwaitingPubkey
+		return f.state, nil, nil
+
+	case KindAccept:
+		// Initiator, awaiting-pubkey → sas-confirm.
+		acc, ok := frame.(AcceptFrame)
+		if !ok {
+			return f.fail("accept kind with wrong concrete type")
+		}
+		if acc.ProtocolVersion != ProtocolVersion {
+			f.state = StateFailed
+			return f.state, []Frame{abortNow(ReasonVersionIncompatible, fmt.Sprintf("accept v=%d unsupported", acc.ProtocolVersion))}, ErrVersionIncompatible
+		}
+		f.state = StateSASConfirm
+		return f.state, nil, nil
+
+	case KindSASConfirm:
+		// Both roles, sas-confirm. Stay in sas-confirm until *both*
+		// sides have observed the other's MAC AND the local user has
+		// confirmed. The driver layer is responsible for tracking
+		// "have I seen peer's mac AND have I sent mine"; the FSM just
+		// reflects "peer's mac arrived, structurally OK".
+		conf, ok := frame.(SASConfirmFrame)
+		if !ok {
+			return f.fail("sas-confirm kind with wrong concrete type")
+		}
+		if !conf.OK {
+			// Peer rejected SAS. We fail.
+			f.state = StateFailed
+			return f.state, nil, nil
+		}
+		// MAC verification is the driver's responsibility (it has the
+		// sas_key + transcript_hash). FSM just accepts the frame
+		// arrived in the right slot.
+		return f.state, nil, nil
+
+	case KindComplete:
+		// Completing → paired. AEAD tag verification is driver-side
+		// (driver has the long_term_key); FSM accepts structural
+		// arrival.
+		f.state = StatePaired
+		return f.state, nil, nil
+
+	case KindAbort:
+		// Any state with abort allowed → failed.
+		f.state = StateFailed
+		return f.state, nil, nil
+	}
+
+	return f.fail(fmt.Sprintf("unhandled frame kind %s", frame.Kind()))
+}
+
+func (f *FSM) fail(detail string) (State, []Frame, error) {
+	f.state = StateFailed
+	return f.state, []Frame{abortNow(ReasonProtocolViolation, detail)}, fmt.Errorf("pair: fsm fault: %s", detail)
+}
+
+// abortNow constructs a pair.abort with the given reason. The TS field
+// is left at zero; the driver fills it in before sending (the FSM has
+// no clock).
+func abortNow(reason AbortReason, detail string) AbortFrame {
+	return AbortFrame{
+		ProtocolVersion: ProtocolVersion,
+		Reason:          reason,
+		Detail:          detail,
+	}
+}

--- a/internal/pair/fsm_test.go
+++ b/internal/pair/fsm_test.go
@@ -1,0 +1,294 @@
+package pair
+
+import (
+	"errors"
+	"testing"
+)
+
+func mustInvite(ts int64) InviteFrame {
+	return InviteFrame{
+		ProtocolVersion: ProtocolVersion,
+		InitiatorPubkey: make([]byte, 32),
+		DeviceID:        "device-desk-test",
+		Kind_:           KindDesktop,
+		DisplayName:     "test desk",
+		TS_:             ts,
+		Nonce:           make([]byte, 16),
+	}
+}
+
+func mustAccept(ts int64) AcceptFrame {
+	return AcceptFrame{
+		ProtocolVersion: ProtocolVersion,
+		ResponderPubkey: make([]byte, 32),
+		DeviceID:        "device-phone-test",
+		Kind_:           KindMobile,
+		DisplayName:     "test phone",
+		TS_:             ts,
+		Nonce:           make([]byte, 16),
+	}
+}
+
+func mustSASConfirm(role Role, ts int64) SASConfirmFrame {
+	return SASConfirmFrame{
+		ProtocolVersion: ProtocolVersion,
+		OK:              true,
+		Role:            role,
+		MAC:             make([]byte, 32),
+		TS_:             ts,
+	}
+}
+
+func mustComplete(ts int64) CompleteFrame {
+	return CompleteFrame{ProtocolVersion: ProtocolVersion, TS_: ts}
+}
+
+func mustAbort(reason AbortReason, ts int64) AbortFrame {
+	return AbortFrame{ProtocolVersion: ProtocolVersion, Reason: reason, TS_: ts}
+}
+
+// TestFSM_InitiatorHappyPath walks the initiator through
+// idle → awaiting-pubkey → sas-confirm → completing → paired.
+func TestFSM_InitiatorHappyPath(t *testing.T) {
+	f := NewFSM(RoleInitiator)
+	if f.State() != StateIdle {
+		t.Fatalf("initial state: got %s want idle", f.State())
+	}
+
+	// 1. EventStartInvite → awaiting-pubkey, emits invite.
+	st, out, err := f.Step(Event{Kind: EventStartInvite, Frame: mustInvite(1)})
+	if err != nil {
+		t.Fatalf("StartInvite: %v", err)
+	}
+	if st != StateAwaitingPubkey {
+		t.Errorf("after StartInvite: got %s want awaiting-pubkey", st)
+	}
+	if len(out) != 1 || out[0].Kind() != KindInvite {
+		t.Errorf("StartInvite outbound: %v", out)
+	}
+
+	// 2. RecvFrame(accept) → sas-confirm.
+	st, _, err = f.Step(Event{Kind: EventRecvFrame, Frame: mustAccept(2)})
+	if err != nil {
+		t.Fatalf("RecvAccept: %v", err)
+	}
+	if st != StateSASConfirm {
+		t.Errorf("after RecvAccept: got %s want sas-confirm", st)
+	}
+
+	// 3. UserConfirmsSAS → completing.
+	st, out, err = f.Step(Event{Kind: EventUserConfirmsSAS, Frame: mustSASConfirm(RoleInitiator, 3)})
+	if err != nil {
+		t.Fatalf("UserConfirms: %v", err)
+	}
+	if st != StateCompleting {
+		t.Errorf("after UserConfirms: got %s want completing", st)
+	}
+	if len(out) != 1 || out[0].Kind() != KindSASConfirm {
+		t.Errorf("UserConfirms outbound: %v", out)
+	}
+
+	// 4. RecvFrame(complete) → paired. Note initiator's lastSeenTS
+	// is shared (single inbound stream), so TS must increase from
+	// the accept(2) we sent before. Use 4.
+	st, _, err = f.Step(Event{Kind: EventRecvFrame, Frame: mustComplete(4)})
+	if err != nil {
+		t.Fatalf("RecvComplete: %v", err)
+	}
+	if st != StatePaired {
+		t.Errorf("after RecvComplete: got %s want paired", st)
+	}
+
+	// 5. Terminal: any further step returns ErrTerminal.
+	_, _, err = f.Step(Event{Kind: EventRecvFrame, Frame: mustAbort(ReasonTimeout, 5)})
+	if !errors.Is(err, ErrTerminal) {
+		t.Errorf("post-paired step: got %v want ErrTerminal", err)
+	}
+}
+
+// TestFSM_ResponderHappyPath walks the responder through
+// idle → awaiting-pubkey → sas-confirm. Responder transitions onward
+// via the driver, not the FSM, so this test stops at sas-confirm.
+func TestFSM_ResponderHappyPath(t *testing.T) {
+	f := NewFSM(RoleResponder)
+
+	st, _, err := f.Step(Event{Kind: EventRecvFrame, Frame: mustInvite(1)})
+	if err != nil {
+		t.Fatalf("RecvInvite: %v", err)
+	}
+	if st != StateAwaitingPubkey {
+		t.Errorf("after RecvInvite: got %s want awaiting-pubkey", st)
+	}
+}
+
+// TestFSM_RejectsUnexpectedFrames exhaustively checks the §6.2
+// allowed-inbound matrix.
+func TestFSM_RejectsUnexpectedFrames(t *testing.T) {
+	type tc struct {
+		name        string
+		role        Role
+		setup       func(*FSM)
+		frame       Frame
+		wantErrIs   error
+	}
+	cases := []tc{
+		{
+			name:      "initiator-idle-rejects-accept",
+			role:      RoleInitiator,
+			setup:     func(*FSM) {},
+			frame:     mustAccept(1),
+			wantErrIs: ErrUnexpectedFrame,
+		},
+		{
+			name:      "responder-idle-rejects-complete",
+			role:      RoleResponder,
+			setup:     func(*FSM) {},
+			frame:     mustComplete(1),
+			wantErrIs: ErrUnexpectedFrame,
+		},
+		{
+			name: "initiator-awaiting-pubkey-rejects-complete",
+			role: RoleInitiator,
+			setup: func(f *FSM) {
+				_, _, _ = f.Step(Event{Kind: EventStartInvite, Frame: mustInvite(1)})
+			},
+			frame:     mustComplete(2),
+			wantErrIs: ErrUnexpectedFrame,
+		},
+		{
+			name: "initiator-sas-confirm-rejects-invite",
+			role: RoleInitiator,
+			setup: func(f *FSM) {
+				_, _, _ = f.Step(Event{Kind: EventStartInvite, Frame: mustInvite(1)})
+				_, _, _ = f.Step(Event{Kind: EventRecvFrame, Frame: mustAccept(2)})
+			},
+			frame:     mustInvite(3),
+			wantErrIs: ErrUnexpectedFrame,
+		},
+		{
+			name: "initiator-completing-rejects-accept",
+			role: RoleInitiator,
+			setup: func(f *FSM) {
+				_, _, _ = f.Step(Event{Kind: EventStartInvite, Frame: mustInvite(1)})
+				_, _, _ = f.Step(Event{Kind: EventRecvFrame, Frame: mustAccept(2)})
+				_, _, _ = f.Step(Event{Kind: EventUserConfirmsSAS, Frame: mustSASConfirm(RoleInitiator, 3)})
+			},
+			frame:     mustAccept(4),
+			wantErrIs: ErrUnexpectedFrame,
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			f := NewFSM(c.role)
+			c.setup(f)
+			_, out, err := f.Step(Event{Kind: EventRecvFrame, Frame: c.frame})
+			if !errors.Is(err, c.wantErrIs) {
+				t.Errorf("err = %v want %v", err, c.wantErrIs)
+			}
+			if f.State() != StateFailed {
+				t.Errorf("state after rejection: got %s want failed", f.State())
+			}
+			if len(out) != 1 || out[0].Kind() != KindAbort {
+				t.Errorf("rejection outbound: %v want pair.abort", out)
+			}
+		})
+	}
+}
+
+// TestFSM_AcceptsAbortInAnyAllowedState — pair.abort should always
+// drive the FSM to failed in the states that allow it.
+func TestFSM_AcceptsAbortInAnyAllowedState(t *testing.T) {
+	cases := []struct {
+		name  string
+		role  Role
+		setup func(*FSM)
+	}{
+		{
+			name: "initiator-inviting",
+			role: RoleInitiator,
+			setup: func(f *FSM) {
+				_, _, _ = f.Step(Event{Kind: EventStartInvite, Frame: mustInvite(1)})
+				// inviting state isn't actually a state; we go straight
+				// to awaiting-pubkey. Override the state to inviting
+				// for completeness.
+				f.state = StateInviting
+			},
+		},
+		{
+			name: "initiator-awaiting-pubkey",
+			role: RoleInitiator,
+			setup: func(f *FSM) {
+				_, _, _ = f.Step(Event{Kind: EventStartInvite, Frame: mustInvite(1)})
+			},
+		},
+		{
+			name: "initiator-sas-confirm",
+			role: RoleInitiator,
+			setup: func(f *FSM) {
+				_, _, _ = f.Step(Event{Kind: EventStartInvite, Frame: mustInvite(1)})
+				_, _, _ = f.Step(Event{Kind: EventRecvFrame, Frame: mustAccept(2)})
+			},
+		},
+		{
+			name: "initiator-completing",
+			role: RoleInitiator,
+			setup: func(f *FSM) {
+				_, _, _ = f.Step(Event{Kind: EventStartInvite, Frame: mustInvite(1)})
+				_, _, _ = f.Step(Event{Kind: EventRecvFrame, Frame: mustAccept(2)})
+				_, _, _ = f.Step(Event{Kind: EventUserConfirmsSAS, Frame: mustSASConfirm(RoleInitiator, 3)})
+			},
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			f := NewFSM(c.role)
+			c.setup(f)
+			_, _, err := f.Step(Event{Kind: EventRecvFrame, Frame: mustAbort(ReasonUserCancel, 1000)})
+			if err != nil {
+				t.Errorf("recv abort: got %v want nil", err)
+			}
+			if f.State() != StateFailed {
+				t.Errorf("state: got %s want failed", f.State())
+			}
+		})
+	}
+}
+
+// TestFSM_VersionIncompatibleInvite — invite with v=2 is rejected.
+func TestFSM_VersionIncompatibleInvite(t *testing.T) {
+	f := NewFSM(RoleResponder)
+	bad := mustInvite(1)
+	bad.ProtocolVersion = 2
+	_, out, err := f.Step(Event{Kind: EventRecvFrame, Frame: bad})
+	if !errors.Is(err, ErrVersionIncompatible) {
+		t.Errorf("err: got %v want ErrVersionIncompatible", err)
+	}
+	if f.State() != StateFailed {
+		t.Errorf("state: got %s want failed", f.State())
+	}
+	if len(out) != 1 || out[0].Kind() != KindAbort {
+		t.Fatalf("outbound: %v want pair.abort", out)
+	}
+	ab := out[0].(AbortFrame)
+	if ab.Reason != ReasonVersionIncompatible {
+		t.Errorf("abort reason: got %s want %s", ab.Reason, ReasonVersionIncompatible)
+	}
+}
+
+// TestFSM_UserCancelEmitsAbort — user-cancel from any non-terminal
+// state emits pair.abort{user-cancel} and fails.
+func TestFSM_UserCancelEmitsAbort(t *testing.T) {
+	f := NewFSM(RoleInitiator)
+	_, _, _ = f.Step(Event{Kind: EventStartInvite, Frame: mustInvite(1)})
+	_, _, _ = f.Step(Event{Kind: EventRecvFrame, Frame: mustAccept(2)})
+	_, out, err := f.Step(Event{Kind: EventUserCancel, Frame: mustAbort(ReasonUserCancel, 3)})
+	if err != nil {
+		t.Fatalf("UserCancel: %v", err)
+	}
+	if f.State() != StateFailed {
+		t.Errorf("state: got %s want failed", f.State())
+	}
+	if len(out) != 1 || out[0].Kind() != KindAbort {
+		t.Fatalf("outbound: %v want pair.abort", out)
+	}
+}

--- a/internal/pair/pair.go
+++ b/internal/pair/pair.go
@@ -1,0 +1,210 @@
+package pair
+
+import (
+	"errors"
+	"fmt"
+)
+
+// ProtocolVersion is the wire-version constant for slice #4. Receivers
+// that see a different value MUST emit pair.abort{version-incompatible}.
+const ProtocolVersion = 1
+
+// KeyVersionPair is the §3.3.1 envelope.keyVersion sentinel for
+// pair-protocol frames. Per spec §3 the inner ciphertext is plaintext
+// (no shared key exists for frames 1-2; frames 3+ keep the same shape
+// for transcript-hash uniformity); keyVersion=0 is the marker for that
+// "unencrypted, pair-protocol scope" mode.
+const KeyVersionPair = 0
+
+// DefaultUser is the v0.1 hardcoded user id (D-04 single-user). v0.2
+// will let the responder validate userId from pair.invite; v0.1 just
+// hardcodes "default" everywhere.
+const DefaultUser = "default"
+
+// DeviceID is the caller-stable identity of one device in a pair. Per
+// spec §9.1 filenames are constrained to [a-zA-Z0-9-]+; ValidateDeviceID
+// enforces that regex.
+type DeviceID string
+
+// DeviceKind enumerates the two device categories spec §3.1 lists in
+// pair.invite.deviceMetadata.kind. "terminal" is added for completeness
+// (see spec §11.D's lock.ClientID kinds); the wire only emits
+// "desktop" / "mobile" today.
+type DeviceKind string
+
+const (
+	KindDesktop  DeviceKind = "desktop"
+	KindMobile   DeviceKind = "mobile"
+	KindTerminal DeviceKind = "terminal"
+)
+
+// FrameKind discriminates the five pair frame types on the wire. These
+// strings are what envelope.kind contains for pair.* frames.
+type FrameKind string
+
+const (
+	KindInvite     FrameKind = "pair.invite"
+	KindAccept     FrameKind = "pair.accept"
+	KindSASConfirm FrameKind = "pair.sas-confirm"
+	KindComplete   FrameKind = "pair.complete"
+	KindAbort      FrameKind = "pair.abort"
+)
+
+// AbortReason enumerates the closed set of reasons pair.abort may carry
+// (spec §3.5 + §12).
+type AbortReason string
+
+const (
+	ReasonSASMismatch         AbortReason = "sas-mismatch"
+	ReasonTimeout             AbortReason = "timeout"
+	ReasonUserCancel          AbortReason = "user-cancel"
+	ReasonVersionIncompatible AbortReason = "version-incompatible"
+	ReasonDupDeviceID         AbortReason = "dup-deviceid"
+	ReasonCertError           AbortReason = "cert-error"
+	ReasonProtocolViolation   AbortReason = "protocol-violation"
+)
+
+// Role identifies which side computed a SAS-confirm MAC. Disambiguates
+// the two MACs sharing the same sas_key + transcript_hash.
+type Role string
+
+const (
+	RoleInitiator Role = "initiator"
+	RoleResponder Role = "responder"
+)
+
+// Frame is the union of pair frame body types. Each concrete type holds
+// the spec §3 fields verbatim; Kind() / TS() / canonicalBody() are how
+// the FSM and transcript dispatch on a frame without knowing its
+// concrete type.
+type Frame interface {
+	Kind() FrameKind
+	TS() int64
+	// canonicalBody returns the JCS-canonical (sorted keys, no
+	// whitespace) JSON encoding of the frame body. Used by transcript.go
+	// and by EnvelopeWrap.
+	canonicalBody() ([]byte, error)
+}
+
+// InviteFrame is spec §3.1 pair.invite.
+type InviteFrame struct {
+	ProtocolVersion int        `json:"v"`
+	InitiatorPubkey []byte     `json:"ephemeralPubkey"`
+	DeviceID        DeviceID   `json:"deviceId"`
+	Kind_           DeviceKind `json:"-"` // exposed via metadata.kind
+	DisplayName     string     `json:"-"` // exposed via metadata.displayName
+	TS_             int64      `json:"ts"`
+	Nonce           []byte     `json:"nonce"`
+}
+
+func (f InviteFrame) Kind() FrameKind { return KindInvite }
+func (f InviteFrame) TS() int64       { return f.TS_ }
+
+// AcceptFrame is spec §3.2 pair.accept.
+type AcceptFrame struct {
+	ProtocolVersion int        `json:"v"`
+	ResponderPubkey []byte     `json:"ephemeralPubkey"`
+	DeviceID        DeviceID   `json:"deviceId"`
+	Kind_           DeviceKind `json:"-"`
+	DisplayName     string     `json:"-"`
+	PushToken       string     `json:"-"`
+	TS_             int64      `json:"ts"`
+	Nonce           []byte     `json:"nonce"`
+}
+
+func (f AcceptFrame) Kind() FrameKind { return KindAccept }
+func (f AcceptFrame) TS() int64       { return f.TS_ }
+
+// SASConfirmFrame is spec §3.3 pair.sas-confirm.
+type SASConfirmFrame struct {
+	ProtocolVersion int    `json:"v"`
+	OK              bool   `json:"ok"`
+	Role            Role   `json:"role"`
+	MAC             []byte `json:"mac,omitempty"`
+	TS_             int64  `json:"ts"`
+}
+
+func (f SASConfirmFrame) Kind() FrameKind { return KindSASConfirm }
+func (f SASConfirmFrame) TS() int64       { return f.TS_ }
+
+// CompleteFrame is spec §3.4 pair.complete (daemon-emitted ack).
+//
+// v0.1 simplification: the spec describes an AEAD tag computed under
+// the derived long_term_key; the slice-#4 implementation models this
+// as a frame the daemon emits once both endpoints' SAS-confirm MACs
+// have been observed. The TS field is the only field the bare ack
+// needs to round-trip; richer payload (registeredAs, longTermKeyId,
+// nonce, tag) lives in CompleteFrameExt for the daemon-driven path.
+type CompleteFrame struct {
+	ProtocolVersion int   `json:"v"`
+	TS_             int64 `json:"ts"`
+}
+
+func (f CompleteFrame) Kind() FrameKind { return KindComplete }
+func (f CompleteFrame) TS() int64       { return f.TS_ }
+
+// AbortFrame is spec §3.5 pair.abort.
+type AbortFrame struct {
+	ProtocolVersion int         `json:"v"`
+	Reason          AbortReason `json:"reason"`
+	Detail          string      `json:"detail,omitempty"`
+	TS_             int64       `json:"ts"`
+}
+
+func (f AbortFrame) Kind() FrameKind { return KindAbort }
+func (f AbortFrame) TS() int64       { return f.TS_ }
+
+// WireEnvelope is the §3.3.1 outer envelope shape limited to the fields
+// pair-protocol cares about. The pair package never builds the full
+// crypto-envelope (that's §11.C / internal/crypto's job); for pair
+// frames keyVersion=0 marks the body as plaintext.
+type WireEnvelope struct {
+	Kind       FrameKind `json:"kind"`
+	KeyVersion int       `json:"keyVersion"`
+	Ciphertext []byte    `json:"ciphertext"`
+	TS         int64     `json:"ts"`
+}
+
+// EnvelopeWrap wraps a pair frame into the §3.3.1 envelope shape with
+// keyVersion=0 (per spec §14 OQ ratification — pair frames pre-shared-
+// key are intentionally plaintext-marked) and the canonical-encoded
+// body in Ciphertext.
+func EnvelopeWrap(frame Frame) (WireEnvelope, error) {
+	body, err := frame.canonicalBody()
+	if err != nil {
+		return WireEnvelope{}, fmt.Errorf("pair: canonical encode %s: %w", frame.Kind(), err)
+	}
+	return WireEnvelope{
+		Kind:       frame.Kind(),
+		KeyVersion: KeyVersionPair,
+		Ciphertext: body,
+		TS:         frame.TS(),
+	}, nil
+}
+
+// ErrUnknownFrameKind is returned by EnvelopeUnwrap when an envelope's
+// Kind is not one of the five pair.* values.
+var ErrUnknownFrameKind = errors.New("pair: unknown frame kind")
+
+// EnvelopeUnwrap decodes an envelope back into a concrete Frame. Used
+// by the FSM driver layer (client.go / server.go) when reading frames
+// off the control stream.
+func EnvelopeUnwrap(env WireEnvelope) (Frame, error) {
+	if env.KeyVersion != KeyVersionPair {
+		return nil, fmt.Errorf("pair: keyVersion %d invalid for pair frame (must be %d)", env.KeyVersion, KeyVersionPair)
+	}
+	switch env.Kind {
+	case KindInvite:
+		return decodeInviteBody(env.Ciphertext)
+	case KindAccept:
+		return decodeAcceptBody(env.Ciphertext)
+	case KindSASConfirm:
+		return decodeSASConfirmBody(env.Ciphertext)
+	case KindComplete:
+		return decodeCompleteBody(env.Ciphertext)
+	case KindAbort:
+		return decodeAbortBody(env.Ciphertext)
+	default:
+		return nil, fmt.Errorf("%w: %q", ErrUnknownFrameKind, env.Kind)
+	}
+}

--- a/internal/pair/registry.go
+++ b/internal/pair/registry.go
@@ -1,0 +1,328 @@
+package pair
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"sync"
+	"time"
+)
+
+// DeviceRecord is the on-disk shape per spec §9.2 — one of these per
+// peer device, written to ~/.tether/users/<user>/devices/<deviceId>.json
+// at file mode 0600. Fields not provided by the v0.1 wire (model,
+// osVersion, appVersion) are kept as optional strings; the daemon may
+// populate them later without a file-format bump because the JSON
+// decoder ignores absent fields.
+type DeviceRecord struct {
+	V                   int            `json:"v"`
+	DeviceID            DeviceID       `json:"deviceId"`
+	Kind                DeviceKind     `json:"kind"`
+	DisplayName         string         `json:"displayName"`
+	Model               string         `json:"model,omitempty"`
+	LongTermKey         []byte         `json:"-"` // serialized as base64url string
+	TransportBindingKey []byte         `json:"-"` // serialized as base64url string
+	LongTermKeyID       string         `json:"longTermKeyId,omitempty"`
+	PushToken           string         `json:"-"` // serialized inside pushToken object
+	PairedAt            time.Time      `json:"-"` // serialized as ISO 8601 UTC ms
+	LastSeen            time.Time      `json:"-"` // serialized as ISO 8601 UTC ms
+}
+
+// jsonDeviceRecord is the wire shape — separate from DeviceRecord so
+// we can format []byte → base64url and time.Time → ISO 8601 without
+// custom MarshalJSON on the public struct.
+type jsonDeviceRecord struct {
+	V                   int        `json:"v"`
+	DeviceID            DeviceID   `json:"deviceId"`
+	Kind                DeviceKind `json:"kind"`
+	DisplayName         string     `json:"displayName"`
+	Model               string     `json:"model,omitempty"`
+	LongTermKey         string     `json:"longTermKey"`
+	TransportBindingKey string     `json:"transportBindingKey"`
+	LongTermKeyID       string     `json:"longTermKeyId,omitempty"`
+	PushToken           *struct {
+		Type    string `json:"type"`
+		Payload struct {
+			Token string `json:"token"`
+		} `json:"payload"`
+	} `json:"pushToken,omitempty"`
+	PairedAt string `json:"pairedAt"`
+	LastSeen string `json:"lastSeen"`
+}
+
+// deviceIDRegexp is the constraint from spec §9.1: filenames are
+// [a-zA-Z0-9-]+ and must be at least 1 char.
+var deviceIDRegexp = regexp.MustCompile(`^[a-zA-Z0-9-]+$`)
+
+// ValidateDeviceID returns nil iff id is a valid filename per §9.1.
+func ValidateDeviceID(id DeviceID) error {
+	if id == "" {
+		return errors.New("pair: empty deviceId")
+	}
+	if !deviceIDRegexp.MatchString(string(id)) {
+		return fmt.Errorf("pair: deviceId %q has invalid characters (allowed: [a-zA-Z0-9-]+)", string(id))
+	}
+	return nil
+}
+
+// Registry persists per-device records under
+// ~/.tether/users/<user>/devices/. v0.1 hardcodes user="default".
+//
+// Concurrency: Save / ForceSave / Delete are mutex-serialized to
+// prevent two paired devices from racing on the same file. Load / List
+// take the mutex briefly to avoid reading a half-written file.
+type Registry struct {
+	root  string // ~/.tether/users/<user>/devices/
+	mu    sync.Mutex
+	audit *AuditLog
+}
+
+// RegistryConfig is the explicit-config form of NewRegistry. Root is
+// the per-user devices directory; AuditLog is the (optional) sink
+// that ForceSave writes pair.force-rotated lines into. If AuditLog is
+// nil, ForceSave still rotates but does not log.
+type RegistryConfig struct {
+	Root  string
+	Audit *AuditLog
+}
+
+// NewRegistry opens (or creates) a Registry at the given directory.
+// Parent dirs are created at 0700 if missing.
+func NewRegistry(cfg RegistryConfig) (*Registry, error) {
+	if cfg.Root == "" {
+		return nil, errors.New("pair: registry root path required")
+	}
+	if err := os.MkdirAll(cfg.Root, 0o700); err != nil {
+		return nil, fmt.Errorf("pair: mkdir registry %q: %w", cfg.Root, err)
+	}
+	// Tighten mode in case dir pre-existed with looser perms.
+	_ = os.Chmod(cfg.Root, 0o700)
+	return &Registry{root: cfg.Root, audit: cfg.Audit}, nil
+}
+
+// DefaultRegistryRoot returns ~/.tether/users/<user>/devices/. user is
+// the v0.1 hardcoded "default"; v0.2 will let callers pass a real id.
+func DefaultRegistryRoot(home, user string) string {
+	if user == "" {
+		user = DefaultUser
+	}
+	return filepath.Join(home, ".tether", "users", user, "devices")
+}
+
+// ErrAlreadyPaired is returned by Save when a record already exists
+// for the deviceId. Per spec §14 Q2 ratification the default re-pair
+// behavior is reject; operators must explicitly call ForceSave to
+// overwrite.
+var ErrAlreadyPaired = errors.New("pair: device already paired")
+
+// ErrNotFound is returned by Load when no record exists for the id.
+var ErrNotFound = errors.New("pair: device record not found")
+
+// Save writes a DeviceRecord at <root>/<deviceId>.json at mode 0600.
+// Returns ErrAlreadyPaired if a record already exists. Atomic via
+// tmp + rename.
+func (r *Registry) Save(rec DeviceRecord) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.saveLocked(rec, false)
+}
+
+// ForceSave overwrites any existing record and emits a
+// pair.force-rotated audit line (if AuditLog is configured). Returns
+// only IO errors.
+func (r *Registry) ForceSave(rec DeviceRecord) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	// Capture old longTermKeyId for the audit line.
+	prevID := ""
+	if existing, err := r.loadLocked(rec.DeviceID); err == nil {
+		prevID = existing.LongTermKeyID
+	}
+	if err := r.saveLocked(rec, true); err != nil {
+		return err
+	}
+	if r.audit != nil {
+		_ = r.audit.AppendForceRotated(rec.DeviceID, rec.LongTermKeyID, prevID)
+	}
+	return nil
+}
+
+func (r *Registry) saveLocked(rec DeviceRecord, force bool) error {
+	if err := ValidateDeviceID(rec.DeviceID); err != nil {
+		return err
+	}
+	path := r.path(rec.DeviceID)
+	if !force {
+		if _, err := os.Stat(path); err == nil {
+			// Audit the rejection so operators can observe re-pair
+			// attempts (§10.3). Best-effort; we don't fail Save on
+			// audit IO error.
+			if r.audit != nil {
+				_ = r.audit.AppendRepairRejected(rec.DeviceID)
+			}
+			return ErrAlreadyPaired
+		} else if !errors.Is(err, os.ErrNotExist) {
+			return fmt.Errorf("pair: stat %q: %w", path, err)
+		}
+	}
+	row := toJSONRecord(rec)
+	body, err := json.MarshalIndent(row, "", "  ")
+	if err != nil {
+		return fmt.Errorf("pair: marshal device record: %w", err)
+	}
+	tmp := path + ".tmp"
+	if err := os.WriteFile(tmp, body, 0o600); err != nil {
+		return fmt.Errorf("pair: write tmp %q: %w", tmp, err)
+	}
+	// Tighten mode in case the file pre-existed with looser perms.
+	_ = os.Chmod(tmp, 0o600)
+	if err := os.Rename(tmp, path); err != nil {
+		// Best-effort cleanup.
+		_ = os.Remove(tmp)
+		return fmt.Errorf("pair: rename %q -> %q: %w", tmp, path, err)
+	}
+	_ = os.Chmod(path, 0o600)
+	return nil
+}
+
+// Load reads the on-disk record for deviceID. Returns ErrNotFound if
+// no record exists.
+func (r *Registry) Load(deviceID DeviceID) (DeviceRecord, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.loadLocked(deviceID)
+}
+
+func (r *Registry) loadLocked(deviceID DeviceID) (DeviceRecord, error) {
+	if err := ValidateDeviceID(deviceID); err != nil {
+		return DeviceRecord{}, err
+	}
+	path := r.path(deviceID)
+	body, err := os.ReadFile(path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return DeviceRecord{}, ErrNotFound
+		}
+		return DeviceRecord{}, fmt.Errorf("pair: read %q: %w", path, err)
+	}
+	var row jsonDeviceRecord
+	if err := json.Unmarshal(body, &row); err != nil {
+		return DeviceRecord{}, fmt.Errorf("pair: parse %q: %w", path, err)
+	}
+	return fromJSONRecord(row)
+}
+
+// List returns the deviceIDs of every record currently on disk.
+// Sorted alphabetically for deterministic test output.
+func (r *Registry) List() ([]DeviceID, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	entries, err := os.ReadDir(r.root)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("pair: read registry %q: %w", r.root, err)
+	}
+	var ids []DeviceID
+	for _, e := range entries {
+		name := e.Name()
+		if e.IsDir() {
+			continue
+		}
+		// Only count files that look like <deviceId>.json. Skip .tmp
+		// crash leftovers, hidden files, etc.
+		if filepath.Ext(name) != ".json" {
+			continue
+		}
+		id := DeviceID(name[:len(name)-len(".json")])
+		if ValidateDeviceID(id) != nil {
+			continue
+		}
+		ids = append(ids, id)
+	}
+	sort.Slice(ids, func(i, j int) bool { return ids[i] < ids[j] })
+	return ids, nil
+}
+
+// Delete removes a device record. Returns ErrNotFound if no such
+// record. Used by the CLI rotate-deviceid path.
+func (r *Registry) Delete(deviceID DeviceID) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if err := ValidateDeviceID(deviceID); err != nil {
+		return err
+	}
+	path := r.path(deviceID)
+	if err := os.Remove(path); err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return ErrNotFound
+		}
+		return fmt.Errorf("pair: remove %q: %w", path, err)
+	}
+	return nil
+}
+
+func (r *Registry) path(id DeviceID) string {
+	return filepath.Join(r.root, string(id)+".json")
+}
+
+func toJSONRecord(rec DeviceRecord) jsonDeviceRecord {
+	row := jsonDeviceRecord{
+		V:                   1,
+		DeviceID:            rec.DeviceID,
+		Kind:                rec.Kind,
+		DisplayName:         rec.DisplayName,
+		Model:               rec.Model,
+		LongTermKey:         b64uEncode(rec.LongTermKey),
+		TransportBindingKey: b64uEncode(rec.TransportBindingKey),
+		LongTermKeyID:       rec.LongTermKeyID,
+		PairedAt:            rec.PairedAt.UTC().Format("2006-01-02T15:04:05.000Z07:00"),
+		LastSeen:            rec.LastSeen.UTC().Format("2006-01-02T15:04:05.000Z07:00"),
+	}
+	if rec.PushToken != "" {
+		var pt struct {
+			Type    string `json:"type"`
+			Payload struct {
+				Token string `json:"token"`
+			} `json:"payload"`
+		}
+		pt.Type = "fcm"
+		pt.Payload.Token = rec.PushToken
+		row.PushToken = &pt
+	}
+	return row
+}
+
+func fromJSONRecord(row jsonDeviceRecord) (DeviceRecord, error) {
+	ltk, err := b64uDecode(row.LongTermKey)
+	if err != nil {
+		return DeviceRecord{}, fmt.Errorf("pair: decode longTermKey: %w", err)
+	}
+	tbk, err := b64uDecode(row.TransportBindingKey)
+	if err != nil {
+		return DeviceRecord{}, fmt.Errorf("pair: decode transportBindingKey: %w", err)
+	}
+	pairedAt, _ := time.Parse(time.RFC3339Nano, row.PairedAt)
+	lastSeen, _ := time.Parse(time.RFC3339Nano, row.LastSeen)
+	rec := DeviceRecord{
+		V:                   row.V,
+		DeviceID:            row.DeviceID,
+		Kind:                row.Kind,
+		DisplayName:         row.DisplayName,
+		Model:               row.Model,
+		LongTermKey:         ltk,
+		TransportBindingKey: tbk,
+		LongTermKeyID:       row.LongTermKeyID,
+		PairedAt:            pairedAt,
+		LastSeen:            lastSeen,
+	}
+	if row.PushToken != nil {
+		rec.PushToken = row.PushToken.Payload.Token
+	}
+	return rec, nil
+}

--- a/internal/pair/registry_test.go
+++ b/internal/pair/registry_test.go
@@ -1,0 +1,200 @@
+package pair
+
+import (
+	"bytes"
+	"errors"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+	"time"
+)
+
+func newTestRegistry(t *testing.T) (*Registry, *AuditLog, string) {
+	t.Helper()
+	dir := t.TempDir()
+	auditPath := filepath.Join(dir, "users", "default", "audit.log")
+	a, err := NewAuditLog(auditPath)
+	if err != nil {
+		t.Fatalf("NewAuditLog: %v", err)
+	}
+	t.Cleanup(func() { _ = a.Close() })
+
+	root := filepath.Join(dir, "users", "default", "devices")
+	r, err := NewRegistry(RegistryConfig{Root: root, Audit: a})
+	if err != nil {
+		t.Fatalf("NewRegistry: %v", err)
+	}
+	return r, a, root
+}
+
+func makeRecord() DeviceRecord {
+	return DeviceRecord{
+		V:                   1,
+		DeviceID:            "device-mobile-abc1",
+		Kind:                KindMobile,
+		DisplayName:         "Test Phone",
+		LongTermKey:         bytes.Repeat([]byte{0xAA}, 32),
+		TransportBindingKey: bytes.Repeat([]byte{0xBB}, 32),
+		LongTermKeyID:       "ltk-test-1",
+		PushToken:           "fcm-token-xyz",
+		PairedAt:            time.Date(2026, 5, 7, 12, 0, 0, 0, time.UTC),
+		LastSeen:            time.Date(2026, 5, 7, 12, 0, 0, 0, time.UTC),
+	}
+}
+
+func TestRegistry_SaveLoadRoundtrip(t *testing.T) {
+	r, _, _ := newTestRegistry(t)
+	rec := makeRecord()
+	if err := r.Save(rec); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	got, err := r.Load(rec.DeviceID)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if got.DeviceID != rec.DeviceID {
+		t.Errorf("DeviceID: got %s want %s", got.DeviceID, rec.DeviceID)
+	}
+	if got.Kind != rec.Kind {
+		t.Errorf("Kind: got %s want %s", got.Kind, rec.Kind)
+	}
+	if !bytes.Equal(got.LongTermKey, rec.LongTermKey) {
+		t.Errorf("LongTermKey mismatch")
+	}
+	if !bytes.Equal(got.TransportBindingKey, rec.TransportBindingKey) {
+		t.Errorf("TransportBindingKey mismatch")
+	}
+	if got.PushToken != rec.PushToken {
+		t.Errorf("PushToken: got %q want %q", got.PushToken, rec.PushToken)
+	}
+}
+
+func TestRegistry_RePairDefaultRejects(t *testing.T) {
+	r, _, _ := newTestRegistry(t)
+	rec := makeRecord()
+	if err := r.Save(rec); err != nil {
+		t.Fatalf("first Save: %v", err)
+	}
+	rec2 := rec
+	rec2.LongTermKey = bytes.Repeat([]byte{0xCC}, 32)
+	if err := r.Save(rec2); !errors.Is(err, ErrAlreadyPaired) {
+		t.Errorf("re-pair Save: got %v want ErrAlreadyPaired", err)
+	}
+	// And the on-disk record was not overwritten.
+	got, err := r.Load(rec.DeviceID)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if !bytes.Equal(got.LongTermKey, rec.LongTermKey) {
+		t.Errorf("Save rejection must not alter on-disk record")
+	}
+}
+
+func TestRegistry_ForceSaveOverwritesAndAudits(t *testing.T) {
+	r, audit, _ := newTestRegistry(t)
+	rec := makeRecord()
+	if err := r.Save(rec); err != nil {
+		t.Fatalf("first Save: %v", err)
+	}
+	rec2 := rec
+	rec2.LongTermKey = bytes.Repeat([]byte{0xCC}, 32)
+	rec2.LongTermKeyID = "ltk-test-2"
+	if err := r.ForceSave(rec2); err != nil {
+		t.Fatalf("ForceSave: %v", err)
+	}
+	got, err := r.Load(rec.DeviceID)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if !bytes.Equal(got.LongTermKey, rec2.LongTermKey) {
+		t.Errorf("ForceSave did not overwrite LongTermKey")
+	}
+	// Audit log should have a force-rotated line.
+	body, err := os.ReadFile(audit.Path())
+	if err != nil {
+		t.Fatalf("read audit: %v", err)
+	}
+	if !bytes.Contains(body, []byte(`"pair.force-rotated"`)) {
+		t.Errorf("audit log missing pair.force-rotated line: %s", body)
+	}
+	if !bytes.Contains(body, []byte(`"previousLongTermKeyId":"ltk-test-1"`)) {
+		t.Errorf("audit log missing previousLongTermKeyId: %s", body)
+	}
+}
+
+func TestRegistry_ListAndDelete(t *testing.T) {
+	r, _, _ := newTestRegistry(t)
+	for _, id := range []DeviceID{"device-mobile-aaa", "device-desktop-bbb"} {
+		rec := makeRecord()
+		rec.DeviceID = id
+		if err := r.Save(rec); err != nil {
+			t.Fatalf("Save %s: %v", id, err)
+		}
+	}
+	ids, err := r.List()
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(ids) != 2 {
+		t.Errorf("List length: got %d want 2", len(ids))
+	}
+	if err := r.Delete("device-mobile-aaa"); err != nil {
+		t.Errorf("Delete: %v", err)
+	}
+	if err := r.Delete("device-mobile-aaa"); !errors.Is(err, ErrNotFound) {
+		t.Errorf("double Delete: got %v want ErrNotFound", err)
+	}
+}
+
+func TestRegistry_FileModeAndDirMode(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("POSIX file modes not enforced on Windows")
+	}
+	r, _, root := newTestRegistry(t)
+	rec := makeRecord()
+	if err := r.Save(rec); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	// File 0600.
+	st, err := os.Stat(filepath.Join(root, string(rec.DeviceID)+".json"))
+	if err != nil {
+		t.Fatalf("stat: %v", err)
+	}
+	if mode := st.Mode().Perm(); mode != 0o600 {
+		t.Errorf("file mode: got %o want 0600", mode)
+	}
+	// Dir 0700.
+	ds, err := os.Stat(root)
+	if err != nil {
+		t.Fatalf("stat dir: %v", err)
+	}
+	if mode := ds.Mode().Perm(); mode != 0o700 {
+		t.Errorf("dir mode: got %o want 0700", mode)
+	}
+}
+
+func TestRegistry_ValidateDeviceID(t *testing.T) {
+	cases := []struct {
+		id    DeviceID
+		valid bool
+	}{
+		{"device-mobile-abc1", true},
+		{"DEVICE-DESK-XYZ", true},
+		{"abc", true},
+		{"", false},
+		{"with space", false},
+		{"with/slash", false},
+		{"with..dots", false},
+		{"unicodé", false},
+	}
+	for _, c := range cases {
+		err := ValidateDeviceID(c.id)
+		if c.valid && err != nil {
+			t.Errorf("ValidateDeviceID(%q): got %v want nil", c.id, err)
+		}
+		if !c.valid && err == nil {
+			t.Errorf("ValidateDeviceID(%q): got nil want error", c.id)
+		}
+	}
+}

--- a/internal/pair/replay_test.go
+++ b/internal/pair/replay_test.go
@@ -1,0 +1,73 @@
+package pair
+
+import (
+	"errors"
+	"testing"
+)
+
+// TestReplay_TSNonMonotonicRejected — a frame with ts <= last-seen-ts
+// is rejected with ErrReplay (treated as protocol-violation per
+// spec §6.1).
+func TestReplay_TSNonMonotonicRejected(t *testing.T) {
+	f := NewFSM(RoleInitiator)
+	_, _, err := f.Step(Event{Kind: EventStartInvite, Frame: mustInvite(1)})
+	if err != nil {
+		t.Fatalf("StartInvite: %v", err)
+	}
+	// Receive accept with ts=100.
+	_, _, err = f.Step(Event{Kind: EventRecvFrame, Frame: mustAccept(100)})
+	if err != nil {
+		t.Fatalf("first accept: %v", err)
+	}
+	// Now a "replay" with ts=100 (<=) of any allowed frame must
+	// trigger ErrReplay.
+	bad := mustSASConfirm(RoleResponder, 100)
+	_, out, err := f.Step(Event{Kind: EventRecvFrame, Frame: bad})
+	if !errors.Is(err, ErrReplay) {
+		t.Errorf("replay (ts==last): got %v want ErrReplay", err)
+	}
+	if f.State() != StateFailed {
+		t.Errorf("state: got %s want failed", f.State())
+	}
+	if len(out) != 1 || out[0].Kind() != KindAbort {
+		t.Errorf("outbound: %v want pair.abort", out)
+	}
+	ab := out[0].(AbortFrame)
+	if ab.Reason != ReasonProtocolViolation {
+		t.Errorf("abort reason: got %s want %s", ab.Reason, ReasonProtocolViolation)
+	}
+}
+
+// TestReplay_TSStrictlyLessRejected — covers the < case explicitly.
+func TestReplay_TSStrictlyLessRejected(t *testing.T) {
+	f := NewFSM(RoleInitiator)
+	_, _, _ = f.Step(Event{Kind: EventStartInvite, Frame: mustInvite(1)})
+	_, _, _ = f.Step(Event{Kind: EventRecvFrame, Frame: mustAccept(50)})
+	bad := mustSASConfirm(RoleResponder, 49) // strictly less
+	_, _, err := f.Step(Event{Kind: EventRecvFrame, Frame: bad})
+	if !errors.Is(err, ErrReplay) {
+		t.Errorf("replay (ts<last): got %v want ErrReplay", err)
+	}
+}
+
+// TestReplay_MonotonicTSAccepted — strictly increasing ts is fine.
+func TestReplay_MonotonicTSAccepted(t *testing.T) {
+	f := NewFSM(RoleInitiator)
+	_, _, _ = f.Step(Event{Kind: EventStartInvite, Frame: mustInvite(1)})
+	for i, ts := range []int64{10, 20, 30} {
+		// Use a frame valid in the current state for each iteration:
+		// after StartInvite we're in awaiting-pubkey, so accept (which
+		// transitions to sas-confirm) is valid; after that, sas-confirm
+		// frames are valid in sas-confirm; etc.
+		var fr Frame
+		switch i {
+		case 0:
+			fr = mustAccept(ts)
+		case 1, 2:
+			fr = mustSASConfirm(RoleResponder, ts)
+		}
+		if _, _, err := f.Step(Event{Kind: EventRecvFrame, Frame: fr}); err != nil {
+			t.Fatalf("step #%d ts=%d: %v", i, ts, err)
+		}
+	}
+}

--- a/internal/pair/sas.go
+++ b/internal/pair/sas.go
@@ -1,0 +1,144 @@
+package pair
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/binary"
+	"errors"
+	"fmt"
+
+	"github.com/piaobeizu/tether/internal/crypto"
+)
+
+// SAS algorithm pinning — these labels are wire-stable. Changing any
+// of them requires a protocol-version bump.
+
+const (
+	// hkdfInfoSAS derives the 32-byte sas_key (also reused as the MAC
+	// key for SAS-confirm) from the X25519 shared secret. Spec §4 step
+	// 1.
+	hkdfInfoSAS = "tether-sas-v1"
+
+	// hkdfInfoSASDisplay derives the 4 raw bytes that are masked to 30
+	// bits and base32-encoded for the user-visible SAS string. Spec §4
+	// step 2.
+	hkdfInfoSASDisplay = "tether-sas-display-v1"
+
+	// hkdfInfoLTK derives the 32-byte long_term_key (the §11.C wrap_key
+	// input). Spec §8.
+	hkdfInfoLTK = "tether-ltk-v1"
+
+	// hkdfInfoTBK derives the 32-byte transport_binding_key (reserved
+	// for v0.1.x channel-binding). Spec §8 + §13 OQ-1.
+	hkdfInfoTBK = "tether-tbk-v1"
+
+	// confirmMACLabelPrefix is prepended to the role + transcript_hash
+	// when computing the SAS-confirm MAC. Per spec §3.3 + §2.1: HMAC
+	// input is "tether-pair-confirm-v1|" || role || "|" || transcript_hash.
+	confirmMACLabelPrefix = "tether-pair-confirm-v1"
+)
+
+// sasAlphabet is the 32-character RFC 4648 base32 alphabet minus the
+// visually-confusable characters 0/O/1/I/L (spec §4 step 3).
+const sasAlphabet = "ABCDEFGHJKLMNPQRSTUVWXYZ23456789"
+
+// ErrSASMismatch is returned when a peer's pair.sas-confirm MAC does
+// not validate against the locally-derived sas_key + transcript_hash.
+// This is the active-MITM detection path.
+var ErrSASMismatch = errors.New("pair: SAS mismatch (active MITM suspected)")
+
+// ComputeSharedSecret runs X25519 ECDH between our private scalar and
+// the peer's public key. Wraps internal/crypto/X25519SharedSecret to
+// keep imports of the lower-level crypto package localized to this
+// file.
+func ComputeSharedSecret(myPriv, peerPub []byte) ([]byte, error) {
+	return crypto.X25519SharedSecret(myPriv, peerPub)
+}
+
+// DeriveSASKey computes:
+//
+//	sas_key = HKDF-SHA256(ikm=shared_secret, salt=transcript_hash,
+//	                     info="tether-sas-v1", L=32)
+//
+// per spec §4 step 1. The output is reused as the HMAC key for the
+// SAS-confirm MACs.
+func DeriveSASKey(shared, transcriptHash []byte) ([]byte, error) {
+	if len(shared) == 0 {
+		return nil, errors.New("pair: empty shared secret")
+	}
+	if len(transcriptHash) == 0 {
+		return nil, errors.New("pair: empty transcript hash")
+	}
+	return crypto.DeriveKey(shared, transcriptHash, hkdfInfoSAS, 32)
+}
+
+// ComputeSAS runs spec §4 step 2 + step 3:
+//
+//   - Expand sas_key with info="tether-sas-display-v1" to 4 bytes.
+//   - Mask low 30 bits of the big-endian uint32.
+//   - Encode as 6 base32 chars (high → low) using the spec alphabet.
+func ComputeSAS(sasKey []byte) (string, error) {
+	bits, err := crypto.DeriveKey(sasKey, nil, hkdfInfoSASDisplay, 4)
+	if err != nil {
+		return "", fmt.Errorf("pair: derive sas display: %w", err)
+	}
+	v := binary.BigEndian.Uint32(bits) & 0x3FFFFFFF // low 30 bits
+	out := make([]byte, 6)
+	out[0] = sasAlphabet[(v>>25)&0x1F]
+	out[1] = sasAlphabet[(v>>20)&0x1F]
+	out[2] = sasAlphabet[(v>>15)&0x1F]
+	out[3] = sasAlphabet[(v>>10)&0x1F]
+	out[4] = sasAlphabet[(v>>5)&0x1F]
+	out[5] = sasAlphabet[v&0x1F]
+	return string(out), nil
+}
+
+// ConfirmMAC computes:
+//
+//	HMAC-SHA256(sas_key,
+//	            "tether-pair-confirm-v1" || "|" || role || "|" || transcript_hash)
+//
+// Per spec §3.3: each side's MAC binds its role label + the same
+// transcript_hash; a peer that did not see the same transcript / does
+// not hold the same sas_key cannot produce a valid MAC.
+func ConfirmMAC(sasKey []byte, role Role, transcriptHash []byte) []byte {
+	h := hmac.New(sha256.New, sasKey)
+	_, _ = h.Write([]byte(confirmMACLabelPrefix))
+	_, _ = h.Write([]byte("|"))
+	_, _ = h.Write([]byte(string(role)))
+	_, _ = h.Write([]byte("|"))
+	_, _ = h.Write(transcriptHash)
+	return h.Sum(nil)
+}
+
+// VerifyConfirmMAC returns nil iff peerMAC is the byte-identical HMAC
+// for the given (sasKey, role, transcriptHash). Constant-time compare.
+func VerifyConfirmMAC(sasKey []byte, role Role, transcriptHash, peerMAC []byte) error {
+	expected := ConfirmMAC(sasKey, role, transcriptHash)
+	if !hmac.Equal(expected, peerMAC) {
+		return ErrSASMismatch
+	}
+	return nil
+}
+
+// DeriveLongTermKey runs spec §8: derives the long_term_key (32B) and
+// the transport_binding_key (32B) from the same (shared_secret,
+// transcript_hash) pair, with distinct HKDF info strings so the two
+// keys never collide.
+func DeriveLongTermKey(shared, transcriptHash []byte) (longTermKey, transportBindingKey []byte, err error) {
+	if len(shared) == 0 {
+		return nil, nil, errors.New("pair: empty shared secret")
+	}
+	if len(transcriptHash) == 0 {
+		return nil, nil, errors.New("pair: empty transcript hash")
+	}
+	ltk, err := crypto.DeriveKey(shared, transcriptHash, hkdfInfoLTK, 32)
+	if err != nil {
+		return nil, nil, fmt.Errorf("pair: derive ltk: %w", err)
+	}
+	tbk, err := crypto.DeriveKey(shared, transcriptHash, hkdfInfoTBK, 32)
+	if err != nil {
+		return nil, nil, fmt.Errorf("pair: derive tbk: %w", err)
+	}
+	return ltk, tbk, nil
+}

--- a/internal/pair/sas_test.go
+++ b/internal/pair/sas_test.go
@@ -1,0 +1,134 @@
+package pair
+
+import (
+	"bytes"
+	"errors"
+	"testing"
+)
+
+// TestSAS_GoldenVector pins the SAS computation against a known
+// (shared_secret, transcript_hash) pair. If this test fails, the
+// algorithm has drifted from spec §4 — coordinate with the Rust UI
+// side before bumping the golden.
+func TestSAS_GoldenVector(t *testing.T) {
+	// Deterministic 32-byte inputs.
+	shared := bytes.Repeat([]byte{0x42}, 32)
+	thash := bytes.Repeat([]byte{0x17}, 32)
+
+	sasKey, err := DeriveSASKey(shared, thash)
+	if err != nil {
+		t.Fatalf("DeriveSASKey: %v", err)
+	}
+	if len(sasKey) != 32 {
+		t.Fatalf("sas_key length: got %d want 32", len(sasKey))
+	}
+
+	sas, err := ComputeSAS(sasKey)
+	if err != nil {
+		t.Fatalf("ComputeSAS: %v", err)
+	}
+	// Pinned golden: shared=0x42*32, thash=0x17*32, info chain per
+	// spec § 4. The actual value is whatever HKDF produces; we
+	// generate it once with a well-formed run and freeze it here.
+	const wantSAS = "2L5UDX"
+	if sas != wantSAS {
+		t.Errorf("SAS: got %q want %q (algorithm drift?)", sas, wantSAS)
+	}
+
+	// Sanity: 6 chars, all from the pinned alphabet.
+	if len(sas) != 6 {
+		t.Errorf("SAS length: got %d want 6", len(sas))
+	}
+	for i, c := range sas {
+		if !bytes.ContainsRune([]byte(sasAlphabet), c) {
+			t.Errorf("SAS char %d (%c) not in alphabet", i, c)
+		}
+	}
+}
+
+// TestSAS_DifferentInputsDifferentSAS — two different transcripts
+// produce two different SAS strings. (The whole point of transcript
+// binding.)
+func TestSAS_DifferentInputsDifferentSAS(t *testing.T) {
+	shared := bytes.Repeat([]byte{0x42}, 32)
+	t1 := bytes.Repeat([]byte{0x17}, 32)
+	t2 := bytes.Repeat([]byte{0x18}, 32)
+
+	k1, _ := DeriveSASKey(shared, t1)
+	k2, _ := DeriveSASKey(shared, t2)
+	s1, _ := ComputeSAS(k1)
+	s2, _ := ComputeSAS(k2)
+	if s1 == s2 {
+		t.Errorf("SAS collision on different transcripts: %q", s1)
+	}
+}
+
+// TestConfirmMAC_GoldenVector pins the HMAC label so peers can verify
+// each other's MAC byte-identically.
+func TestConfirmMAC_GoldenVector(t *testing.T) {
+	sasKey := bytes.Repeat([]byte{0x55}, 32)
+	thash := bytes.Repeat([]byte{0xAA}, 32)
+
+	// Initiator MAC.
+	macI := ConfirmMAC(sasKey, RoleInitiator, thash)
+	if len(macI) != 32 {
+		t.Errorf("MAC length: got %d want 32", len(macI))
+	}
+	// Responder MAC over the same key+thash MUST differ — the role
+	// label is the disambiguator.
+	macR := ConfirmMAC(sasKey, RoleResponder, thash)
+	if bytes.Equal(macI, macR) {
+		t.Errorf("initiator and responder MAC must differ for the same key+thash")
+	}
+
+	// Verify round-trips.
+	if err := VerifyConfirmMAC(sasKey, RoleInitiator, thash, macI); err != nil {
+		t.Errorf("VerifyConfirmMAC initiator: %v", err)
+	}
+	if err := VerifyConfirmMAC(sasKey, RoleResponder, thash, macR); err != nil {
+		t.Errorf("VerifyConfirmMAC responder: %v", err)
+	}
+	// Cross verification fails.
+	err := VerifyConfirmMAC(sasKey, RoleInitiator, thash, macR)
+	if !errors.Is(err, ErrSASMismatch) {
+		t.Errorf("cross-role verify: got %v want ErrSASMismatch", err)
+	}
+}
+
+// TestDeriveLongTermKey_DistinctKeys — long_term_key and
+// transport_binding_key must be different bytes (different HKDF info
+// strings — spec §8 + §13).
+func TestDeriveLongTermKey_DistinctKeys(t *testing.T) {
+	shared := bytes.Repeat([]byte{0x42}, 32)
+	thash := bytes.Repeat([]byte{0x17}, 32)
+	ltk, tbk, err := DeriveLongTermKey(shared, thash)
+	if err != nil {
+		t.Fatalf("DeriveLongTermKey: %v", err)
+	}
+	if len(ltk) != 32 || len(tbk) != 32 {
+		t.Errorf("key sizes: ltk=%d tbk=%d (want 32/32)", len(ltk), len(tbk))
+	}
+	if bytes.Equal(ltk, tbk) {
+		t.Errorf("ltk and tbk must differ (HKDF info strings should be distinct)")
+	}
+}
+
+// TestSAS_AlphabetMatchesSpec — the alphabet constant is the exact
+// 32-char string from spec §4: "ABCDEFGHJKLMNPQRSTUVWXYZ23456789".
+// Spec § 4 prose says "0/O/1/I/L removed" but the literal alphabet it
+// gives contains L; the literal is normative for wire compatibility.
+// 0/O/1/I are confirmed absent.
+func TestSAS_AlphabetMatchesSpec(t *testing.T) {
+	const want = "ABCDEFGHJKLMNPQRSTUVWXYZ23456789"
+	if sasAlphabet != want {
+		t.Errorf("alphabet: got %q want %q", sasAlphabet, want)
+	}
+	if len(sasAlphabet) != 32 {
+		t.Errorf("alphabet length: got %d want 32", len(sasAlphabet))
+	}
+	for _, c := range []byte{'0', 'O', '1', 'I'} {
+		if bytes.ContainsRune([]byte(sasAlphabet), rune(c)) {
+			t.Errorf("alphabet must not contain %c (visually confusable)", c)
+		}
+	}
+}

--- a/internal/pair/server.go
+++ b/internal/pair/server.go
@@ -1,0 +1,283 @@
+package pair
+
+import (
+	"context"
+	"crypto/rand"
+	"fmt"
+	"io"
+	"time"
+)
+
+// Server is the responder-side driver — the device that receives the
+// invite (typically mobile, scanning a QR / receiving an inbound).
+//
+// The slice-#4 daemon-relay role described in spec §2.4 ("daemon emits
+// pair.complete after observing both endpoints' SAS-confirms") is
+// modeled here as: the responder side is the one that emits
+// pair.complete after sending its own pair.sas-confirm. This keeps the
+// 2-actor test surface (client + server, no daemon as a third process)
+// — the daemon-as-relay split lands in a follow-up PR after this and
+// daemon-wt-wire merge.
+type Server struct {
+	identity  Identity
+	confirmer SASConfirmer
+	now       func() time.Time
+	rand      io.Reader
+
+	registry *Registry
+	audit    *AuditLog
+}
+
+// ServerConfig is the explicit-config form of NewServer. Registry and
+// Audit may be nil for tests that only care about the protocol output.
+type ServerConfig struct {
+	Identity  Identity
+	Confirmer SASConfirmer
+	Now       func() time.Time
+	Rand      io.Reader
+
+	Registry *Registry
+	Audit    *AuditLog
+}
+
+// NewServer constructs a responder-side driver. Confirmer defaults to
+// AutoConfirm.
+func NewServer(cfg ServerConfig) *Server {
+	s := &Server{
+		identity:  cfg.Identity,
+		confirmer: cfg.Confirmer,
+		now:       cfg.Now,
+		rand:      cfg.Rand,
+		registry:  cfg.Registry,
+		audit:     cfg.Audit,
+	}
+	if s.confirmer == nil {
+		s.confirmer = AutoConfirm
+	}
+	if s.now == nil {
+		s.now = func() time.Time { return time.Now().UTC() }
+	}
+	if s.rand == nil {
+		s.rand = rand.Reader
+	}
+	return s
+}
+
+// Run drives the responder-side pairing flow. Returns Result on
+// `paired`. If a Registry was configured, a record is persisted before
+// return; if an AuditLog was configured, the appropriate
+// pair.success / pair.fail line is appended.
+func (s *Server) Run(ctx context.Context, stream io.ReadWriter) (Result, error) {
+	if err := ValidateDeviceID(s.identity.DeviceID); err != nil {
+		return Result{}, err
+	}
+	r := newStreamReader(stream)
+	w := newStreamWriter(stream)
+	fsm := NewFSM(RoleResponder)
+
+	priv, pub, err := genX25519(s.rand)
+	if err != nil {
+		return Result{}, fmt.Errorf("pair: server gen ephemeral: %w", err)
+	}
+	defer zero(priv)
+
+	transcript := NewTranscript()
+
+	// 1. Receive pair.invite (no timeout — this is the signal that the
+	//    responder side is engaged in the first place; daemons that
+	//    want to bound idle should wrap ctx with their own deadline).
+	frame, err := readFrameWithCtx(ctx, r)
+	if err != nil {
+		return Result{}, fmt.Errorf("pair: server recv invite: %w", err)
+	}
+	if _, _, err := fsm.Step(Event{Kind: EventRecvFrame, Frame: frame}); err != nil {
+		return s.failAudit(s.identity.DeviceID, ReasonProtocolViolation, err.Error()), err
+	}
+	invite, ok := frame.(InviteFrame)
+	if !ok {
+		return Result{}, fmt.Errorf("pair: server expected pair.invite, got %T", frame)
+	}
+	if err := transcript.Append(invite); err != nil {
+		return Result{}, err
+	}
+
+	// 1.b. Re-pair check: if a record already exists for invite.DeviceID,
+	//      and registry is configured, abort with dup-deviceid (spec
+	//      §10.1 default path). The registry check itself returns
+	//      ErrAlreadyPaired on Save; we surface that *before* doing
+	//      ECDH so we don't waste the ephemeral.
+	if s.registry != nil {
+		if _, err := s.registry.Load(invite.DeviceID); err == nil {
+			ab := abortNow(ReasonDupDeviceID, fmt.Sprintf("deviceId %q already paired", invite.DeviceID))
+			ab.TS_ = s.now().UnixMilli()
+			_ = w.writeFrame(ab)
+			if s.audit != nil {
+				_ = s.audit.AppendRepairRejected(invite.DeviceID)
+			}
+			return Result{}, fmt.Errorf("pair: %w: %s", ErrAlreadyPaired, invite.DeviceID)
+		}
+	}
+
+	// 2. Compose + send pair.accept.
+	accept := AcceptFrame{
+		ProtocolVersion: ProtocolVersion,
+		ResponderPubkey: pub,
+		DeviceID:        s.identity.DeviceID,
+		Kind_:           s.identity.Kind,
+		DisplayName:     s.identity.DisplayName,
+		PushToken:       s.identity.PushToken,
+		TS_:             s.now().UnixMilli(),
+		Nonce:           mustRandomNonce(s.rand, 16),
+	}
+	if err := w.writeFrame(accept); err != nil {
+		return Result{}, fmt.Errorf("pair: server send accept: %w", err)
+	}
+	// Responder transitions awaiting-pubkey → sas-confirm by virtue
+	// of having emitted accept. The FSM expresses this via a manual
+	// state push (the FSM's allowed-inbound matrix doesn't model this
+	// path because it's a self-driven step).
+	fsm.state = StateSASConfirm
+	if err := transcript.Append(accept); err != nil {
+		return Result{}, err
+	}
+
+	// 3. Derive shared secret + sas_key + display SAS.
+	shared, err := ComputeSharedSecret(priv, invite.InitiatorPubkey)
+	if err != nil {
+		return Result{}, fmt.Errorf("pair: server ECDH: %w", err)
+	}
+	defer zero(shared)
+	thash := transcript.Hash()
+	sasKey, err := DeriveSASKey(shared, thash)
+	if err != nil {
+		return Result{}, err
+	}
+	defer zero(sasKey)
+	sas, err := ComputeSAS(sasKey)
+	if err != nil {
+		return Result{}, err
+	}
+
+	// 4. Receive peer's pair.sas-confirm (60s).
+	confirmCtx, confirmCancel := context.WithTimeout(ctx, TimeoutSASConfirm)
+	frame, err = readFrameWithCtx(confirmCtx, r)
+	confirmCancel()
+	if err != nil {
+		ab := abortNow(reasonForCtxErr(err), err.Error())
+		ab.TS_ = s.now().UnixMilli()
+		_ = w.writeFrame(ab)
+		return Result{}, fmt.Errorf("pair: server recv peer sas-confirm: %w", err)
+	}
+	peerConfirm, ok := frame.(SASConfirmFrame)
+	if !ok {
+		ab := abortNow(ReasonProtocolViolation, fmt.Sprintf("expected sas-confirm, got %s", frame.Kind()))
+		ab.TS_ = s.now().UnixMilli()
+		_ = w.writeFrame(ab)
+		return Result{}, fmt.Errorf("pair: expected pair.sas-confirm, got %T", frame)
+	}
+	if !peerConfirm.OK {
+		return Result{}, ErrSASMismatch
+	}
+	if peerConfirm.Role != RoleInitiator {
+		ab := abortNow(ReasonProtocolViolation, fmt.Sprintf("peer sas-confirm role=%q", peerConfirm.Role))
+		ab.TS_ = s.now().UnixMilli()
+		_ = w.writeFrame(ab)
+		return Result{}, fmt.Errorf("pair: peer sas-confirm role mismatch %q", peerConfirm.Role)
+	}
+	if err := VerifyConfirmMAC(sasKey, RoleInitiator, thash, peerConfirm.MAC); err != nil {
+		ab := abortNow(ReasonSASMismatch, "peer MAC mismatch")
+		ab.TS_ = s.now().UnixMilli()
+		_ = w.writeFrame(ab)
+		return Result{}, err
+	}
+	if err := transcript.Append(peerConfirm); err != nil {
+		return Result{}, err
+	}
+
+	// 5. Local user confirms SAS.
+	if err := s.confirmer.Confirm(sas); err != nil {
+		ab := abortNow(ReasonSASMismatch, err.Error())
+		ab.TS_ = s.now().UnixMilli()
+		_ = w.writeFrame(ab)
+		if s.audit != nil {
+			_ = s.audit.AppendFail(s.identity.DeviceID, ReasonSASMismatch, err.Error())
+		}
+		return Result{}, fmt.Errorf("pair: user rejected SAS: %w", err)
+	}
+
+	// 6. Emit our pair.sas-confirm{ok:true,role:responder}.
+	myMAC := ConfirmMAC(sasKey, RoleResponder, thash)
+	myConfirm := SASConfirmFrame{
+		ProtocolVersion: ProtocolVersion,
+		OK:              true,
+		Role:            RoleResponder,
+		MAC:             myMAC,
+		TS_:             s.now().UnixMilli(),
+	}
+	if err := w.writeFrame(myConfirm); err != nil {
+		return Result{}, fmt.Errorf("pair: server send sas-confirm: %w", err)
+	}
+	if err := transcript.Append(myConfirm); err != nil {
+		return Result{}, err
+	}
+
+	// 7. Emit pair.complete (server-side ack per spec §2.4 daemon role
+	//    — responder + daemon co-located in v0.1).
+	complete := CompleteFrame{
+		ProtocolVersion: ProtocolVersion,
+		TS_:             s.now().UnixMilli(),
+	}
+	if err := w.writeFrame(complete); err != nil {
+		return Result{}, fmt.Errorf("pair: server send complete: %w", err)
+	}
+	fsm.state = StatePaired
+
+	// 8. Derive long-term keys + persist + audit.
+	ltk, tbk, err := DeriveLongTermKey(shared, thash)
+	if err != nil {
+		return Result{}, err
+	}
+	res := Result{
+		LocalDeviceID:       s.identity.DeviceID,
+		PeerDeviceID:        invite.DeviceID,
+		PeerKind:            invite.Kind_,
+		PeerName:            invite.DisplayName,
+		LongTermKey:         ltk,
+		TransportBindingKey: tbk,
+		TranscriptHash:      thash,
+		SAS:                 sas,
+	}
+	if s.registry != nil {
+		rec := DeviceRecord{
+			V:                   1,
+			DeviceID:            invite.DeviceID,
+			Kind:                invite.Kind_,
+			DisplayName:         invite.DisplayName,
+			LongTermKey:         ltk,
+			TransportBindingKey: tbk,
+			LongTermKeyID:       fmt.Sprintf("ltk-%s", s.now().UTC().Format("20060102-150405")),
+			PairedAt:            s.now().UTC(),
+			LastSeen:            s.now().UTC(),
+		}
+		if err := s.registry.Save(rec); err != nil {
+			// Re-pair race: someone else paired this id between our
+			// pre-flight check and now. Surface the error; caller
+			// decides whether to ForceSave.
+			return res, fmt.Errorf("pair: server persist: %w", err)
+		}
+	}
+	if s.audit != nil {
+		_ = s.audit.AppendSuccess(s.identity.DeviceID, invite.DeviceID, "", thash)
+	}
+	return res, nil
+}
+
+// failAudit logs a pair.fail event (best-effort) and returns a zero
+// Result to caller. Used at error paths where we still want to record
+// the attempt before unwinding.
+func (s *Server) failAudit(id DeviceID, reason AbortReason, detail string) Result {
+	if s.audit != nil {
+		_ = s.audit.AppendFail(id, reason, detail)
+	}
+	return Result{}
+}

--- a/internal/pair/timeout_test.go
+++ b/internal/pair/timeout_test.go
@@ -1,0 +1,66 @@
+package pair
+
+import (
+	"testing"
+	"time"
+)
+
+// TestTimeout_SpecValues — the timeout constants match the spec §7
+// table exactly. Future spec revisions must update both this test
+// and the consumers.
+func TestTimeout_SpecValues(t *testing.T) {
+	if TimeoutAwaitingPubkey != 30*time.Second {
+		t.Errorf("awaiting-pubkey timeout: got %s want 30s", TimeoutAwaitingPubkey)
+	}
+	if TimeoutSASConfirm != 60*time.Second {
+		t.Errorf("sas-confirm timeout: got %s want 60s", TimeoutSASConfirm)
+	}
+	if TimeoutCompleting != 10*time.Second {
+		t.Errorf("completing timeout: got %s want 10s", TimeoutCompleting)
+	}
+}
+
+// TestTimeoutForState — TimeoutForState returns the spec-pinned
+// duration per state.
+func TestTimeoutForState(t *testing.T) {
+	cases := []struct {
+		state State
+		want  time.Duration
+	}{
+		{StateIdle, 0},
+		{StateInviting, 0},
+		{StateAwaitingPubkey, TimeoutAwaitingPubkey},
+		{StateSASConfirm, TimeoutSASConfirm},
+		{StateCompleting, TimeoutCompleting},
+		{StatePaired, 0},
+		{StateFailed, 0},
+	}
+	for _, c := range cases {
+		if got := TimeoutForState(c.state); got != c.want {
+			t.Errorf("TimeoutForState(%s) = %s want %s", c.state, got, c.want)
+		}
+	}
+}
+
+// TestTimeout_FSMEmitsAbortOnExpiry — feeding an EventTimeout fails
+// the FSM with the supplied pair.abort{timeout}.
+func TestTimeout_FSMEmitsAbortOnExpiry(t *testing.T) {
+	f := NewFSM(RoleInitiator)
+	_, _, _ = f.Step(Event{Kind: EventStartInvite, Frame: mustInvite(1)})
+
+	timeoutAbort := mustAbort(ReasonTimeout, 999)
+	_, out, err := f.Step(Event{Kind: EventTimeout, Frame: timeoutAbort})
+	if err != nil {
+		t.Fatalf("timeout step: %v", err)
+	}
+	if f.State() != StateFailed {
+		t.Errorf("state: got %s want failed", f.State())
+	}
+	if len(out) != 1 || out[0].Kind() != KindAbort {
+		t.Fatalf("outbound: %v want pair.abort", out)
+	}
+	ab := out[0].(AbortFrame)
+	if ab.Reason != ReasonTimeout {
+		t.Errorf("abort reason: got %s want %s", ab.Reason, ReasonTimeout)
+	}
+}

--- a/internal/pair/timeouts.go
+++ b/internal/pair/timeouts.go
@@ -1,0 +1,27 @@
+package pair
+
+import "time"
+
+// Timeouts per spec §7. Single-shot, start-on-state-entry. The driver
+// (client.go / server.go) creates a timer when transitioning into a
+// timed state and cancels it on next state change.
+const (
+	TimeoutAwaitingPubkey = 30 * time.Second
+	TimeoutSASConfirm     = 60 * time.Second
+	TimeoutCompleting     = 10 * time.Second
+)
+
+// TimeoutForState returns the timer that should be armed when entering
+// state. Returns 0 for states that have no timeout.
+func TimeoutForState(s State) time.Duration {
+	switch s {
+	case StateAwaitingPubkey:
+		return TimeoutAwaitingPubkey
+	case StateSASConfirm:
+		return TimeoutSASConfirm
+	case StateCompleting:
+		return TimeoutCompleting
+	default:
+		return 0
+	}
+}

--- a/internal/pair/transcript.go
+++ b/internal/pair/transcript.go
@@ -1,0 +1,371 @@
+package pair
+
+import (
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/binary"
+	"encoding/json"
+	"fmt"
+	"hash"
+	"sort"
+	"strings"
+)
+
+// Transcript is the running SHA-256 over all canonicalized pair frame
+// bodies appended in order. Each frame is fed to the hash as
+// `LP4(frameKind) || LP4(frameBodyBytes)` so frame ordering AND frame
+// kind are pinned: shuffling the order or swapping a kind for another
+// produces a different transcript_hash.
+//
+// Per spec §5: each frame body is JSON-canonicalized (sorted keys, no
+// whitespace, UTF-8 — RFC 8785 / JCS) before being fed.
+//
+// Per spec §5 the frames that go into T are: pair.invite, pair.accept,
+// pair.sas-confirm (both directions). pair.complete and pair.abort are
+// NOT appended; they reference the transcript hash as it stood after
+// the SAS-confirm frames.
+type Transcript struct {
+	h hash.Hash
+}
+
+// NewTranscript starts a fresh empty transcript.
+func NewTranscript() *Transcript {
+	return &Transcript{h: sha256.New()}
+}
+
+// Append feeds a frame into the transcript. The frame is canonicalized
+// (JCS) and then `LP4(kind) || LP4(body)` is mixed into the hash.
+func (t *Transcript) Append(frame Frame) error {
+	body, err := frame.canonicalBody()
+	if err != nil {
+		return fmt.Errorf("transcript: canonicalize %s: %w", frame.Kind(), err)
+	}
+	kind := []byte(frame.Kind())
+	if err := writeLP4(t.h, kind); err != nil {
+		return err
+	}
+	return writeLP4(t.h, body)
+}
+
+// Hash returns a snapshot of the running hash. Subsequent Append calls
+// continue from the same state — Hash does not mutate the transcript.
+func (t *Transcript) Hash() []byte {
+	// hash.Hash.Sum(nil) returns the digest WITHOUT mutating the
+	// internal state, so calling Hash() between Appends is safe.
+	return t.h.Sum(nil)
+}
+
+func writeLP4(h hash.Hash, b []byte) error {
+	var lp [4]byte
+	binary.BigEndian.PutUint32(lp[:], uint32(len(b)))
+	if _, err := h.Write(lp[:]); err != nil {
+		return fmt.Errorf("transcript: write lp4: %w", err)
+	}
+	if _, err := h.Write(b); err != nil {
+		return fmt.Errorf("transcript: write body: %w", err)
+	}
+	return nil
+}
+
+// canonicalJSON emits a JSON encoding of v with keys sorted at every
+// object level, no whitespace, and base64url-no-pad encoding for
+// []byte (matching the spec's wire convention of "base64url-32B" etc).
+//
+// The implementation walks the value via the standard encoding/json
+// Marshal first to get a valid JSON tree, then re-encodes that tree
+// with sorted keys. This is simpler than maintaining a parallel
+// reflection-based encoder and matches the JCS subset we need (our
+// frame bodies are flat structs with primitive / []byte / string
+// fields — no nested JSON Number subtleties).
+//
+// For []byte fields we cannot rely on encoding/json's default base64-
+// std encoding; we use base64url-no-pad explicitly. Since []byte is
+// only used in InviteFrame.InitiatorPubkey, AcceptFrame.ResponderPubkey,
+// SASConfirmFrame.MAC, and the nonce fields, the per-frame encode
+// helpers below format those slices via base64url before assembling
+// the map for canonicalJSON.
+func canonicalJSON(m map[string]any) ([]byte, error) {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	var sb strings.Builder
+	sb.WriteByte('{')
+	for i, k := range keys {
+		if i > 0 {
+			sb.WriteByte(',')
+		}
+		kb, err := json.Marshal(k)
+		if err != nil {
+			return nil, err
+		}
+		sb.Write(kb)
+		sb.WriteByte(':')
+		v := m[k]
+		vb, err := encodeCanonValue(v)
+		if err != nil {
+			return nil, err
+		}
+		sb.Write(vb)
+	}
+	sb.WriteByte('}')
+	return []byte(sb.String()), nil
+}
+
+func encodeCanonValue(v any) ([]byte, error) {
+	switch vv := v.(type) {
+	case map[string]any:
+		return canonicalJSON(vv)
+	case []any:
+		var sb strings.Builder
+		sb.WriteByte('[')
+		for i, e := range vv {
+			if i > 0 {
+				sb.WriteByte(',')
+			}
+			eb, err := encodeCanonValue(e)
+			if err != nil {
+				return nil, err
+			}
+			sb.Write(eb)
+		}
+		sb.WriteByte(']')
+		return []byte(sb.String()), nil
+	default:
+		// Fall back to encoding/json for primitives. Note: encoding/json
+		// does NOT sort map keys — but at this leaf path v is always
+		// a primitive (string, bool, int, float, nil), so no sort is
+		// needed.
+		return json.Marshal(vv)
+	}
+}
+
+// b64u encodes bytes using base64url with no padding (matches spec
+// "base64url-32B" notation).
+var b64u = base64.RawURLEncoding
+
+func b64uEncode(b []byte) string {
+	if b == nil {
+		return ""
+	}
+	return b64u.EncodeToString(b)
+}
+
+func b64uDecode(s string) ([]byte, error) {
+	if s == "" {
+		return nil, nil
+	}
+	return b64u.DecodeString(s)
+}
+
+// canonicalBody implementations: each fills a sorted-key map and runs
+// it through canonicalJSON.
+
+func (f InviteFrame) canonicalBody() ([]byte, error) {
+	return canonicalJSON(map[string]any{
+		"type":            string(KindInvite),
+		"v":               f.ProtocolVersion,
+		"deviceId":        string(f.DeviceID),
+		"ephemeralPubkey": b64uEncode(f.InitiatorPubkey),
+		"deviceMetadata": map[string]any{
+			"kind":        string(f.Kind_),
+			"displayName": f.DisplayName,
+		},
+		"ts":    f.TS_,
+		"nonce": b64uEncode(f.Nonce),
+	})
+}
+
+func (f AcceptFrame) canonicalBody() ([]byte, error) {
+	meta := map[string]any{
+		"kind":        string(f.Kind_),
+		"displayName": f.DisplayName,
+	}
+	body := map[string]any{
+		"type":            string(KindAccept),
+		"v":               f.ProtocolVersion,
+		"deviceId":        string(f.DeviceID),
+		"ephemeralPubkey": b64uEncode(f.ResponderPubkey),
+		"deviceMetadata":  meta,
+		"ts":              f.TS_,
+		"nonce":           b64uEncode(f.Nonce),
+	}
+	if f.PushToken != "" {
+		body["pushSubscription"] = map[string]any{
+			"type":    "fcm",
+			"payload": map[string]any{"token": f.PushToken},
+		}
+	}
+	return canonicalJSON(body)
+}
+
+func (f SASConfirmFrame) canonicalBody() ([]byte, error) {
+	body := map[string]any{
+		"type": string(KindSASConfirm),
+		"v":    f.ProtocolVersion,
+		"ok":   f.OK,
+		"role": string(f.Role),
+		"ts":   f.TS_,
+	}
+	if f.OK {
+		body["mac"] = b64uEncode(f.MAC)
+	}
+	return canonicalJSON(body)
+}
+
+func (f CompleteFrame) canonicalBody() ([]byte, error) {
+	return canonicalJSON(map[string]any{
+		"type": string(KindComplete),
+		"v":    f.ProtocolVersion,
+		"ts":   f.TS_,
+	})
+}
+
+func (f AbortFrame) canonicalBody() ([]byte, error) {
+	body := map[string]any{
+		"type":   string(KindAbort),
+		"v":      f.ProtocolVersion,
+		"reason": string(f.Reason),
+		"ts":     f.TS_,
+	}
+	if f.Detail != "" {
+		body["detail"] = f.Detail
+	}
+	return canonicalJSON(body)
+}
+
+// Decode helpers — used by EnvelopeUnwrap. They round-trip through the
+// generic map[string]any path so we tolerate field-order variation in
+// what arrives over the wire.
+
+func decodeInviteBody(b []byte) (InviteFrame, error) {
+	var raw struct {
+		V               int    `json:"v"`
+		DeviceID        string `json:"deviceId"`
+		EphemeralPubkey string `json:"ephemeralPubkey"`
+		DeviceMetadata  struct {
+			Kind        string `json:"kind"`
+			DisplayName string `json:"displayName"`
+		} `json:"deviceMetadata"`
+		TS    int64  `json:"ts"`
+		Nonce string `json:"nonce"`
+	}
+	if err := json.Unmarshal(b, &raw); err != nil {
+		return InviteFrame{}, fmt.Errorf("pair: decode invite: %w", err)
+	}
+	pk, err := b64uDecode(raw.EphemeralPubkey)
+	if err != nil {
+		return InviteFrame{}, fmt.Errorf("pair: invite pubkey: %w", err)
+	}
+	nonce, err := b64uDecode(raw.Nonce)
+	if err != nil {
+		return InviteFrame{}, fmt.Errorf("pair: invite nonce: %w", err)
+	}
+	return InviteFrame{
+		ProtocolVersion: raw.V,
+		InitiatorPubkey: pk,
+		DeviceID:        DeviceID(raw.DeviceID),
+		Kind_:           DeviceKind(raw.DeviceMetadata.Kind),
+		DisplayName:     raw.DeviceMetadata.DisplayName,
+		TS_:             raw.TS,
+		Nonce:           nonce,
+	}, nil
+}
+
+func decodeAcceptBody(b []byte) (AcceptFrame, error) {
+	var raw struct {
+		V               int    `json:"v"`
+		DeviceID        string `json:"deviceId"`
+		EphemeralPubkey string `json:"ephemeralPubkey"`
+		DeviceMetadata  struct {
+			Kind        string `json:"kind"`
+			DisplayName string `json:"displayName"`
+		} `json:"deviceMetadata"`
+		PushSubscription *struct {
+			Type    string `json:"type"`
+			Payload struct {
+				Token string `json:"token"`
+			} `json:"payload"`
+		} `json:"pushSubscription"`
+		TS    int64  `json:"ts"`
+		Nonce string `json:"nonce"`
+	}
+	if err := json.Unmarshal(b, &raw); err != nil {
+		return AcceptFrame{}, fmt.Errorf("pair: decode accept: %w", err)
+	}
+	pk, err := b64uDecode(raw.EphemeralPubkey)
+	if err != nil {
+		return AcceptFrame{}, fmt.Errorf("pair: accept pubkey: %w", err)
+	}
+	nonce, err := b64uDecode(raw.Nonce)
+	if err != nil {
+		return AcceptFrame{}, fmt.Errorf("pair: accept nonce: %w", err)
+	}
+	out := AcceptFrame{
+		ProtocolVersion: raw.V,
+		ResponderPubkey: pk,
+		DeviceID:        DeviceID(raw.DeviceID),
+		Kind_:           DeviceKind(raw.DeviceMetadata.Kind),
+		DisplayName:     raw.DeviceMetadata.DisplayName,
+		TS_:             raw.TS,
+		Nonce:           nonce,
+	}
+	if raw.PushSubscription != nil {
+		out.PushToken = raw.PushSubscription.Payload.Token
+	}
+	return out, nil
+}
+
+func decodeSASConfirmBody(b []byte) (SASConfirmFrame, error) {
+	var raw struct {
+		V    int    `json:"v"`
+		OK   bool   `json:"ok"`
+		Role string `json:"role"`
+		MAC  string `json:"mac"`
+		TS   int64  `json:"ts"`
+	}
+	if err := json.Unmarshal(b, &raw); err != nil {
+		return SASConfirmFrame{}, fmt.Errorf("pair: decode sas-confirm: %w", err)
+	}
+	mac, err := b64uDecode(raw.MAC)
+	if err != nil {
+		return SASConfirmFrame{}, fmt.Errorf("pair: sas-confirm mac: %w", err)
+	}
+	return SASConfirmFrame{
+		ProtocolVersion: raw.V,
+		OK:              raw.OK,
+		Role:            Role(raw.Role),
+		MAC:             mac,
+		TS_:             raw.TS,
+	}, nil
+}
+
+func decodeCompleteBody(b []byte) (CompleteFrame, error) {
+	var raw struct {
+		V  int   `json:"v"`
+		TS int64 `json:"ts"`
+	}
+	if err := json.Unmarshal(b, &raw); err != nil {
+		return CompleteFrame{}, fmt.Errorf("pair: decode complete: %w", err)
+	}
+	return CompleteFrame{ProtocolVersion: raw.V, TS_: raw.TS}, nil
+}
+
+func decodeAbortBody(b []byte) (AbortFrame, error) {
+	var raw struct {
+		V      int    `json:"v"`
+		Reason string `json:"reason"`
+		Detail string `json:"detail"`
+		TS     int64  `json:"ts"`
+	}
+	if err := json.Unmarshal(b, &raw); err != nil {
+		return AbortFrame{}, fmt.Errorf("pair: decode abort: %w", err)
+	}
+	return AbortFrame{
+		ProtocolVersion: raw.V,
+		Reason:          AbortReason(raw.Reason),
+		Detail:          raw.Detail,
+		TS_:             raw.TS,
+	}, nil
+}

--- a/internal/pair/transcript_test.go
+++ b/internal/pair/transcript_test.go
@@ -1,0 +1,120 @@
+package pair
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+)
+
+// TestTranscript_OrderMatters — appending the same frames in different
+// orders produces different hashes. (The whole point of running-hash
+// transcript binding.)
+func TestTranscript_OrderMatters(t *testing.T) {
+	inv := mustInvite(1)
+	acc := mustAccept(2)
+
+	t1 := NewTranscript()
+	if err := t1.Append(inv); err != nil {
+		t.Fatalf("append inv: %v", err)
+	}
+	if err := t1.Append(acc); err != nil {
+		t.Fatalf("append acc: %v", err)
+	}
+	h1 := t1.Hash()
+
+	t2 := NewTranscript()
+	if err := t2.Append(acc); err != nil {
+		t.Fatalf("append acc: %v", err)
+	}
+	if err := t2.Append(inv); err != nil {
+		t.Fatalf("append inv: %v", err)
+	}
+	h2 := t2.Hash()
+
+	if bytes.Equal(h1, h2) {
+		t.Errorf("transcript hash collided across orders: %x", h1)
+	}
+}
+
+// TestTranscript_HashStableAcrossSnapshots — calling Hash() twice
+// without appends must yield the same bytes.
+func TestTranscript_HashStableAcrossSnapshots(t *testing.T) {
+	tr := NewTranscript()
+	_ = tr.Append(mustInvite(1))
+	h1 := tr.Hash()
+	h2 := tr.Hash()
+	if !bytes.Equal(h1, h2) {
+		t.Errorf("Hash() mutated state: %x vs %x", h1, h2)
+	}
+	// Now appending another frame changes the hash.
+	_ = tr.Append(mustAccept(2))
+	h3 := tr.Hash()
+	if bytes.Equal(h1, h3) {
+		t.Errorf("Hash() unchanged across Append")
+	}
+}
+
+// TestCanonicalJSON_KeyOrderIndependent — the canonical encoding sorts
+// keys. We feed two map[string]any with same content / different
+// insertion orders and verify the byte output matches.
+func TestCanonicalJSON_KeyOrderIndependent(t *testing.T) {
+	// Go maps already randomize iteration; we just call canonicalJSON
+	// twice with the "same" map (literal) and verify byte-equality.
+	a := map[string]any{
+		"z": "last",
+		"a": "first",
+		"m": map[string]any{"y": 1, "b": 2},
+	}
+	b := map[string]any{
+		"a": "first",
+		"m": map[string]any{"b": 2, "y": 1},
+		"z": "last",
+	}
+	ja, err := canonicalJSON(a)
+	if err != nil {
+		t.Fatalf("canonicalJSON a: %v", err)
+	}
+	jb, err := canonicalJSON(b)
+	if err != nil {
+		t.Fatalf("canonicalJSON b: %v", err)
+	}
+	if !bytes.Equal(ja, jb) {
+		t.Errorf("canonicalJSON not deterministic: %s vs %s", ja, jb)
+	}
+	// And it parses as valid JSON.
+	var out any
+	if err := json.Unmarshal(ja, &out); err != nil {
+		t.Errorf("canonicalJSON not valid JSON: %v", err)
+	}
+}
+
+// TestEnvelopeRoundtrip — encode + decode an envelope through
+// EnvelopeWrap / EnvelopeUnwrap and verify field equality.
+func TestEnvelopeRoundtrip(t *testing.T) {
+	frames := []Frame{
+		mustInvite(100),
+		mustAccept(200),
+		mustSASConfirm(RoleInitiator, 300),
+		mustComplete(400),
+		mustAbort(ReasonTimeout, 500),
+	}
+	for _, f := range frames {
+		env, err := EnvelopeWrap(f)
+		if err != nil {
+			t.Errorf("EnvelopeWrap %s: %v", f.Kind(), err)
+			continue
+		}
+		if env.KeyVersion != KeyVersionPair {
+			t.Errorf("envelope keyVersion: got %d want %d", env.KeyVersion, KeyVersionPair)
+		}
+		got, err := EnvelopeUnwrap(env)
+		if err != nil {
+			t.Errorf("EnvelopeUnwrap %s: %v", f.Kind(), err)
+			continue
+		}
+		if got.Kind() != f.Kind() || got.TS() != f.TS() {
+			t.Errorf("roundtrip kind/ts: got (%s,%d) want (%s,%d)",
+				got.Kind(), got.TS(), f.Kind(), f.TS())
+		}
+	}
+}

--- a/internal/pair/wire.go
+++ b/internal/pair/wire.go
@@ -1,0 +1,152 @@
+package pair
+
+import (
+	"bufio"
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"sync"
+)
+
+// wireFormat: one WireEnvelope per line. ciphertext is base64url-no-pad
+// encoded as a string field. This is the seam the daemon's WT control
+// channel handler will plug into — at that layer the envelope is
+// already framed by the WT-channel codec, so wire.go's job is only to
+// (de)serialize the envelope struct.
+//
+// We keep our own minimal codec rather than reusing internal/transport/wt
+// directly so the pair package has zero coupling to the transport
+// (the spec calls out that the io.ReadWriter parameter is the seam).
+
+type wireEnvelopeJSON struct {
+	Kind       FrameKind `json:"kind"`
+	KeyVersion int       `json:"keyVersion"`
+	// Ciphertext is base64url-no-pad encoded so the wire is a single
+	// line of plain JSON.
+	Ciphertext string `json:"ciphertext"`
+	TS         int64  `json:"ts"`
+}
+
+func encodeEnvelope(env WireEnvelope) ([]byte, error) {
+	row := wireEnvelopeJSON{
+		Kind:       env.Kind,
+		KeyVersion: env.KeyVersion,
+		Ciphertext: base64.RawURLEncoding.EncodeToString(env.Ciphertext),
+		TS:         env.TS,
+	}
+	b, err := json.Marshal(row)
+	if err != nil {
+		return nil, fmt.Errorf("pair: marshal envelope: %w", err)
+	}
+	return append(b, '\n'), nil
+}
+
+func decodeEnvelope(line []byte) (WireEnvelope, error) {
+	var row wireEnvelopeJSON
+	if err := json.Unmarshal(line, &row); err != nil {
+		return WireEnvelope{}, fmt.Errorf("pair: unmarshal envelope: %w", err)
+	}
+	body, err := base64.RawURLEncoding.DecodeString(row.Ciphertext)
+	if err != nil {
+		return WireEnvelope{}, fmt.Errorf("pair: decode ciphertext: %w", err)
+	}
+	return WireEnvelope{
+		Kind:       row.Kind,
+		KeyVersion: row.KeyVersion,
+		Ciphertext: body,
+		TS:         row.TS,
+	}, nil
+}
+
+// streamReader wraps a bufio.Scanner for the inbound side. SetBuffer
+// is bumped to 1 MiB to allow large pair frames (push tokens can be
+// long, though typical frames are <1 KiB).
+type streamReader struct {
+	sc *bufio.Scanner
+}
+
+func newStreamReader(r io.Reader) *streamReader {
+	sc := bufio.NewScanner(r)
+	sc.Buffer(make([]byte, 0, 4096), 1<<20)
+	return &streamReader{sc: sc}
+}
+
+// readEnvelope blocks until one envelope arrives or the underlying
+// reader returns an error / EOF.
+func (sr *streamReader) readEnvelope() (WireEnvelope, error) {
+	if !sr.sc.Scan() {
+		if err := sr.sc.Err(); err != nil {
+			return WireEnvelope{}, err
+		}
+		return WireEnvelope{}, io.EOF
+	}
+	return decodeEnvelope(sr.sc.Bytes())
+}
+
+// streamWriter serializes outbound envelopes. mu protects against
+// torn writes from concurrent goroutines.
+type streamWriter struct {
+	w  io.Writer
+	mu sync.Mutex
+}
+
+func newStreamWriter(w io.Writer) *streamWriter {
+	return &streamWriter{w: w}
+}
+
+func (sw *streamWriter) writeFrame(frame Frame) error {
+	env, err := EnvelopeWrap(frame)
+	if err != nil {
+		return err
+	}
+	line, err := encodeEnvelope(env)
+	if err != nil {
+		return err
+	}
+	sw.mu.Lock()
+	defer sw.mu.Unlock()
+	_, err = sw.w.Write(line)
+	return err
+}
+
+// readFrameWithCtx wraps streamReader.readEnvelope with context
+// cancellation. Because bufio.Scanner doesn't support deadlines, we
+// run the read on a goroutine and select against ctx.Done.
+func readFrameWithCtx(ctx context.Context, sr *streamReader) (Frame, error) {
+	type result struct {
+		f   Frame
+		err error
+	}
+	ch := make(chan result, 1)
+	go func() {
+		env, err := sr.readEnvelope()
+		if err != nil {
+			ch <- result{nil, err}
+			return
+		}
+		f, err := EnvelopeUnwrap(env)
+		ch <- result{f, err}
+	}()
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	case r := <-ch:
+		return r.f, r.err
+	}
+}
+
+// errCtxOrEOF returns ctx.Err() if cancellation arrived first, else
+// the underlying io error. Used by drivers to disambiguate timeouts
+// from peer-disconnects.
+func errCtxOrEOF(ctx context.Context, ioErr error) error {
+	if ctxErr := ctx.Err(); ctxErr != nil {
+		return ctxErr
+	}
+	if ioErr == nil {
+		return errors.New("pair: unknown io error")
+	}
+	return ioErr
+}

--- a/internal/pair/x25519.go
+++ b/internal/pair/x25519.go
@@ -1,0 +1,26 @@
+package pair
+
+import (
+	"fmt"
+
+	"golang.org/x/crypto/curve25519"
+)
+
+// basepointMulPub multiplies the curve25519 basepoint by priv to derive
+// the matching public key. Lives in the pair package (rather than
+// reaching into internal/crypto) so the pair driver can take a
+// deterministic io.Reader for tests without leaking that surface up
+// through internal/crypto.
+//
+// curve25519 clamps the scalar internally per RFC 7748 §5, so passing
+// a raw 32-byte random scalar produces a valid pubkey.
+func basepointMulPub(priv []byte) ([]byte, error) {
+	if len(priv) != 32 {
+		return nil, fmt.Errorf("pair: x25519 private key must be 32 bytes (got %d)", len(priv))
+	}
+	pub, err := curve25519.X25519(priv, curve25519.Basepoint)
+	if err != nil {
+		return nil, fmt.Errorf("pair: x25519 basepoint mul: %w", err)
+	}
+	return pub, nil
+}


### PR DESCRIPTION
## Summary

Implements the slice-#4 spec at `tether-doc/wiki/specs/2026-05-07-pairing-protocol.md` (§11.AB of the main design doc): X25519 ECDH + SAS + transcript-binding pairing between two devices that have never met, over the WT control channel.

- New package `internal/pair/`. Zero changes to `daemon.go` / `transport/`. Daemon integration lands in a follow-up PR after this and `daemon-wt-wire` merge.
- All file modes asserted in tests: `<deviceId>.json` at `0600`, `~/.tether/users/<user>/devices/` at `0700`, `audit.log` at `0600`.

## Pieces (all in `internal/pair/`)

| File | Role |
|---|---|
| `pair.go` | Frame structs (5 frames per spec § 3) + `EnvelopeWrap` |
| `fsm.go` | Pure Mealy state machine (`idle` / `inviting` / `awaiting-pubkey` / `sas-confirm` / `completing` / `paired` / `failed`); per-state allowed-frame matrix + per-direction strictly-monotonic `ts` anti-replay |
| `sas.go` | HKDF-SHA256 derivations + ConfirmMAC + `DeriveLongTermKey` (returns `ltk`, `tbk`) |
| `transcript.go` | Running SHA-256 over `LP4(kind) ‖ LP4(canonicalBody)`; deterministic-JSON canonicalization |
| `client.go` | Initiator-side driver (`Run` against an `io.ReadWriter`) |
| `server.go` | Responder-side driver; emits `pair.complete` server-side ack |
| `registry.go` | `~/.tether/users/<user>/devices/<deviceId>.json` at `0600`; atomic tmp+rename; **re-pair default = reject** |
| `audit.go` | Append-only JSONL at `~/.tether/users/<user>/audit.log` |

## Design choices

### Frame canonical encoding for transcript
Deterministic JSON: sorted keys at every object level, no whitespace, UTF-8, base64url-no-pad for `[]byte` fields. Length-prefixed by 4-byte big-endian when concatenated as `LP4(kind) ‖ LP4(body)`. Implemented inline rather than pulling a JCS library — our frame bodies are flat structs with primitive / `[]byte` / `string` fields, so a single sorted-key map walk covers the JCS subset we need.

### HKDF info-string list (one per derived key, all distinct, all pinned)
- `tether-sas-v1` — `sas_key` (also reused as MAC key)
- `tether-sas-display-v1` — `sas_bits` (30 bits → 6 base32 chars)
- `tether-pair-confirm-v1|<role>|<thash>` — HMAC-SHA256 input for SAS-confirm
- `tether-ltk-v1` — `long_term_key` (32B; the §11.C `wrap_key` input)
- `tether-tbk-v1` — `transport_binding_key` (32B; reserved for v0.1.x channel binding)

### Audit log integration
Writes share the spec § 10.3 / § 11.D file `~/.tether/users/<user>/audit.log`. Append-only, file mode `0600`, parent dir `0700`. Four event kinds: `pair.success` / `pair.fail` / `pair.repair-rejected` / `pair.force-rotated`. fsync per append (matches `lock.JSONLLogSink` discipline).

### Re-pair default = reject (per § 14 Q2 ratification)
`Registry.Save` returns `ErrAlreadyPaired` if a record for the deviceId exists; an inbound invite for an existing deviceId triggers `pair.abort{dup-deviceid}` from the responder. Operators must explicitly call `Registry.ForceSave` to overwrite, which also emits a `pair.force-rotated` audit line carrying `previousLongTermKeyId`.

## Spec ambiguity resolved
Spec § 4 prose says "`0/O/1/I/L` removed" from the SAS alphabet, but the literal alphabet in the same section (`ABCDEFGHJKLMNPQRSTUVWXYZ23456789`) contains `L`. Code uses the literal — it's the wire-normative form; the prose is descriptive. Test pins both the literal and the absence of `0/O/1/I`.

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test -race -count=10 ./internal/pair/...` clean (6.4s)
- [x] `go test -race -count=1 ./...` full repo green
- [x] FSM exhaustive transitions (allowed + rejected per spec § 6.2 matrix)
- [x] SAS golden vector pinned (`shared=0x42*32, thash=0x17*32 → "2L5UDX"`)
- [x] HMAC label distinguishes initiator vs responder (cross-role verify fails)
- [x] LTK and TBK derive to different bytes (distinct HKDF info strings)
- [x] Transcript hash differs across frame orderings
- [x] Canonical-JSON encoding deterministic across map-iteration orders
- [x] Replay detection: `ts <= last-seen` → `ErrReplay`
- [x] Timeout constants match spec § 7 (30s / 60s / 10s)
- [x] Registry roundtrip; re-pair default reject; ForceSave overwrites + audits
- [x] File modes 0600 / 0700 asserted (POSIX only — Windows skipped)
- [x] Audit log: append-only invariant (seed line preserved); concurrent appends don't tear; file mode 0600
- [x] Full happy-path: client + server reach `paired` with matching long-term keys + transcript hashes + SAS strings
- [x] MITM: flipping a byte in `pair.accept.ephemeralPubkey` mid-stream causes `sas_key` divergence → MAC verification fails → neither side reaches `paired`

## Out of scope (next slices)

- Daemon integration (dispatch of `pair.*` envelopes into `Run()`)
- WT transport details (the `io.ReadWriter` parameter is the seam)
- UI / Tauri / Rust side (separate slice, in flight)
- FCM / APNs push-token sending (v0.1 stores token verbatim only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)