### PR TITLE
fix(wt): integration-layer correctness — C1 / R1#4 / M1 from R3 review

### DIFF
--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -158,6 +158,14 @@ type Config struct {
 	// hermetic). Production callers leave this nil.
 	OnEmitterReady func(*agent.EnvelopeEmitter)
 
+	// OnAuthBrokerReady, when non-nil, is invoked once after the
+	// daemon constructs the AuthBroker (only fires when
+	// EnableAuthBroker=true). Tests use this to drive broker.Ask()
+	// directly so they can assert end-to-end decision routing without
+	// having to POST through the hookserver. Production callers leave
+	// this nil.
+	OnAuthBrokerReady func(*agent.AuthBroker)
+
 	// WTKeySource is the LEGACY (pre-pair) hook for resolving the per-
 	// session shared key. Slice #4 (pair-glue) now resolves keys via
 	// pair.Registry by deviceId WHEN the peer announces a DeviceID in
@@ -340,6 +348,9 @@ func Run(ctx context.Context, cfg Config) error {
 			if err != nil {
 				_ = emitter.Close()
 				return fmt.Errorf("daemon: auth broker: %w", err)
+			}
+			if cfg.OnAuthBrokerReady != nil {
+				cfg.OnAuthBrokerReady(broker)
 			}
 		}
 
@@ -528,8 +539,13 @@ func Run(ctx context.Context, cfg Config) error {
 				legacyKeySource:   cfg.WTKeySource,
 				registry:          pairRegistry,
 				pairServerFactory: pairFactory,
-				logf:              logf,
-				warnf:             warnf,
+				// authBroker — when EnableAuthBroker is on, wire the
+				// broker through so the per-session control-stream
+				// dispatcher can route auth.tool-decision frames (C1).
+				// Nil when broker disabled — control loop is a no-op.
+				authBroker: broker,
+				logf:       logf,
+				warnf:      warnf,
 			}))
 		}
 		// emitter lives for the daemon's full lifetime; clean up

--- a/internal/daemon/wtsubsystem.go
+++ b/internal/daemon/wtsubsystem.go
@@ -80,8 +80,15 @@ type wtSubsystemConfig struct {
 	// disables inbound pair entirely (control-channel pair.invite is
 	// rejected).
 	pairServerFactory func() *pair.Server
-	logf              func(format string, args ...any)
-	warnf             func(format string, args ...any)
+	// authBroker is the per-daemon AuthBroker. When non-nil, the
+	// per-session control-stream dispatcher (post-header) routes
+	// incoming JSON lines whose `type == "auth.tool-decision"` to
+	// authBroker.SubmitDecision. Nil disables control-frame
+	// interception — non-decision lines (and all lines when nil) are
+	// dropped silently to keep the wire forward-compatible.
+	authBroker *agent.AuthBroker
+	logf       func(format string, args ...any)
+	warnf      func(format string, args ...any)
 }
 
 // wtSubsystem owns the lifetime of the WT listener under the watchdog.
@@ -189,7 +196,7 @@ func (w *wtSubsystem) handleSession(parentCtx context.Context, sess *wt.Session)
 		w.warnSession("parse session header: %v", err)
 		return
 	}
-	w.handleSessionDispatch(ctx, sess, hdr)
+	w.handleSessionDispatch(ctx, sess, hdr, br)
 }
 
 // handlePairInvite drives the responder-side pair flow over the control
@@ -241,7 +248,13 @@ func (w *wtSubsystem) handlePairInvite(ctx context.Context, ctrl io.ReadWriter, 
 // handleSessionDispatch is the v0.1 envelope-dispatch path. Resolves
 // the AEAD key (per-device via Registry or legacy fallback), subscribes
 // to the emitter, and pushes envelopes onto the events stream.
-func (w *wtSubsystem) handleSessionDispatch(ctx context.Context, sess *wt.Session, hdr wt.SessionIDHeader) {
+//
+// `ctrlReader` is the post-header control-stream reader (bufio.Reader
+// wrapped around the WT control bidi). It's tied through here so the
+// post-header control-frame dispatcher (auth.tool-decision routing →
+// AuthBroker) consumes exactly what handleSession peeked off, with no
+// risk of byte-stealing on a separate reader.
+func (w *wtSubsystem) handleSessionDispatch(ctx context.Context, sess *wt.Session, hdr wt.SessionIDHeader, ctrlReader *bufio.Reader) {
 	key, err := w.resolveKeyForSession(hdr)
 	if err != nil {
 		w.warnSession("key resolve sid=%s deviceId=%s: %v", hdr.SessionID, hdr.DeviceID, err)
@@ -279,6 +292,24 @@ func (w *wtSubsystem) handleSessionDispatch(ctx context.Context, sess *wt.Sessio
 		w.cfg.logf("[daemon] wt session sid=%s peer=%s dispatching", hdr.SessionID, toDevice)
 	}
 
+	// Spawn the post-header control-frame dispatcher (C1).
+	//
+	// AppShell sends `auth.tool-decision` JSON lines on the WT control
+	// stream after the SessionIDHeader. Without this loop the daemon
+	// reads the header once and never the rest of the stream, so the
+	// AuthBroker's Ask() call sits its full timeout (60s) and fail-
+	// closes — every cc tool gets denied. This mirrors the UDS
+	// dispatcher in attach_socket.go::readInputs (which already routes
+	// auth.tool-decision pre-lock).
+	//
+	// Lifecycle: scanner exits when the control stream closes (peer
+	// half-closes) OR ctx (the session ctx) is cancelled. We don't
+	// block the dispatcher Run on this goroutine — the events push
+	// loop exit drives session shutdown via teardown + evStream.Close.
+	if w.cfg.authBroker != nil {
+		go w.runControlDispatcher(ctx, hdr.SessionID, ctrlReader)
+	}
+
 	pushErr := wt.PushEnvelopeStream(ctx, evStream, envCh, wt.PushEnvelopeOptions{
 		SharedKey:    key,
 		FromDeviceID: "daemon-default",
@@ -286,6 +317,70 @@ func (w *wtSubsystem) handleSessionDispatch(ctx context.Context, sess *wt.Sessio
 	})
 	if pushErr != nil && w.cfg.warnf != nil {
 		w.cfg.warnf("[daemon] wt session sid=%s push: %v", hdr.SessionID, pushErr)
+	}
+}
+
+// runControlDispatcher loops over the post-header control stream,
+// decoding each \n-delimited JSON line and routing recognized
+// control-frame kinds to the daemon's broker. Today only
+// `auth.tool-decision` is wired; future control-frame kinds (e.g.
+// reauthenticate, resume) extend the switch.
+//
+// Tolerant on failure: a malformed/non-matching line is dropped
+// silently — we never tear the session down because a peer sent garbage
+// on the control stream. Real errors (stream EOF, ctx done) exit the
+// goroutine cleanly.
+func (w *wtSubsystem) runControlDispatcher(ctx context.Context, sid string, br *bufio.Reader) {
+	scanner := bufio.NewScanner(br)
+	// Cap each control frame at 64 KiB. Auth-decision frames are
+	// ~150 bytes today; a 64 KiB cap leaves ample slack for future
+	// control kinds while preventing a hostile peer from forcing
+	// unbounded buffer growth via a never-newline-terminated line.
+	scanner.Buffer(make([]byte, 0, 64*1024), 64*1024)
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		for scanner.Scan() {
+			line := scanner.Bytes()
+			if len(line) == 0 {
+				continue
+			}
+			// Mirror attach_socket.go::readInputs (lines 459-471) — try
+			// to decode as the v0.1 control-frame envelope; on failure
+			// drop the line silently. Non-JSON garbage and JSON-shaped
+			// non-decision frames both fall through.
+			var frame agent.AuthDecisionFrame
+			if err := json.Unmarshal(line, &frame); err != nil {
+				continue
+			}
+			if frame.Type != agent.KindAuthToolDecision {
+				continue
+			}
+			if w.cfg.authBroker == nil {
+				continue
+			}
+			if subErr := w.cfg.authBroker.SubmitDecision(frame); subErr != nil {
+				if w.cfg.warnf != nil {
+					w.cfg.warnf("[daemon] wt control sid=%s: auth decision: %v", sid, subErr)
+				}
+			}
+		}
+		// scanner.Err() may be the WT stream-close error or a deadline
+		// hit; both are normal session-end signals. Surface only at
+		// debug level (logf, not warnf) to avoid log spam on routine
+		// disconnects.
+		if err := scanner.Err(); err != nil && w.cfg.logf != nil {
+			w.cfg.logf("[daemon] wt control sid=%s: scanner exit: %v", sid, err)
+		}
+	}()
+	select {
+	case <-ctx.Done():
+		// Session ctx cancelled — the underlying stream Read will
+		// unblock when wt.Server tears the session down. We just stop
+		// waiting; the goroutine exits on its own once Read returns.
+		return
+	case <-done:
+		return
 	}
 }
 

--- a/internal/daemon/wtsubsystem_authdecision_test.go
+++ b/internal/daemon/wtsubsystem_authdecision_test.go
@@ -1,0 +1,237 @@
+package daemon_test
+
+import (
+	"context"
+	"crypto/tls"
+	"encoding/json"
+	"fmt"
+	"net"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/piaobeizu/tether/internal/agent"
+	"github.com/piaobeizu/tether/internal/daemon"
+	"github.com/piaobeizu/tether/internal/transport/wt"
+)
+
+// TestWTIntegration_AuthDecisionRoutes pins the C1 fix: the daemon's
+// WT subsystem must route auth.tool-decision JSON lines that arrive on
+// the control stream (after the SessionIDHeader) into AuthBroker.
+//
+// Repro of the bug this fix closes: pre-fix, wtsubsystem.go::
+// handleSession peeked the first control-stream line for pair.invite vs
+// SessionIDHeader and then never read the control stream again. The UI
+// would PUT auth.tool-decision over the WT control stream (mirror of
+// the UDS path the cc tests already exercise), and the daemon would
+// drop it on the floor — broker.Ask() blocked its full timeout, fail-
+// closed denying every cc tool call.
+//
+// Test shape (mirrors hookserver_integration_test.go's
+// TestIntegration_HookServerWireup_NoInputSink_AuthDecisionFlows but
+// for the WT path):
+//
+//  1. Boot a daemon with EnableAuthBroker=true + WT enabled. Capture
+//     handles to the emitter (so we can verify Inject reaches the WT
+//     subscriber) and broker (so we can drive Ask + assert it returns
+//     allow once we route the decision).
+//  2. Open a Go-side WT client; send the SessionIDHeader + accept the
+//     events stream. This brings the WT control-frame dispatcher loop
+//     online for the test sid.
+//  3. Run broker.Ask(sid, "Bash", ...) in a goroutine. Inject inside
+//     Ask emits a tool-request envelope; the WT events stream carries
+//     it (we don't need to read it for this test — only the requestId
+//     matters, which we extract via a parallel emitter tap).
+//  4. Send a {type:"auth.tool-decision", requestId, decision:"allow-once"}
+//     JSON line over the WT control stream.
+//  5. Assert: broker.Ask returns AllowOnce. Pre-fix, this would deadline
+//     out at the test's 5s mark with DenyOnce.
+func TestWTIntegration_AuthDecisionRoutes(t *testing.T) {
+	t.Parallel()
+
+	const sid = "test-wt-auth-routes"
+
+	tmp := t.TempDir()
+	cfg := daemon.Config{
+		ProjectsDir:      filepath.Join(tmp, "projects"),
+		AttachSocketPath: filepath.Join(tmp, "attach.sock"),
+		LockAuditLogPath: filepath.Join(tmp, "lock.log"),
+		HookSettingsDir:  filepath.Join(tmp, "cc-settings"),
+		EnableAuthBroker: true,
+		// Disable pair audit + registry for this hermetic test — we
+		// don't need the per-device key path; legacy DevSharedKey is
+		// fine.
+		DisablePairAudit:  true,
+		DisablePairServer: true,
+		PairRegistryRoot:  filepath.Join(tmp, "pair-reg"),
+		// Need an InputSink to keep the daemon's settings.json wiring
+		// happy (the hookserver path will fire OnHookSettingsReady but
+		// we don't use it).
+		InputSink: func(_ string, _ []byte) error { return nil },
+	}
+	if err := os.MkdirAll(cfg.ProjectsDir, 0o700); err != nil {
+		t.Fatalf("setup: %v", err)
+	}
+
+	udp, err := net.ListenUDP("udp", &net.UDPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 0})
+	if err != nil {
+		t.Fatalf("ListenUDP: %v", err)
+	}
+	port := udp.LocalAddr().(*net.UDPAddr).Port
+	cfg.WTListener = udp
+
+	emitterCh := make(chan *agent.EnvelopeEmitter, 1)
+	cfg.OnEmitterReady = func(em *agent.EnvelopeEmitter) {
+		select {
+		case emitterCh <- em:
+		default:
+		}
+	}
+	brokerCh := make(chan *agent.AuthBroker, 1)
+	cfg.OnAuthBrokerReady = func(b *agent.AuthBroker) {
+		select {
+		case brokerCh <- b:
+		default:
+		}
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- daemon.Run(ctx, cfg) }()
+	defer func() {
+		cancel()
+		select {
+		case derr := <-done:
+			if derr != nil {
+				t.Errorf("daemon.Run = %v", derr)
+			}
+		case <-time.After(3 * time.Second):
+			t.Errorf("daemon did not shut down within 3s")
+		}
+	}()
+
+	var em *agent.EnvelopeEmitter
+	select {
+	case em = <-emitterCh:
+	case <-time.After(2 * time.Second):
+		t.Fatal("OnEmitterReady never fired")
+	}
+	var broker *agent.AuthBroker
+	select {
+	case broker = <-brokerCh:
+	case <-time.After(2 * time.Second):
+		t.Fatal("OnAuthBrokerReady never fired")
+	}
+
+	// Give the WT subsystem a beat to start the accept loop.
+	time.Sleep(150 * time.Millisecond)
+
+	// Connect the WT client + send SessionIDHeader.
+	dialCtx, dialCancel := context.WithTimeout(context.Background(), 8*time.Second)
+	defer dialCancel()
+
+	url := fmt.Sprintf("https://127.0.0.1:%d%s", port, wt.EndpointPath)
+	cli, err := wt.Dial(dialCtx, wt.ClientConfig{
+		URL: url,
+		TLSClientConfig: &tls.Config{
+			InsecureSkipVerify: true, //nolint:gosec // test-only: dev-cert chain unreachable
+			NextProtos:         []string{"h3"},
+			MinVersion:         tls.VersionTLS13,
+		},
+	})
+	if err != nil {
+		t.Fatalf("wt.Dial: %v", err)
+	}
+	defer cli.Close()
+
+	ctrl, err := cli.OpenControl(dialCtx)
+	if err != nil {
+		t.Fatalf("OpenControl: %v", err)
+	}
+	if err := wt.WriteSessionIDHeader(ctrl, sid); err != nil {
+		t.Fatalf("WriteSessionIDHeader: %v", err)
+	}
+
+	// Accept the events stream — daemon opens it after subscribing,
+	// which guarantees the control dispatcher goroutine is running.
+	events, err := cli.AcceptEvents(dialCtx)
+	if err != nil {
+		t.Fatalf("AcceptEvents: %v", err)
+	}
+	defer events.Close()
+
+	// Tap the emitter for the auth.tool-request envelope so we can
+	// extract the requestId. The WT subsystem also subscribes — Inject
+	// fan-outs to all subscribers — so this tap is non-destructive.
+	envCh, teardown, err := em.Subscribe(sid)
+	if err != nil {
+		t.Fatalf("emitter Subscribe: %v", err)
+	}
+	defer teardown()
+
+	// Run broker.Ask in a goroutine; the response is what we ultimately
+	// assert on.
+	type askResult struct {
+		decision agent.AuthDecision
+		err      error
+	}
+	askCh := make(chan askResult, 1)
+	go func() {
+		d, aerr := broker.Ask(ctx, sid, "Bash", json.RawMessage(`{"command":"ls"}`), "list cwd")
+		askCh <- askResult{d, aerr}
+	}()
+
+	// Wait for the broker's tool-request envelope to land on our tap.
+	var requestID string
+	select {
+	case env := <-envCh:
+		if env.Kind != agent.KindAuthToolRequest {
+			t.Fatalf("first emitter envelope kind=%q want %q", env.Kind, agent.KindAuthToolRequest)
+		}
+		ridRaw, ok := env.PlaintextMetadata["requestId"]
+		if !ok {
+			t.Fatalf("auth.tool-request missing requestId: %+v", env.PlaintextMetadata)
+		}
+		requestID, _ = ridRaw.(string)
+		if requestID == "" {
+			t.Fatalf("requestId not a string: %v", ridRaw)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatalf("auth.tool-request envelope never arrived on emitter tap")
+	}
+
+	// Send the auth.tool-decision frame over the WT control stream as
+	// AppShell does. wt-attach.ts:207-219 newline-terminates the JSON;
+	// mirror that.
+	frame := agent.AuthDecisionFrame{
+		Type:      agent.KindAuthToolDecision,
+		RequestID: requestID,
+		Decision:  agent.AuthDecisionAllowOnce,
+	}
+	frameBytes, err := json.Marshal(frame)
+	if err != nil {
+		t.Fatalf("marshal decision: %v", err)
+	}
+	frameBytes = append(frameBytes, '\n')
+	if _, err := ctrl.Write(frameBytes); err != nil {
+		t.Fatalf("write decision over WT control: %v", err)
+	}
+
+	// The broker.Ask call should now return allow-once; pre-fix it
+	// would block its full timeout (60s) because the daemon never read
+	// the line off the WT control stream.
+	select {
+	case r := <-askCh:
+		if r.err != nil {
+			t.Fatalf("broker.Ask error=%v (decision=%q) — auth.tool-decision was not routed via the WT control stream",
+				r.err, r.decision)
+		}
+		if r.decision != agent.AuthDecisionAllowOnce {
+			t.Fatalf("broker.Ask decision=%q want %q",
+				r.decision, agent.AuthDecisionAllowOnce)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatalf("broker.Ask did not return within 5s of decision write — C1 (WT control dispatch) is broken")
+	}
+}

--- a/internal/transport/wt/client.go
+++ b/internal/transport/wt/client.go
@@ -262,7 +262,10 @@ func (c *Client) acceptUniLoop() {
 }
 
 func (c *Client) routeIncomingBidi(str *webtransport.Stream) {
-	tag, err := readChannelID(str)
+	// Same DoS guard as the server side (M1) — bound the time we wait
+	// for the channel-id byte so a hostile/abandoned server can't pin
+	// per-stream goroutines.
+	tag, err := readChannelID(str, defaultChannelIDDeadline)
 	if err != nil {
 		c.logger.Printf("wt-client: bidi stream tag read: %v", err)
 		str.CancelRead(streamErrorCodeBadChannelID)
@@ -291,7 +294,7 @@ func (c *Client) routeIncomingBidi(str *webtransport.Stream) {
 }
 
 func (c *Client) routeIncomingUni(str *webtransport.ReceiveStream) {
-	tag, err := readChannelID(str)
+	tag, err := readChannelID(str, defaultChannelIDDeadline)
 	if err != nil {
 		c.logger.Printf("wt-client: uni stream tag read: %v", err)
 		str.CancelRead(streamErrorCodeBadChannelID)

--- a/internal/transport/wt/dispatch_test.go
+++ b/internal/transport/wt/dispatch_test.go
@@ -151,8 +151,13 @@ func TestPushEnvelopeStream_WriteErrorPropagates(t *testing.T) {
 
 	in := make(chan fakeLocalEnvelope, 1)
 	in <- fakeLocalEnvelope{Kind: "output.agent-event", SessionID: "sess", Body: "x"}
-	w := &blockingWriter{}
-	w.Close() // pre-closed → first write fails
+	// brokenWriter returns a non-clean-close error (io.ErrShortWrite) so
+	// PushEnvelopeStream's classifier (R1 #4) treats it as session-fatal
+	// and returns the wrapped error to the caller. io.EOF / ErrClosedPipe
+	// / ctx.Canceled are now intentionally swallowed as clean shutdown
+	// signals — the regression bar for this test is "non-clean errors
+	// still propagate".
+	w := &brokenWriter{err: io.ErrShortWrite}
 
 	err := PushEnvelopeStream(ctx, w, in, PushEnvelopeOptions{
 		SharedKey:    DevSharedKey[:],
@@ -165,7 +170,51 @@ func TestPushEnvelopeStream_WriteErrorPropagates(t *testing.T) {
 	if !strings.Contains(err.Error(), "write frame") {
 		t.Errorf("expected 'write frame' in error, got %v", err)
 	}
+	if !errors.Is(err, io.ErrShortWrite) {
+		t.Errorf("expected errors.Is(err, io.ErrShortWrite), got %v", err)
+	}
 }
+
+// TestPushEnvelopeStream_CleanCloseSwallowed pins the R1 #4 fix from
+// the dispatcher's perspective: when WriteFrame fails with io.EOF /
+// io.ErrClosedPipe / context.Canceled (a clean peer disconnect), the
+// dispatcher must return nil instead of treating it as a session-fatal
+// error. Pre-fix WriteFrame wrapped the inner error with %v so
+// errors.Is never matched and the dispatcher returned a noisy error.
+func TestPushEnvelopeStream_CleanCloseSwallowed(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name string
+		err  error
+	}{
+		{"eof", io.EOF},
+		{"closed-pipe", io.ErrClosedPipe},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			defer cancel()
+			in := make(chan fakeLocalEnvelope, 1)
+			in <- fakeLocalEnvelope{Kind: "output.agent-event", SessionID: "sess", Body: "x"}
+			w := &brokenWriter{err: tc.err}
+			err := PushEnvelopeStream(ctx, w, in, PushEnvelopeOptions{
+				SharedKey:    DevSharedKey[:],
+				FromDeviceID: "from",
+				ToDeviceID:   "to",
+			})
+			if err != nil {
+				t.Fatalf("PushEnvelopeStream returned %v on clean peer-close error %v; want nil (R1 #4)", err, tc.err)
+			}
+		})
+	}
+}
+
+// brokenWriter is an EventsWriter that always fails Write with a
+// caller-supplied error.
+type brokenWriter struct{ err error }
+
+func (b *brokenWriter) Write(_ []byte) (int, error) { return 0, b.err }
+func (b *brokenWriter) Close() error                { return nil }
 
 // TestEnvelopeFrameReader_RoundTrip — Reader-side helper consumes a
 // framed stream produced by PushEnvelopeStream + decrypts each.

--- a/internal/transport/wt/envelope.go
+++ b/internal/transport/wt/envelope.go
@@ -350,11 +350,15 @@ func WriteFrame(w io.Writer, env *WireEnvelope) (int, error) {
 	}
 	var hdr [4]byte
 	binary.BigEndian.PutUint32(hdr[:], uint32(len(body)))
+	// Wrap with %w so callers (dispatch.go::PushEnvelopeStream) can
+	// errors.Is(err, io.EOF) / io.ErrClosedPipe / context.Canceled to
+	// distinguish clean peer-close from session-fatal write failures.
+	// %v stripped the chain and broke that classification (R1 #4).
 	if _, err := w.Write(hdr[:]); err != nil {
-		return 0, fmt.Errorf("%w: write length: %v", ErrWireEnvelope, err)
+		return 0, fmt.Errorf("%w: write length: %w", ErrWireEnvelope, err)
 	}
 	if _, err := w.Write(body); err != nil {
-		return 0, fmt.Errorf("%w: write body: %v", ErrWireEnvelope, err)
+		return 0, fmt.Errorf("%w: write body: %w", ErrWireEnvelope, err)
 	}
 	return len(body), nil
 }
@@ -379,8 +383,10 @@ func ReadFrame(r io.Reader) (*WireEnvelope, error) {
 		return nil, fmt.Errorf("%w: frame size %d exceeds max %d", ErrWireEnvelope, n, FrameSizeMax)
 	}
 	body := make([]byte, n)
+	// Wrap underlying read error with %w so callers can errors.Is
+	// against io.EOF / io.ErrUnexpectedEOF / context.Canceled.
 	if _, err := io.ReadFull(r, body); err != nil {
-		return nil, fmt.Errorf("%w: read body: %v", ErrWireEnvelope, err)
+		return nil, fmt.Errorf("%w: read body: %w", ErrWireEnvelope, err)
 	}
 	var env WireEnvelope
 	if err := json.Unmarshal(body, &env); err != nil {

--- a/internal/transport/wt/integration_fix_test.go
+++ b/internal/transport/wt/integration_fix_test.go
@@ -1,0 +1,180 @@
+package wt
+
+import (
+	"bytes"
+	"context"
+	"crypto/x509"
+	"errors"
+	"io"
+	"net"
+	"sync"
+	"testing"
+	"time"
+)
+
+// TestWriteFrame_WrapsErrorChain pins R1 #4: WriteFrame must wrap the
+// underlying writer's error with %w (not %v) so callers can do
+// `errors.Is(err, io.EOF)` / `io.ErrClosedPipe` / `context.Canceled`.
+//
+// Repro of the bug: dispatch.go::PushEnvelopeStream classifies a
+// peer-closes-cleanly error class via errors.Is. Pre-fix, WriteFrame
+// did `fmt.Errorf("%w: write body: %v", ErrWireEnvelope, err)` — the
+// %v stripped the chain, errors.Is(err, io.EOF) returned false, and
+// the dispatcher treated a clean disconnect as a session-fatal write
+// failure (returning the error → daemon logs a noisy warnf for what's
+// actually a graceful peer close).
+func TestWriteFrame_WrapsErrorChain(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		want error
+	}{
+		{"eof", io.EOF},
+		{"closed-pipe", io.ErrClosedPipe},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			env := &WireEnvelope{
+				ID:           "00000000-0000-0000-0000-000000000001",
+				FromDeviceID: "from",
+				ToDeviceID:   "to",
+				Kind:         "x.test",
+				KeyVersion:   CurrentKeyVersion,
+				Nonce:        bytes.Repeat([]byte{0}, NonceSize),
+				Ciphertext:   []byte{1, 2, 3},
+			}
+			_, err := WriteFrame(&erroringWriter{err: tc.want}, env)
+			if err == nil {
+				t.Fatalf("want error, got nil")
+			}
+			if !errors.Is(err, tc.want) {
+				t.Fatalf("errors.Is(err, %v) = false (R1 #4 broken); err=%v", tc.want, err)
+			}
+			if !errors.Is(err, ErrWireEnvelope) {
+				t.Errorf("errors.Is(err, ErrWireEnvelope) = false; err=%v", err)
+			}
+		})
+	}
+}
+
+// TestReadFrame_WrapsErrorChain pins the symmetric R1 #4 fix on the
+// receiver side — partial-frame errors must keep io.ErrUnexpectedEOF
+// in the chain. Length prefix says 100 bytes; we feed exactly 1 body
+// byte, so io.ReadFull returns io.ErrUnexpectedEOF.
+func TestReadFrame_WrapsErrorChain(t *testing.T) {
+	t.Parallel()
+
+	r := bytes.NewReader([]byte{0, 0, 0, 100, 0xab})
+	_, err := ReadFrame(r)
+	if err == nil {
+		t.Fatalf("want error, got nil")
+	}
+	if !errors.Is(err, io.ErrUnexpectedEOF) {
+		t.Fatalf("errors.Is(err, io.ErrUnexpectedEOF) = false (R1 #4 broken); err=%v", err)
+	}
+}
+
+// erroringWriter is an io.Writer that returns a fixed error on Write.
+// Length prefix succeeds via the first call only when the test wants
+// it; we want both length + body writes to fail consistently — so any
+// Write returns the configured error.
+type erroringWriter struct {
+	err error
+}
+
+func (w *erroringWriter) Write(_ []byte) (int, error) { return 0, w.err }
+
+// TestReadChannelID_AppliesDeadline pins the M1 fix: readChannelID
+// must enforce a deadline so a peer that opens a bidi stream and never
+// writes the channel-id byte cannot pin a goroutine forever.
+//
+// Repro of the bug: pre-fix, readChannelID did io.ReadFull on the
+// stream with NO deadline. The defaultChannelIDDeadline constant
+// existed in channel.go but was never referenced. routeIncomingBidi /
+// routeIncomingUni would block in readChannelID indefinitely, leaking
+// one goroutine + one stream resource per silent stream a hostile
+// peer opens.
+//
+// This test exercises readChannelID directly with a stub reader that
+// records SetReadDeadline calls and never returns from Read. Pre-fix
+// the test would hang (no deadline → no SetReadDeadline call → Read
+// blocks forever). With the fix, SetReadDeadline is invoked with a
+// non-zero time, and the stub's Read returns the deadline error
+// immediately, allowing readChannelID to surface it.
+func TestReadChannelID_AppliesDeadline(t *testing.T) {
+	t.Parallel()
+
+	stub := &deadlineStub{}
+	done := make(chan struct{})
+	var (
+		got ChannelID
+		err error
+	)
+	go func() {
+		got, err = readChannelID(stub, defaultChannelIDDeadline)
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatalf("readChannelID did not respect deadline — M1 fix not applied (call hung)")
+	}
+	if err == nil {
+		t.Fatalf("readChannelID returned nil error (got=%v); want deadline error", got)
+	}
+	if !stub.deadlineSet {
+		t.Errorf("SetReadDeadline was never called — M1 fix not applied")
+	}
+	if !stub.deadlineCleared {
+		t.Errorf("SetReadDeadline was not cleared on exit (deferred reset to zero time)")
+	}
+}
+
+// deadlineStub is a channelIDDeadliner that records SetReadDeadline
+// calls and returns a deadline error on Read once a non-zero deadline
+// has been set. The goroutine that owns the Read returns
+// "deadline-exceeded" so the test can verify readChannelID exited via
+// the deadline path (not a real read).
+type deadlineStub struct {
+	deadlineSet     bool
+	deadlineCleared bool
+	deadlineMu      sync.Mutex
+}
+
+func (s *deadlineStub) SetReadDeadline(t time.Time) error {
+	s.deadlineMu.Lock()
+	defer s.deadlineMu.Unlock()
+	if t.IsZero() {
+		s.deadlineCleared = true
+	} else {
+		s.deadlineSet = true
+	}
+	return nil
+}
+
+func (s *deadlineStub) Read(_ []byte) (int, error) {
+	// Simulate a peer that never writes the byte: block until the
+	// deadline times out. We return immediately with a deadline-
+	// shaped error after the SetReadDeadline call lands so the test
+	// terminates quickly.
+	for {
+		s.deadlineMu.Lock()
+		set := s.deadlineSet
+		s.deadlineMu.Unlock()
+		if set {
+			return 0, errors.New("i/o timeout (stub deadline exceeded)")
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+}
+
+// satisfy unused-import linter — these dependencies are referenced
+// only by other tests in this file.
+var (
+	_ = bootTestServer
+	_ = dialClient
+	_ = context.Background
+	_ = (&x509.CertPool{})
+	_ = net.IPv4
+)

--- a/internal/transport/wt/session.go
+++ b/internal/transport/wt/session.go
@@ -32,6 +32,7 @@ import (
 	"io"
 	"log"
 	"sync"
+	"time"
 
 	"github.com/quic-go/webtransport-go"
 )
@@ -291,8 +292,13 @@ func (s *Session) acceptUniLoop() {
 
 // routeIncomingBidi reads one byte of channel-id then enqueues to the
 // matching per-channel queue. Bad byte → reset stream + log.
+//
+// A peer that opens a bidi stream and never writes the leading byte
+// would otherwise pin this goroutine forever — readChannelID applies
+// defaultChannelIDDeadline so a stalled / hostile peer is evicted
+// within ~5s instead of leaking a goroutine per opened stream (M1).
 func (s *Session) routeIncomingBidi(str *webtransport.Stream) {
-	tag, err := readChannelID(str)
+	tag, err := readChannelID(str, defaultChannelIDDeadline)
 	if err != nil {
 		s.logger.Printf("wt: bidi stream tag read: %v", err)
 		str.CancelRead(streamErrorCodeBadChannelID)
@@ -320,9 +326,11 @@ func (s *Session) routeIncomingBidi(str *webtransport.Stream) {
 	}
 }
 
-// routeIncomingUni mirrors routeIncomingBidi for uni-streams.
+// routeIncomingUni mirrors routeIncomingBidi for uni-streams. Uses the
+// same defaultChannelIDDeadline so an abandoned uni stream cannot leak
+// a goroutine (M1).
 func (s *Session) routeIncomingUni(str *webtransport.ReceiveStream) {
-	tag, err := readChannelID(str)
+	tag, err := readChannelID(str, defaultChannelIDDeadline)
 	if err != nil {
 		s.logger.Printf("wt: uni stream tag read: %v", err)
 		str.CancelRead(streamErrorCodeBadChannelID)
@@ -346,10 +354,30 @@ func (s *Session) routeIncomingUni(str *webtransport.ReceiveStream) {
 	}
 }
 
+// channelIDDeadliner is the subset of *webtransport.Stream /
+// *webtransport.ReceiveStream we touch to bound readChannelID. Both
+// concrete types satisfy this; tests can stub with an in-memory pipe
+// that no-ops SetReadDeadline.
+type channelIDDeadliner interface {
+	io.Reader
+	SetReadDeadline(time.Time) error
+}
+
 // readChannelID reads exactly one byte from r and validates it as a
 // known channel-id. The returned ChannelID may still be ChannelDatagram
 // — caller must check streamCapable().
-func readChannelID(r io.Reader) (ChannelID, error) {
+//
+// deadline > 0 caps how long we wait for the byte; a misbehaving peer
+// that opens a stream and never writes the tag would otherwise pin a
+// goroutine forever (M1). Pass 0 to disable the deadline (e.g. tests
+// against an io.Reader that doesn't support SetReadDeadline).
+func readChannelID(r channelIDDeadliner, deadline time.Duration) (ChannelID, error) {
+	if deadline > 0 {
+		// Best-effort — if SetReadDeadline isn't supported by this
+		// reader (test stubs), fall through and read without a cap.
+		_ = r.SetReadDeadline(time.Now().Add(deadline))
+		defer func() { _ = r.SetReadDeadline(time.Time{}) }()
+	}
 	var buf [1]byte
 	if _, err := io.ReadFull(r, buf[:]); err != nil {
 		return 0, err


### PR DESCRIPTION
## Summary

Three integration-level WT bugs surfaced by the R3 / R1 deep review. Each fix is reproduced by a new test that fails pre-fix and passes after.

Cross-link: companion tether-app PR for C2 + M2 (the UI-side bugs in the same review).

## Fixes

### C1 — WT control-stream `auth.tool-decision` dropped on the floor

- **File:** `internal/daemon/wtsubsystem.go:151-193, 244-…` (handleSession + handleSessionDispatch + new runControlDispatcher)
- **Repro:** AppShell sends `auth.tool-decision` JSON over WT control via `wt-attach.ts:207-219`. Pre-fix, `handleSession` peeked the first line for pair.invite vs SessionIDHeader and never read the control stream again. `AuthBroker.Ask` waited 60s then fail-closed deny → every cc tool blocked. Same #47-pattern as the UDS fix; UDS path has its dispatcher (`attach_socket.go::readInputs:441-510`) so tests passed there.
- **Fix:** spawn a per-session control-frame dispatcher post-header that scans \\n-delimited JSON lines and routes `auth.tool-decision` frames to `broker.SubmitDecision`. Tolerant on malformed lines; lifecycle tied to session ctx + stream close. Plumb `AuthBroker` through `wtSubsystemConfig` + add `OnAuthBrokerReady` test hook in `daemon.Config`.

### R1 #4 — `WriteFrame` / `ReadFrame` use `%v`, errors.Is fails

- **File:** `internal/transport/wt/envelope.go:354,357,383` (WriteFrame + ReadFrame)
- **Repro:** `dispatch.go:131` does `errors.Is(err, io.EOF) || io.ErrClosedPipe || context.Canceled` to classify clean peer-close vs session-fatal. Pre-fix, `fmt.Errorf(\"%w: write body: %v\", ErrWireEnvelope, err)` stripped the chain — errors.Is never matched, peer-clean-close surfaced as a noisy session-fatal warnf.
- **Fix:** switch the inner wraps to `%w` (Go 1.25 supports multi-%w). New `TestWriteFrame_WrapsErrorChain` (sub-tests eof, closed-pipe) + `TestReadFrame_WrapsErrorChain` lock the unwrap. Existing `TestPushEnvelopeStream_WriteErrorPropagates` was relying on the broken behavior — updated to use `io.ErrShortWrite` (still propagates) + new `TestPushEnvelopeStream_CleanCloseSwallowed` pins the inverse.

### M1 — `readChannelID` had no deadline; goroutine-leak DoS

- **File:** `internal/transport/wt/channel.go:98` (defaultChannelIDDeadline declared, never used) + `session.go::routeIncomingBidi/Uni` + `client.go::routeIncomingBidi/Uni`
- **Repro:** A peer that opens a QUIC bidi stream and never writes the 1-byte channel-id pinned a goroutine forever — readChannelID's `io.ReadFull` blocked indefinitely.
- **Fix:** add a `deadline time.Duration` parameter to `readChannelID`; best-effort `SetReadDeadline` with deferred cleanup; pass `defaultChannelIDDeadline` (5s) from all four callsites. New `channelIDDeadliner` interface lets tests stub. `TestReadChannelID_AppliesDeadline` proves the function exits via the deadline path with a stub reader that never returns from Read.

## Tests

- `internal/daemon/wtsubsystem_authdecision_test.go` — `TestWTIntegration_AuthDecisionRoutes`
- `internal/transport/wt/integration_fix_test.go` — `TestWriteFrame_WrapsErrorChain` (eof + closed-pipe), `TestReadFrame_WrapsErrorChain`, `TestReadChannelID_AppliesDeadline`
- `internal/transport/wt/dispatch_test.go` — `TestPushEnvelopeStream_CleanCloseSwallowed` (eof + closed-pipe)

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test -race -count=10 ./internal/daemon/... ./internal/transport/wt/...` — both packages green
- [x] `go test -race -count=1 ./...` — full repo green

Cross-link: tether-app PR https://github.com/piaobeizu/tether-app/pull/new/pf2.wt-integration-fix (C2 + M2). A parallel \`pair-correctness-fix\` agent is concurrently fixing pair Go + Rust files; this PR explicitly stays out of \`internal/pair/*\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)