### PR TITLE
fix(pair): cross-stack correctness — 5 BLOCKER fixes from R2 review

### DIFF
--- a/internal/pair/client.go
+++ b/internal/pair/client.go
@@ -31,6 +31,11 @@ type Result struct {
 	// SAS is the 6-character display string both endpoints saw. Used
 	// in tests + UX confirmation; not security-relevant after pairing.
 	SAS string
+
+	// LongTermKeyID is the daemon-assigned record id from pair.complete
+	// (spec §3.4). Echoed back to the UI for display. Empty on the
+	// responder side (the responder ASSIGNS it; the initiator OBSERVES it).
+	LongTermKeyID string
 }
 
 // SASConfirmer is the user-confirm hook. The driver calls Confirm with
@@ -52,10 +57,22 @@ var AutoConfirm SASConfirmer = SASConfirmFunc(func(string) error { return nil })
 
 // Identity carries the local device's stable metadata that gets baked
 // into pair.invite / pair.accept frames.
+//
+// Model / OSVersion / AppVersion are spec §3.1/§3.2 OPTIONAL deviceMetadata
+// fields. They MUST be included in the canonical body (and thus the
+// transcript) when non-empty. The Rust client already populates these on
+// the wire (e.g. tether-app's UI passes appVersion="tether 0.1.0-dev"
+// through), so the Go side needs to (a) accept them on inbound and (b)
+// include them in canonical body for cross-stack transcript-hash parity.
 type Identity struct {
 	DeviceID    DeviceID
 	Kind        DeviceKind
 	DisplayName string
+	// Optional spec §3.1/§3.2 deviceMetadata fields. Empty string =>
+	// omit from canonical body / wire.
+	Model      string
+	OSVersion  string
+	AppVersion string
 	// PushToken is meaningful only when Kind == KindMobile (responder).
 	PushToken string
 }
@@ -122,6 +139,9 @@ func (c *Client) Run(ctx context.Context, stream io.ReadWriter) (Result, error) 
 		DeviceID:        c.identity.DeviceID,
 		Kind_:           c.identity.Kind,
 		DisplayName:     c.identity.DisplayName,
+		Model:           c.identity.Model,
+		OSVersion:       c.identity.OSVersion,
+		AppVersion:      c.identity.AppVersion,
 		TS_:             c.now().UnixMilli(),
 		Nonce:           mustRandomNonce(c.rand, 16),
 	}
@@ -258,13 +278,24 @@ func (c *Client) Run(ctx context.Context, stream io.ReadWriter) (Result, error) 
 	if _, _, err := fsm.Step(Event{Kind: EventRecvFrame, Frame: frame}); err != nil {
 		return Result{}, err
 	}
-	if frame.Kind() != KindComplete {
-		return Result{}, fmt.Errorf("pair: expected pair.complete, got %s", frame.Kind())
+	complete, ok := frame.(CompleteFrame)
+	if !ok {
+		return Result{}, fmt.Errorf("pair: expected pair.complete, got %T", frame)
 	}
 
-	// 8. Derive long-term keys.
+	// 8. Derive long-term keys, then verify the §3.4 AEAD tag. A rogue
+	//    daemon (or any in-path actor that survived TLS) cannot forge
+	//    this tag without sharing our derived ltk + the same
+	//    transcript_hash. Mismatch ⇒ pair.abort{cert-error}, do NOT
+	//    persist the registry record.
 	ltk, tbk, err := DeriveLongTermKey(shared, thash)
 	if err != nil {
+		return Result{}, err
+	}
+	if err := OpenCompleteTag(ltk, thash, complete.Nonce, complete.Tag); err != nil {
+		ab := abortNow(ReasonCertError, "pair.complete AEAD tag verification failed")
+		ab.TS_ = c.now().UnixMilli()
+		_ = w.writeFrame(ab)
 		return Result{}, err
 	}
 	return Result{
@@ -277,6 +308,7 @@ func (c *Client) Run(ctx context.Context, stream io.ReadWriter) (Result, error) 
 		TransportBindingKey: tbk,
 		TranscriptHash:      thash,
 		SAS:                 sas,
+		LongTermKeyID:       complete.LongTermKeyID,
 	}, nil
 }
 

--- a/internal/pair/complete_aead_test.go
+++ b/internal/pair/complete_aead_test.go
@@ -1,0 +1,244 @@
+package pair
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"sync"
+	"testing"
+	"time"
+)
+
+// TestSealOpenCompleteTag_RoundTrip verifies the AEAD seal/open round
+// trip works for honest peers (BLOCKER-4 happy path).
+func TestSealOpenCompleteTag_RoundTrip(t *testing.T) {
+	ltk := bytes.Repeat([]byte{0xEE}, 32)
+	thash := bytes.Repeat([]byte{0x11}, 32)
+	nonce, tag, err := SealCompleteTag(ltk, thash, nil)
+	if err != nil {
+		t.Fatalf("SealCompleteTag: %v", err)
+	}
+	if len(nonce) != 24 {
+		t.Errorf("nonce length: got %d want 24", len(nonce))
+	}
+	if len(tag) != 16 {
+		t.Errorf("tag length: got %d want 16", len(tag))
+	}
+	if err := OpenCompleteTag(ltk, thash, nonce, tag); err != nil {
+		t.Errorf("OpenCompleteTag honest: got %v want nil", err)
+	}
+}
+
+// TestOpenCompleteTag_TamperDetected — flipping any byte in the tag,
+// nonce, ltk, or transcript_hash trips ErrCompleteAEAD.
+func TestOpenCompleteTag_TamperDetected(t *testing.T) {
+	ltk := bytes.Repeat([]byte{0xEE}, 32)
+	thash := bytes.Repeat([]byte{0x11}, 32)
+	nonce, tag, err := SealCompleteTag(ltk, thash, nil)
+	if err != nil {
+		t.Fatalf("SealCompleteTag: %v", err)
+	}
+
+	// Tamper tag.
+	bad := append([]byte(nil), tag...)
+	bad[0] ^= 0x01
+	if err := OpenCompleteTag(ltk, thash, nonce, bad); !errors.Is(err, ErrCompleteAEAD) {
+		t.Errorf("tampered tag: got %v want ErrCompleteAEAD", err)
+	}
+
+	// Tamper nonce.
+	badN := append([]byte(nil), nonce...)
+	badN[0] ^= 0x01
+	if err := OpenCompleteTag(ltk, thash, badN, tag); !errors.Is(err, ErrCompleteAEAD) {
+		t.Errorf("tampered nonce: got %v want ErrCompleteAEAD", err)
+	}
+
+	// Wrong ltk.
+	badLtk := append([]byte(nil), ltk...)
+	badLtk[31] ^= 0x01
+	if err := OpenCompleteTag(badLtk, thash, nonce, tag); !errors.Is(err, ErrCompleteAEAD) {
+		t.Errorf("wrong ltk: got %v want ErrCompleteAEAD", err)
+	}
+
+	// Wrong transcript_hash.
+	badTh := append([]byte(nil), thash...)
+	badTh[15] ^= 0x01
+	if err := OpenCompleteTag(ltk, badTh, nonce, tag); !errors.Is(err, ErrCompleteAEAD) {
+		t.Errorf("wrong transcript_hash: got %v want ErrCompleteAEAD", err)
+	}
+}
+
+// TestOpenCompleteTag_BadSizes — defense-in-depth: malformed sizes
+// surface as ErrCompleteAEAD, not a different error class. Callers can
+// uniformly map to pair.abort{cert-error}.
+func TestOpenCompleteTag_BadSizes(t *testing.T) {
+	ltk := bytes.Repeat([]byte{0xEE}, 32)
+	thash := bytes.Repeat([]byte{0x11}, 32)
+	if err := OpenCompleteTag(ltk[:31], thash, make([]byte, 24), make([]byte, 16)); !errors.Is(err, ErrCompleteAEAD) {
+		t.Errorf("short ltk: got %v want ErrCompleteAEAD", err)
+	}
+	if err := OpenCompleteTag(ltk, thash, make([]byte, 23), make([]byte, 16)); !errors.Is(err, ErrCompleteAEAD) {
+		t.Errorf("short nonce: got %v want ErrCompleteAEAD", err)
+	}
+	if err := OpenCompleteTag(ltk, thash, make([]byte, 24), make([]byte, 15)); !errors.Is(err, ErrCompleteAEAD) {
+		t.Errorf("short tag: got %v want ErrCompleteAEAD", err)
+	}
+	if err := OpenCompleteTag(ltk, nil, make([]byte, 24), make([]byte, 16)); !errors.Is(err, ErrCompleteAEAD) {
+		t.Errorf("empty thash: got %v want ErrCompleteAEAD", err)
+	}
+}
+
+// TestServer_RogueComplete_Rejects — end-to-end test that a forged
+// pair.complete (tag flipped after server emits it) is rejected by
+// the initiator with cert-error.
+//
+// We intercept the responder→initiator stream; once we see pair.complete,
+// flip a byte in the AEAD tag, forward the rest. Initiator (Client.Run)
+// must surface ErrCompleteAEAD and emit pair.abort{cert-error} on its
+// outbound side.
+func TestServer_RogueComplete_Rejects(t *testing.T) {
+	clientPipeR, serverPipeW := io.Pipe()       // server → mitm → client
+	mitmPipeR, mitmPipeW := io.Pipe()           // mitm → client (post-tamper)
+	clientToServerR, clientToServerW := io.Pipe()
+
+	clientSide := rwPair{R: mitmPipeR, W: clientToServerW}
+	serverSide := rwPair{R: clientToServerR, W: serverPipeW}
+
+	// Tamper-relay: scan envelopes, when we hit KindComplete flip a tag byte.
+	mitm := &completeTamper{
+		scanner: bufio.NewScanner(clientPipeR),
+		dst:     mitmPipeW,
+	}
+	mitm.scanner.Buffer(make([]byte, 0, 4096), 1<<20)
+	go func() {
+		_ = mitm.pump()
+		_ = mitmPipeW.Close()
+	}()
+
+	clk := &monotonicClock{base: time.Date(2026, 5, 7, 0, 0, 0, 0, time.UTC)}
+	now := clk.Now
+	clientRand := &detRand{fillByte: 0x10}
+	serverRand := &detRand{fillByte: 0x80}
+
+	client := NewClient(ClientConfig{
+		Identity: Identity{
+			DeviceID:    "device-desktop-rogue",
+			Kind:        KindDesktop,
+			DisplayName: "rogue test",
+		},
+		Confirmer: AutoConfirm,
+		Now:       now,
+		Rand:      clientRand,
+	})
+	server := NewServer(ServerConfig{
+		Identity: Identity{
+			DeviceID:    "device-mobile-rogue",
+			Kind:        KindMobile,
+			DisplayName: "rogue phone",
+		},
+		Confirmer: AutoConfirm,
+		Now:       now,
+		Rand:      serverRand,
+	})
+
+	type result struct {
+		res Result
+		err error
+	}
+	clientCh := make(chan result, 1)
+	serverCh := make(chan result, 1)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	go func() {
+		res, err := client.Run(ctx, clientSide)
+		_ = clientToServerW.Close()
+		clientCh <- result{res, err}
+	}()
+	go func() {
+		res, err := server.Run(ctx, serverSide)
+		_ = serverPipeW.Close()
+		// Close the client→server reader so the client's "best-effort
+		// pair.abort{cert-error}" writeFrame doesn't deadlock against an
+		// io.Pipe with no remaining reader. Without this, the
+		// synchronous io.Pipe blocks the client goroutine forever.
+		_ = clientToServerR.Close()
+		serverCh <- result{res, err}
+	}()
+
+	cr := <-clientCh
+	<-serverCh
+
+	if cr.err == nil {
+		t.Fatalf("expected client to fail on rogue complete; got nil err and result %+v", cr.res)
+	}
+	if !errors.Is(cr.err, ErrCompleteAEAD) {
+		t.Errorf("client err: got %v want ErrCompleteAEAD", cr.err)
+	}
+	if !mitm.flipped {
+		t.Errorf("MITM didn't observe a pair.complete to flip — test plumbing bug")
+	}
+}
+
+// completeTamper relays envelopes server→client; when it sees
+// KindComplete, flips a single byte in the base64-decoded `tag` field
+// of the inner body, re-encodes, and forwards.
+type completeTamper struct {
+	mu      sync.Mutex
+	scanner *bufio.Scanner
+	dst     io.Writer
+	flipped bool
+}
+
+func (c *completeTamper) pump() error {
+	for c.scanner.Scan() {
+		line := append([]byte(nil), c.scanner.Bytes()...)
+		out := c.maybeFlip(line)
+		if _, err := c.dst.Write(append(out, '\n')); err != nil {
+			return err
+		}
+	}
+	return c.scanner.Err()
+}
+
+func (c *completeTamper) maybeFlip(line []byte) []byte {
+	env, err := decodeEnvelope(line)
+	if err != nil {
+		return line
+	}
+	if env.Kind != KindComplete {
+		return line
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	var raw map[string]any
+	if err := json.Unmarshal(env.Ciphertext, &raw); err != nil {
+		return line
+	}
+	tagS, ok := raw["tag"].(string)
+	if !ok || tagS == "" {
+		return line
+	}
+	tag, err := b64uDecode(tagS)
+	if err != nil || len(tag) == 0 {
+		return line
+	}
+	tag[0] ^= 0x01
+	raw["tag"] = b64uEncode(tag)
+	body, err := json.Marshal(raw)
+	if err != nil {
+		return line
+	}
+	env.Ciphertext = body
+	out, err := encodeEnvelope(env)
+	if err != nil {
+		return line
+	}
+	c.flipped = true
+	// encodeEnvelope already appends '\n'; strip it because pump adds.
+	return bytes.TrimRight(out, "\n")
+}

--- a/internal/pair/pair.go
+++ b/internal/pair/pair.go
@@ -87,12 +87,20 @@ type Frame interface {
 }
 
 // InviteFrame is spec §3.1 pair.invite.
+//
+// Optional deviceMetadata fields (Model / OSVersion / AppVersion) are
+// included in the canonical body when non-empty. These cross-stack
+// optionals are the BLOCKER-2 fix surface — Rust serializes Some(_) and
+// skips None, so the Go side mirrors via empty-string-omit.
 type InviteFrame struct {
 	ProtocolVersion int        `json:"v"`
 	InitiatorPubkey []byte     `json:"ephemeralPubkey"`
 	DeviceID        DeviceID   `json:"deviceId"`
 	Kind_           DeviceKind `json:"-"` // exposed via metadata.kind
 	DisplayName     string     `json:"-"` // exposed via metadata.displayName
+	Model           string     `json:"-"` // exposed via metadata.model (omit if empty)
+	OSVersion       string     `json:"-"` // exposed via metadata.osVersion (omit if empty)
+	AppVersion      string     `json:"-"` // exposed via metadata.appVersion (omit if empty)
 	TS_             int64      `json:"ts"`
 	Nonce           []byte     `json:"nonce"`
 }
@@ -101,12 +109,20 @@ func (f InviteFrame) Kind() FrameKind { return KindInvite }
 func (f InviteFrame) TS() int64       { return f.TS_ }
 
 // AcceptFrame is spec §3.2 pair.accept.
+//
+// Optional deviceMetadata fields (Model / OSVersion / AppVersion)
+// participate in the canonical body via empty-string-omit, matching
+// Rust's Option::None skip behavior. PushToken is the optional spec
+// §3.2 pushSubscription.payload.token.
 type AcceptFrame struct {
 	ProtocolVersion int        `json:"v"`
 	ResponderPubkey []byte     `json:"ephemeralPubkey"`
 	DeviceID        DeviceID   `json:"deviceId"`
 	Kind_           DeviceKind `json:"-"`
 	DisplayName     string     `json:"-"`
+	Model           string     `json:"-"`
+	OSVersion       string     `json:"-"`
+	AppVersion      string     `json:"-"`
 	PushToken       string     `json:"-"`
 	TS_             int64      `json:"ts"`
 	Nonce           []byte     `json:"nonce"`
@@ -129,15 +145,38 @@ func (f SASConfirmFrame) TS() int64       { return f.TS_ }
 
 // CompleteFrame is spec §3.4 pair.complete (daemon-emitted ack).
 //
-// v0.1 simplification: the spec describes an AEAD tag computed under
-// the derived long_term_key; the slice-#4 implementation models this
-// as a frame the daemon emits once both endpoints' SAS-confirm MACs
-// have been observed. The TS field is the only field the bare ack
-// needs to round-trip; richer payload (registeredAs, longTermKeyId,
-// nonce, tag) lives in CompleteFrameExt for the daemon-driven path.
+// Per spec §3.4, the frame carries an AEAD authenticator over the
+// derived long-term key:
+//
+//	tag = XChaCha20-Poly1305.Seal(
+//	    key       = long_term_key,
+//	    nonce     = random 24B,
+//	    plaintext = "" (empty),
+//	    AD        = transcript_hash || "tether-pair-complete-v1",
+//	)
+//
+// `Tag` carries the 16-byte AEAD tag (which is the entire ciphertext
+// since plaintext is empty). Receivers MUST verify the tag with their
+// own derived `long_term_key` + the transcript_hash they observed.
+// Mismatch → emit pair.abort{cert-error} and DO NOT save the registry
+// record. Without this verification, a rogue daemon (or any in-path
+// actor that survived TLS) can forge a pair.complete and trick both
+// endpoints into "succeeding" with an attacker-mediated key.
+//
+// RegisteredAs and LongTermKeyID are §3.4 informational fields the
+// daemon assigns; they are echoed back to the UI for display but do
+// NOT enter the AEAD AD (only `transcript_hash` does).
 type CompleteFrame struct {
-	ProtocolVersion int   `json:"v"`
-	TS_             int64 `json:"ts"`
+	ProtocolVersion int    `json:"v"`
+	TS_             int64  `json:"ts"`
+	Nonce           []byte `json:"-"` // 24B XChaCha20 nonce
+	Tag             []byte `json:"-"` // 16B Poly1305 tag (= AEAD ciphertext over empty plaintext)
+	// Optional informational fields (spec §3.4) — omitted from canonical
+	// body when empty. The daemon assigns these post-pairing; they're
+	// for UI / audit display only and do NOT enter the AEAD AD.
+	RegisteredInitiatorDeviceID string `json:"-"`
+	RegisteredResponderDeviceID string `json:"-"`
+	LongTermKeyID               string `json:"-"`
 }
 
 func (f CompleteFrame) Kind() FrameKind { return KindComplete }

--- a/internal/pair/sas.go
+++ b/internal/pair/sas.go
@@ -2,10 +2,14 @@ package pair
 
 import (
 	"crypto/hmac"
+	"crypto/rand"
 	"crypto/sha256"
 	"encoding/binary"
 	"errors"
 	"fmt"
+	"io"
+
+	"golang.org/x/crypto/chacha20poly1305"
 
 	"github.com/piaobeizu/tether/internal/crypto"
 )
@@ -141,4 +145,102 @@ func DeriveLongTermKey(shared, transcriptHash []byte) (longTermKey, transportBin
 		return nil, nil, fmt.Errorf("pair: derive tbk: %w", err)
 	}
 	return ltk, tbk, nil
+}
+
+// completeAEADInfo is the §3.4 AD suffix appended to the transcript_hash
+// when sealing / opening the pair.complete AEAD tag. Wire-stable —
+// changing requires a protocol-version bump.
+const completeAEADInfo = "tether-pair-complete-v1"
+
+// ErrCompleteAEAD is returned when pair.complete tag verification fails.
+// Treated as ReasonCertError per spec §3.4 / §3.5: a rogue daemon (or
+// any in-path actor that survived TLS) cannot forge this tag without
+// also deriving the same long_term_key from the same transcript_hash.
+var ErrCompleteAEAD = errors.New("pair: pair.complete AEAD tag verification failed")
+
+// completeAEADAd builds the AD = transcript_hash || "tether-pair-complete-v1".
+// Both seal and open MUST construct this identically.
+func completeAEADAd(transcriptHash []byte) []byte {
+	out := make([]byte, 0, len(transcriptHash)+len(completeAEADInfo))
+	out = append(out, transcriptHash...)
+	out = append(out, []byte(completeAEADInfo)...)
+	return out
+}
+
+// SealCompleteTag seals an empty plaintext under the long_term_key with
+// AD = transcript_hash || "tether-pair-complete-v1" and a freshly
+// generated 24-byte XChaCha20 nonce. Returns (nonce, tag) where tag is
+// the 16-byte Poly1305 tag (= the entire AEAD ciphertext, since
+// plaintext is empty).
+//
+// Per spec §3.4: this tag is what proves "the daemon emitting
+// pair.complete derived the same long_term_key from the same transcript".
+// Without it, a forged complete frame trips both endpoints into
+// "succeeding" with attacker-mediated keys.
+//
+// The `randSrc` parameter lets tests inject a deterministic source; pass
+// nil for the production crypto/rand.Reader.
+func SealCompleteTag(longTermKey, transcriptHash []byte, randSrc io.Reader) (nonce, tag []byte, err error) {
+	if len(longTermKey) != chacha20poly1305.KeySize {
+		return nil, nil, fmt.Errorf("pair: complete seal: ltk must be %d bytes", chacha20poly1305.KeySize)
+	}
+	if len(transcriptHash) == 0 {
+		return nil, nil, errors.New("pair: complete seal: empty transcript hash")
+	}
+	aead, err := chacha20poly1305.NewX(longTermKey)
+	if err != nil {
+		return nil, nil, fmt.Errorf("pair: complete seal: %w", err)
+	}
+	nonce = make([]byte, chacha20poly1305.NonceSizeX)
+	src := randSrc
+	if src == nil {
+		src = rand.Reader
+	}
+	if _, err := io.ReadFull(src, nonce); err != nil {
+		return nil, nil, fmt.Errorf("pair: complete seal nonce: %w", err)
+	}
+	ad := completeAEADAd(transcriptHash)
+	// Empty plaintext + tag-only output is equivalent to AEAD.Seal(nil,
+	// nonce, []byte{}, ad) — golang.org/x/crypto/chacha20poly1305 returns
+	// just the 16-byte tag in this case.
+	tag = aead.Seal(nil, nonce, []byte{}, ad)
+	if len(tag) != chacha20poly1305.Overhead {
+		return nil, nil, fmt.Errorf("pair: complete seal: unexpected tag len %d", len(tag))
+	}
+	return nonce, tag, nil
+}
+
+// OpenCompleteTag verifies a (nonce, tag) pair produced by
+// SealCompleteTag against the same long_term_key + transcript_hash.
+// Returns nil iff the tag authenticates; ErrCompleteAEAD on any
+// mismatch (including malformed sizes — defense-in-depth so callers
+// don't get a different error class for "bad input" vs "auth fail").
+func OpenCompleteTag(longTermKey, transcriptHash, nonce, tag []byte) error {
+	if len(longTermKey) != chacha20poly1305.KeySize {
+		return ErrCompleteAEAD
+	}
+	if len(transcriptHash) == 0 {
+		return ErrCompleteAEAD
+	}
+	if len(nonce) != chacha20poly1305.NonceSizeX {
+		return ErrCompleteAEAD
+	}
+	if len(tag) != chacha20poly1305.Overhead {
+		return ErrCompleteAEAD
+	}
+	aead, err := chacha20poly1305.NewX(longTermKey)
+	if err != nil {
+		return ErrCompleteAEAD
+	}
+	ad := completeAEADAd(transcriptHash)
+	// Open tag-only ciphertext: pass the 16-byte tag as the entire
+	// ciphertext; expected plaintext is empty.
+	pt, err := aead.Open(nil, nonce, tag, ad)
+	if err != nil {
+		return ErrCompleteAEAD
+	}
+	if len(pt) != 0 {
+		return ErrCompleteAEAD
+	}
+	return nil
 }

--- a/internal/pair/sas_test.go
+++ b/internal/pair/sas_test.go
@@ -2,6 +2,7 @@ package pair
 
 import (
 	"bytes"
+	"encoding/hex"
 	"errors"
 	"testing"
 )
@@ -43,6 +44,61 @@ func TestSAS_GoldenVector(t *testing.T) {
 		if !bytes.ContainsRune([]byte(sasAlphabet), c) {
 			t.Errorf("SAS char %d (%c) not in alphabet", i, c)
 		}
+	}
+}
+
+// TestSAS_CrossStackGolden pins the SAS for the SAME input vector the
+// Rust client pins (tether-app/src-tauri/src/wt/pair.rs::sas_golden_vector):
+//
+//	shared_secret  = [0x01; 32]
+//	transcript_hash = [0x02; 32]
+//	expected SAS   = "J8LNUS"
+//
+// If this divergence trips on either side, BOTH packages' goldens
+// trip simultaneously and the breaking change is caught at CI time.
+// This is the BLOCKER-3 fix: previously Go and Rust used different
+// inputs so algorithm-level mismatches couldn't be caught by either
+// suite alone.
+func TestSAS_CrossStackGolden(t *testing.T) {
+	shared := bytes.Repeat([]byte{0x01}, 32)
+	thash := bytes.Repeat([]byte{0x02}, 32)
+	sasKey, err := DeriveSASKey(shared, thash)
+	if err != nil {
+		t.Fatalf("DeriveSASKey: %v", err)
+	}
+	sas, err := ComputeSAS(sasKey)
+	if err != nil {
+		t.Fatalf("ComputeSAS: %v", err)
+	}
+	const want = "J8LNUS"
+	if sas != want {
+		t.Errorf("cross-stack SAS golden: got %q want %q — divergence with Rust trips both suites", sas, want)
+	}
+}
+
+// TestConfirmMAC_CrossStackGolden — pin the HMAC against a vector the
+// Rust side mirrors. Inputs match the Rust `confirm_mac_golden` test:
+//
+//	sas_key        = [0xAA; 32]
+//	transcript_hash = [0xBB; 32]
+//
+// Expected hex digests (initiator + responder) are pinned on both
+// sides. Divergence ⇒ cross-stack pair fails MAC verification and
+// BOTH suites' goldens trip.
+func TestConfirmMAC_CrossStackGolden(t *testing.T) {
+	key := bytes.Repeat([]byte{0xAA}, 32)
+	thash := bytes.Repeat([]byte{0xBB}, 32)
+	initMAC := ConfirmMAC(key, RoleInitiator, thash)
+	respMAC := ConfirmMAC(key, RoleResponder, thash)
+	const wantInit = "1392c88c645a6088be25b285b47d52a88215b4f82a927e14844fa24f080033dd"
+	const wantResp = "3e9f0fe0cb6d6b48aa8d43d47786bbaa5a7bc4c8b308c23abc1bab681d550117"
+	gotInit := hex.EncodeToString(initMAC)
+	gotResp := hex.EncodeToString(respMAC)
+	if gotInit != wantInit {
+		t.Errorf("initiator confirm-mac cross-stack golden: got %s want %s", gotInit, wantInit)
+	}
+	if gotResp != wantResp {
+		t.Errorf("responder confirm-mac cross-stack golden: got %s want %s", gotResp, wantResp)
 	}
 }
 

--- a/internal/pair/server.go
+++ b/internal/pair/server.go
@@ -125,6 +125,9 @@ func (s *Server) Run(ctx context.Context, stream io.ReadWriter) (Result, error) 
 		DeviceID:        s.identity.DeviceID,
 		Kind_:           s.identity.Kind,
 		DisplayName:     s.identity.DisplayName,
+		Model:           s.identity.Model,
+		OSVersion:       s.identity.OSVersion,
+		AppVersion:      s.identity.AppVersion,
 		PushToken:       s.identity.PushToken,
 		TS_:             s.now().UnixMilli(),
 		Nonce:           mustRandomNonce(s.rand, 16),
@@ -221,22 +224,18 @@ func (s *Server) Run(ctx context.Context, stream io.ReadWriter) (Result, error) 
 		return Result{}, err
 	}
 
-	// 7. Emit pair.complete (server-side ack per spec §2.4 daemon role
-	//    — responder + daemon co-located in v0.1).
-	complete := CompleteFrame{
-		ProtocolVersion: ProtocolVersion,
-		TS_:             s.now().UnixMilli(),
-	}
-	if err := w.writeFrame(complete); err != nil {
-		return Result{}, fmt.Errorf("pair: server send complete: %w", err)
-	}
-	fsm.state = StatePaired
-
-	// 8. Derive long-term keys + persist + audit.
+	// 7. Derive long-term keys + persist + audit BEFORE emitting
+	//    pair.complete — fixes review C3 TOCTOU. A spec-compliant peer
+	//    reconnects on receiving complete and the daemon's
+	//    resolveKeyForSession must find the registry record. If we
+	//    emitted complete first, the peer could race a reconnect before
+	//    Save returned, get ErrNotFound, and silently fall back to the
+	//    dev-shared key.
 	ltk, tbk, err := DeriveLongTermKey(shared, thash)
 	if err != nil {
 		return Result{}, err
 	}
+	ltkID := fmt.Sprintf("ltk-%s", s.now().UTC().Format("20060102-150405"))
 	res := Result{
 		LocalDeviceID:       s.identity.DeviceID,
 		PeerDeviceID:        invite.DeviceID,
@@ -253,22 +252,69 @@ func (s *Server) Run(ctx context.Context, stream io.ReadWriter) (Result, error) 
 			DeviceID:            invite.DeviceID,
 			Kind:                invite.Kind_,
 			DisplayName:         invite.DisplayName,
+			Model:               invite.Model,
 			LongTermKey:         ltk,
 			TransportBindingKey: tbk,
-			LongTermKeyID:       fmt.Sprintf("ltk-%s", s.now().UTC().Format("20060102-150405")),
+			LongTermKeyID:       ltkID,
 			PairedAt:            s.now().UTC(),
 			LastSeen:            s.now().UTC(),
 		}
 		if err := s.registry.Save(rec); err != nil {
 			// Re-pair race: someone else paired this id between our
-			// pre-flight check and now. Surface the error; caller
-			// decides whether to ForceSave.
+			// pre-flight check and now. Surface internal-error to peer
+			// (we can't fulfill the contract) — they'll abort cleanly.
+			ab := abortNow(ReasonProtocolViolation, "internal-error: registry save failed")
+			ab.TS_ = s.now().UnixMilli()
+			_ = w.writeFrame(ab)
 			return res, fmt.Errorf("pair: server persist: %w", err)
 		}
 	}
 	if s.audit != nil {
 		_ = s.audit.AppendSuccess(s.identity.DeviceID, invite.DeviceID, "", thash)
 	}
+
+	// 8. Compose + emit pair.complete with the §3.4 AEAD tag. Receiver
+	//    (initiator) verifies tag with its own derived ltk + same
+	//    transcript_hash; mismatch ⇒ ReasonCertError. This is the
+	//    BLOCKER-4 fix surface — without the tag, a forged complete
+	//    from any in-path actor that survived TLS lets attacker-mediated
+	//    keys be accepted.
+	nonce, tag, err := SealCompleteTag(ltk, thash, s.rand)
+	if err != nil {
+		ab := abortNow(ReasonProtocolViolation, "internal-error: complete seal failed")
+		ab.TS_ = s.now().UnixMilli()
+		_ = w.writeFrame(ab)
+		return res, fmt.Errorf("pair: server seal complete: %w", err)
+	}
+	complete := CompleteFrame{
+		ProtocolVersion:             ProtocolVersion,
+		TS_:                         s.now().UnixMilli(),
+		Nonce:                       nonce,
+		Tag:                         tag,
+		LongTermKeyID:               ltkID,
+		RegisteredInitiatorDeviceID: string(invite.DeviceID),
+		RegisteredResponderDeviceID: string(s.identity.DeviceID),
+	}
+	if err := w.writeFrame(complete); err != nil {
+		return res, fmt.Errorf("pair: server send complete: %w", err)
+	}
+	fsm.state = StatePaired
+
+	// Drain-wait: after emitting the FINAL pair.complete frame, give the
+	// peer a chance to read + verify it before our caller (e.g. the
+	// daemon's wtsubsystem) tears down the underlying stream. Without
+	// this, the transport-level close races our final write and the
+	// client may see "session done" before the buffered pair.complete
+	// bytes arrive.
+	//
+	// We bound the wait via a short context — a healthy peer either
+	// closes the stream (we observe EOF) or in the cert-error path
+	// emits pair.abort{cert-error} (we log and return). 500ms covers
+	// QUIC ACK + FIN at any sane RTT; tests with in-process pipes
+	// typically observe EOF within microseconds.
+	drainCtx, drainCancel := context.WithTimeout(ctx, 500*time.Millisecond)
+	_, _ = readFrameWithCtx(drainCtx, r) // intentionally ignore — peer-close → EOF.
+	drainCancel()
 	return res, nil
 }
 

--- a/internal/pair/transcript.go
+++ b/internal/pair/transcript.go
@@ -161,19 +161,40 @@ func b64uDecode(s string) ([]byte, error) {
 
 // canonicalBody implementations: each fills a sorted-key map and runs
 // it through canonicalJSON.
+//
+// CROSS-STACK INVARIANT: these maps MUST byte-match what the Rust side
+// produces via `serde_json::to_value(&frame)` + `canonical_json` in
+// tether-app/src-tauri/src/wt/pair.rs. Spec §3.1/§3.2 lists the full
+// field set; optional fields (model / osVersion / appVersion / push)
+// follow Rust's `Option::None` skip semantics — empty Go string ⇒ key
+// omitted. Any divergence breaks the transcript_hash ⇒ SAS / MAC
+// mismatch ⇒ cross-stack pair becomes impossible.
+//
+// See sas_test.go::TestCanonicalBody_InviteFullFields for the pinned
+// byte sequence.
 
 func (f InviteFrame) canonicalBody() ([]byte, error) {
+	meta := map[string]any{
+		"kind":        string(f.Kind_),
+		"displayName": f.DisplayName,
+	}
+	if f.Model != "" {
+		meta["model"] = f.Model
+	}
+	if f.OSVersion != "" {
+		meta["osVersion"] = f.OSVersion
+	}
+	if f.AppVersion != "" {
+		meta["appVersion"] = f.AppVersion
+	}
 	return canonicalJSON(map[string]any{
 		"type":            string(KindInvite),
 		"v":               f.ProtocolVersion,
 		"deviceId":        string(f.DeviceID),
 		"ephemeralPubkey": b64uEncode(f.InitiatorPubkey),
-		"deviceMetadata": map[string]any{
-			"kind":        string(f.Kind_),
-			"displayName": f.DisplayName,
-		},
-		"ts":    f.TS_,
-		"nonce": b64uEncode(f.Nonce),
+		"deviceMetadata":  meta,
+		"ts":              f.TS_,
+		"nonce":           b64uEncode(f.Nonce),
 	})
 }
 
@@ -181,6 +202,15 @@ func (f AcceptFrame) canonicalBody() ([]byte, error) {
 	meta := map[string]any{
 		"kind":        string(f.Kind_),
 		"displayName": f.DisplayName,
+	}
+	if f.Model != "" {
+		meta["model"] = f.Model
+	}
+	if f.OSVersion != "" {
+		meta["osVersion"] = f.OSVersion
+	}
+	if f.AppVersion != "" {
+		meta["appVersion"] = f.AppVersion
 	}
 	body := map[string]any{
 		"type":            string(KindAccept),
@@ -215,11 +245,27 @@ func (f SASConfirmFrame) canonicalBody() ([]byte, error) {
 }
 
 func (f CompleteFrame) canonicalBody() ([]byte, error) {
-	return canonicalJSON(map[string]any{
+	body := map[string]any{
 		"type": string(KindComplete),
 		"v":    f.ProtocolVersion,
 		"ts":   f.TS_,
-	})
+	}
+	if len(f.Nonce) > 0 {
+		body["nonce"] = b64uEncode(f.Nonce)
+	}
+	if len(f.Tag) > 0 {
+		body["tag"] = b64uEncode(f.Tag)
+	}
+	if f.LongTermKeyID != "" {
+		body["longTermKeyId"] = f.LongTermKeyID
+	}
+	if f.RegisteredInitiatorDeviceID != "" || f.RegisteredResponderDeviceID != "" {
+		body["registeredAs"] = map[string]any{
+			"initiatorDeviceId": f.RegisteredInitiatorDeviceID,
+			"responderDeviceId": f.RegisteredResponderDeviceID,
+		}
+	}
+	return canonicalJSON(body)
 }
 
 func (f AbortFrame) canonicalBody() ([]byte, error) {
@@ -247,6 +293,9 @@ func decodeInviteBody(b []byte) (InviteFrame, error) {
 		DeviceMetadata  struct {
 			Kind        string `json:"kind"`
 			DisplayName string `json:"displayName"`
+			Model       string `json:"model"`
+			OSVersion   string `json:"osVersion"`
+			AppVersion  string `json:"appVersion"`
 		} `json:"deviceMetadata"`
 		TS    int64  `json:"ts"`
 		Nonce string `json:"nonce"`
@@ -268,6 +317,9 @@ func decodeInviteBody(b []byte) (InviteFrame, error) {
 		DeviceID:        DeviceID(raw.DeviceID),
 		Kind_:           DeviceKind(raw.DeviceMetadata.Kind),
 		DisplayName:     raw.DeviceMetadata.DisplayName,
+		Model:           raw.DeviceMetadata.Model,
+		OSVersion:       raw.DeviceMetadata.OSVersion,
+		AppVersion:      raw.DeviceMetadata.AppVersion,
 		TS_:             raw.TS,
 		Nonce:           nonce,
 	}, nil
@@ -281,6 +333,9 @@ func decodeAcceptBody(b []byte) (AcceptFrame, error) {
 		DeviceMetadata  struct {
 			Kind        string `json:"kind"`
 			DisplayName string `json:"displayName"`
+			Model       string `json:"model"`
+			OSVersion   string `json:"osVersion"`
+			AppVersion  string `json:"appVersion"`
 		} `json:"deviceMetadata"`
 		PushSubscription *struct {
 			Type    string `json:"type"`
@@ -308,6 +363,9 @@ func decodeAcceptBody(b []byte) (AcceptFrame, error) {
 		DeviceID:        DeviceID(raw.DeviceID),
 		Kind_:           DeviceKind(raw.DeviceMetadata.Kind),
 		DisplayName:     raw.DeviceMetadata.DisplayName,
+		Model:           raw.DeviceMetadata.Model,
+		OSVersion:       raw.DeviceMetadata.OSVersion,
+		AppVersion:      raw.DeviceMetadata.AppVersion,
 		TS_:             raw.TS,
 		Nonce:           nonce,
 	}
@@ -343,13 +401,39 @@ func decodeSASConfirmBody(b []byte) (SASConfirmFrame, error) {
 
 func decodeCompleteBody(b []byte) (CompleteFrame, error) {
 	var raw struct {
-		V  int   `json:"v"`
-		TS int64 `json:"ts"`
+		V             int    `json:"v"`
+		TS            int64  `json:"ts"`
+		Nonce         string `json:"nonce"`
+		Tag           string `json:"tag"`
+		LongTermKeyID string `json:"longTermKeyId"`
+		RegisteredAs  *struct {
+			InitiatorDeviceID string `json:"initiatorDeviceId"`
+			ResponderDeviceID string `json:"responderDeviceId"`
+		} `json:"registeredAs"`
 	}
 	if err := json.Unmarshal(b, &raw); err != nil {
 		return CompleteFrame{}, fmt.Errorf("pair: decode complete: %w", err)
 	}
-	return CompleteFrame{ProtocolVersion: raw.V, TS_: raw.TS}, nil
+	nonce, err := b64uDecode(raw.Nonce)
+	if err != nil {
+		return CompleteFrame{}, fmt.Errorf("pair: complete nonce: %w", err)
+	}
+	tag, err := b64uDecode(raw.Tag)
+	if err != nil {
+		return CompleteFrame{}, fmt.Errorf("pair: complete tag: %w", err)
+	}
+	out := CompleteFrame{
+		ProtocolVersion: raw.V,
+		TS_:             raw.TS,
+		Nonce:           nonce,
+		Tag:             tag,
+		LongTermKeyID:   raw.LongTermKeyID,
+	}
+	if raw.RegisteredAs != nil {
+		out.RegisteredInitiatorDeviceID = raw.RegisteredAs.InitiatorDeviceID
+		out.RegisteredResponderDeviceID = raw.RegisteredAs.ResponderDeviceID
+	}
+	return out, nil
 }
 
 func decodeAbortBody(b []byte) (AbortFrame, error) {

--- a/internal/pair/transcript_test.go
+++ b/internal/pair/transcript_test.go
@@ -88,6 +88,88 @@ func TestCanonicalJSON_KeyOrderIndependent(t *testing.T) {
 	}
 }
 
+// TestCanonicalBody_InviteFullFields pins the EXACT byte sequence
+// produced by InviteFrame.canonicalBody() when all optional spec
+// §3.1 deviceMetadata fields are populated. This is the BLOCKER-2
+// cross-stack invariant: the Rust side
+// (tether-app/src-tauri/src/wt/pair.rs::canonical_body_invite_full_fields_golden)
+// MUST produce the same bytes for the same inputs. Divergence ⇒
+// transcript_hash diverges ⇒ SAS / MAC mismatch ⇒ pairing fails.
+//
+// Why this exact ordering: canonicalJSON sorts keys lexicographically
+// at every object level. The expected layout reflects:
+//
+//	deviceId, deviceMetadata{appVersion, displayName, kind, model, osVersion},
+//	ephemeralPubkey, nonce, ts, type, v
+//
+// Note that "v" sorts AFTER "type" (lex byte order: 't' < 'v'), and
+// inside deviceMetadata the optional fields all sort before the
+// required ones since their first-letter byte values are smaller.
+func TestCanonicalBody_InviteFullFields(t *testing.T) {
+	// Fixed-byte deterministic inputs — these match the Rust pinning.
+	pubkey := bytes.Repeat([]byte{0xAB}, 32)
+	nonce := bytes.Repeat([]byte{0xCD}, 16)
+	f := InviteFrame{
+		ProtocolVersion: 1,
+		InitiatorPubkey: pubkey,
+		DeviceID:        "device-desktop-aaaa",
+		Kind_:           KindDesktop,
+		DisplayName:     "Kang's MacBook",
+		Model:           "MBP",
+		OSVersion:       "macOS 14.5",
+		AppVersion:      "tether 0.1.0-dev",
+		TS_:             1714000000000,
+		Nonce:           nonce,
+	}
+	got, err := f.canonicalBody()
+	if err != nil {
+		t.Fatalf("canonicalBody: %v", err)
+	}
+	// Pinned: lex-sorted keys, no whitespace, base64url-no-pad for
+	// pubkey + nonce. Construct as a literal so any drift trips here.
+	const want = `{"deviceId":"device-desktop-aaaa","deviceMetadata":{"appVersion":"tether 0.1.0-dev","displayName":"Kang's MacBook","kind":"desktop","model":"MBP","osVersion":"macOS 14.5"},"ephemeralPubkey":"q6urq6urq6urq6urq6urq6urq6urq6urq6urq6urq6s","nonce":"zc3Nzc3Nzc3Nzc3Nzc3NzQ","ts":1714000000000,"type":"pair.invite","v":1}`
+	if string(got) != want {
+		t.Errorf("invite canonical body diverged from cross-stack golden:\n got: %s\nwant: %s", string(got), want)
+	}
+
+	// Round-trip through decode — guarantees all-fields-included survives.
+	parsed, err := decodeInviteBody(got)
+	if err != nil {
+		t.Fatalf("decodeInviteBody: %v", err)
+	}
+	if parsed.Model != "MBP" || parsed.OSVersion != "macOS 14.5" || parsed.AppVersion != "tether 0.1.0-dev" {
+		t.Errorf("optional fields lost on round-trip: %+v", parsed)
+	}
+}
+
+// TestCanonicalBody_InviteOptionalsOmitted — when the optionals are
+// empty strings, they MUST be absent from the canonical body (matching
+// Rust's `Option::None` skip semantics). Otherwise an honest peer that
+// happens to omit them produces a different transcript than one that
+// passes empty strings, breaking interop.
+func TestCanonicalBody_InviteOptionalsOmitted(t *testing.T) {
+	pubkey := bytes.Repeat([]byte{0xAB}, 32)
+	nonce := bytes.Repeat([]byte{0xCD}, 16)
+	f := InviteFrame{
+		ProtocolVersion: 1,
+		InitiatorPubkey: pubkey,
+		DeviceID:        "device-desktop-aaaa",
+		Kind_:           KindDesktop,
+		DisplayName:     "Kang's MacBook",
+		// Model / OSVersion / AppVersion intentionally empty.
+		TS_:   1714000000000,
+		Nonce: nonce,
+	}
+	got, err := f.canonicalBody()
+	if err != nil {
+		t.Fatalf("canonicalBody: %v", err)
+	}
+	const want = `{"deviceId":"device-desktop-aaaa","deviceMetadata":{"displayName":"Kang's MacBook","kind":"desktop"},"ephemeralPubkey":"q6urq6urq6urq6urq6urq6urq6urq6urq6urq6urq6s","nonce":"zc3Nzc3Nzc3Nzc3Nzc3NzQ","ts":1714000000000,"type":"pair.invite","v":1}`
+	if string(got) != want {
+		t.Errorf("omit-optionals canonical body:\n got: %s\nwant: %s", string(got), want)
+	}
+}
+
 // TestEnvelopeRoundtrip — encode + decode an envelope through
 // EnvelopeWrap / EnvelopeUnwrap and verify field equality.
 func TestEnvelopeRoundtrip(t *testing.T) {

--- a/internal/pair/wire_cross_stack_test.go
+++ b/internal/pair/wire_cross_stack_test.go
@@ -1,0 +1,229 @@
+package pair
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+)
+
+var dummyTime = time.Date(2026, 5, 7, 0, 0, 0, 0, time.UTC)
+
+func testCtx(t *testing.T) context.Context {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	t.Cleanup(cancel)
+	return ctx
+}
+
+// TestWire_JSONLEnvelopeShape pins the on-the-wire envelope shape that
+// Rust must produce and consume byte-identically. This is the BLOCKER-1
+// fix surface: previously Go wrote `{"kind":..,"keyVersion":..,...}\n`
+// and Rust wrote `<4-byte BE length><canonical body>` — incompatible.
+//
+// The pinned shape is:
+//
+//	{"kind":"<frame-kind>","keyVersion":0,"ciphertext":"<b64url-no-pad>","ts":<unix-ms>}\n
+//
+// where ciphertext is the canonical-JSON-encoded inner body, base64-
+// url-no-pad encoded so the line is plain JSON (no embedded raw bytes).
+//
+// keyVersion=0 is the §3.3.1 sentinel for "pair-protocol scope,
+// plaintext body" per spec §14 OQ ratification.
+func TestWire_JSONLEnvelopeShape(t *testing.T) {
+	frame := InviteFrame{
+		ProtocolVersion: 1,
+		InitiatorPubkey: bytes.Repeat([]byte{0xAB}, 32),
+		DeviceID:        "device-desktop-aaaa",
+		Kind_:           KindDesktop,
+		DisplayName:     "Kang's MacBook",
+		Model:           "MBP",
+		OSVersion:       "macOS 14.5",
+		AppVersion:      "tether 0.1.0-dev",
+		TS_:             1714000000000,
+		Nonce:           bytes.Repeat([]byte{0xCD}, 16),
+	}
+	env, err := EnvelopeWrap(frame)
+	if err != nil {
+		t.Fatalf("EnvelopeWrap: %v", err)
+	}
+	line, err := encodeEnvelope(env)
+	if err != nil {
+		t.Fatalf("encodeEnvelope: %v", err)
+	}
+	if !strings.HasSuffix(string(line), "\n") {
+		t.Errorf("envelope line missing trailing \\n")
+	}
+	// Decode the line back as plain JSON to verify field names + shape.
+	var raw map[string]any
+	if err := json.Unmarshal(line, &raw); err != nil {
+		t.Fatalf("envelope line not valid JSON: %v", err)
+	}
+	if raw["kind"] != "pair.invite" {
+		t.Errorf("kind: got %v want pair.invite", raw["kind"])
+	}
+	// keyVersion arrives as float64 from generic JSON decode.
+	if raw["keyVersion"] != float64(0) {
+		t.Errorf("keyVersion: got %v want 0", raw["keyVersion"])
+	}
+	if _, ok := raw["ciphertext"].(string); !ok {
+		t.Errorf("ciphertext: got %T want string", raw["ciphertext"])
+	}
+	if raw["ts"] != float64(1714000000000) {
+		t.Errorf("ts: got %v want 1714000000000", raw["ts"])
+	}
+}
+
+// TestWire_DecodeRustStyleEnvelope simulates the Rust client emitting an
+// envelope (using the same JSONL shape) and verifies the Go side decodes
+// it identically. If the shapes diverged, this would surface as either
+// a JSON parse failure or a fields-mismatch.
+func TestWire_DecodeRustStyleEnvelope(t *testing.T) {
+	// Hand-build a Rust-side envelope: the Rust client computes
+	// canonical_json(frame) for the inner body and base64url-no-pad
+	// encodes it as `ciphertext`.
+	innerBody := []byte(`{"deviceId":"device-mobile-bbbb","deviceMetadata":{"appVersion":"tether 0.1.0-dev","displayName":"Test Phone","kind":"mobile"},"ephemeralPubkey":"q6urq6urq6urq6urq6urq6urq6urq6urq6urq6urq6s","nonce":"zc3Nzc3Nzc3Nzc3Nzc3NzQ","ts":1714000000500,"type":"pair.accept","v":1}`)
+	env := WireEnvelope{
+		Kind:       KindAccept,
+		KeyVersion: KeyVersionPair,
+		Ciphertext: innerBody,
+		TS:         1714000000500,
+	}
+	line, err := encodeEnvelope(env)
+	if err != nil {
+		t.Fatalf("encodeEnvelope: %v", err)
+	}
+	// Round-trip: decode back.
+	got, err := decodeEnvelope(bytes.TrimRight(line, "\n"))
+	if err != nil {
+		t.Fatalf("decodeEnvelope: %v", err)
+	}
+	if got.Kind != KindAccept {
+		t.Errorf("kind round-trip: got %s want pair.accept", got.Kind)
+	}
+	if !bytes.Equal(got.Ciphertext, innerBody) {
+		t.Errorf("ciphertext round-trip mismatch")
+	}
+	// Now feed the inner body through the AcceptFrame decoder and
+	// verify the optional fields all round-trip.
+	parsed, err := decodeAcceptBody(got.Ciphertext)
+	if err != nil {
+		t.Fatalf("decodeAcceptBody: %v", err)
+	}
+	if parsed.AppVersion != "tether 0.1.0-dev" {
+		t.Errorf("appVersion round-trip: got %q", parsed.AppVersion)
+	}
+	if parsed.DisplayName != "Test Phone" {
+		t.Errorf("displayName round-trip: got %q", parsed.DisplayName)
+	}
+	if string(parsed.DeviceID) != "device-mobile-bbbb" {
+		t.Errorf("deviceId round-trip: got %q", parsed.DeviceID)
+	}
+}
+
+// TestWire_FullCycleByteIdentical drives a full Server.Run pair cycle
+// and captures every wire byte. Verifies (a) all five frame kinds
+// observed are the JSONL shape, (b) the inner canonical bodies decode
+// to the spec field set, and (c) the byte stream is suffix-newline
+// terminated for every frame.
+//
+// This is the cross-stack smoke required by the deliverable: "verify
+// 'Go server speaks the wire format we documented'".
+func TestWire_FullCycleByteIdentical(t *testing.T) {
+	// We piggyback on the existing happy-path duplex pipe but tee both
+	// sides' wire bytes so we can introspect them after.
+	// Implemented inline rather than reusing TestClientServer_HappyPath
+	// because Go's io.Pipe doesn't tee easily.
+	pipe := newDuplexPipe()
+	defer pipe.Close()
+
+	clientWrite := &bytes.Buffer{}
+	serverWrite := &bytes.Buffer{}
+
+	clientSide := &teeRW{rw: pipe.ClientSide(), capW: clientWrite}
+	serverSide := &teeRW{rw: pipe.ServerSide(), capW: serverWrite}
+
+	clk := &monotonicClock{base: dummyTime}
+	now := clk.Now
+	client := NewClient(ClientConfig{
+		Identity:  Identity{DeviceID: "device-desktop-aaaa", Kind: KindDesktop, DisplayName: "Test Desktop", AppVersion: "tether 0.1.0-dev"},
+		Confirmer: AutoConfirm,
+		Now:       now,
+		Rand:      &detRand{fillByte: 0x10},
+	})
+	server := NewServer(ServerConfig{
+		Identity:  Identity{DeviceID: "device-mobile-bbbb", Kind: KindMobile, DisplayName: "Test Phone", PushToken: "fcm-test"},
+		Confirmer: AutoConfirm,
+		Now:       now,
+		Rand:      &detRand{fillByte: 0x80},
+	})
+	type result struct {
+		res Result
+		err error
+	}
+	clientCh := make(chan result, 1)
+	serverCh := make(chan result, 1)
+	go func() {
+		res, err := client.Run(testCtx(t), clientSide)
+		_ = pipe.clientWriter.Close()
+		clientCh <- result{res, err}
+	}()
+	go func() {
+		res, err := server.Run(testCtx(t), serverSide)
+		_ = pipe.serverWriter.Close()
+		serverCh <- result{res, err}
+	}()
+	cr := <-clientCh
+	sr := <-serverCh
+	if cr.err != nil {
+		t.Fatalf("client: %v", cr.err)
+	}
+	if sr.err != nil {
+		t.Fatalf("server: %v", sr.err)
+	}
+	// Every wire chunk MUST be JSONL (one JSON envelope per line).
+	for label, buf := range map[string]*bytes.Buffer{"client": clientWrite, "server": serverWrite} {
+		// Split on newline, expect every non-empty chunk to be a
+		// valid envelope JSON.
+		lines := bytes.Split(buf.Bytes(), []byte("\n"))
+		nonEmpty := 0
+		for _, ln := range lines {
+			if len(ln) == 0 {
+				continue
+			}
+			nonEmpty++
+			env, err := decodeEnvelope(ln)
+			if err != nil {
+				t.Errorf("%s wire: malformed envelope %q: %v", label, ln, err)
+				continue
+			}
+			if env.KeyVersion != KeyVersionPair {
+				t.Errorf("%s wire: keyVersion=%d want %d", label, env.KeyVersion, KeyVersionPair)
+			}
+			switch env.Kind {
+			case KindInvite, KindAccept, KindSASConfirm, KindComplete, KindAbort:
+				// OK — known frame kind.
+			default:
+				t.Errorf("%s wire: unknown frame kind %q", label, env.Kind)
+			}
+		}
+		if nonEmpty == 0 {
+			t.Errorf("%s wire: no envelopes captured", label)
+		}
+	}
+}
+
+// teeRW wraps an io.ReadWriter and captures every byte written for
+// post-test introspection. Reads pass through unmodified.
+type teeRW struct {
+	rw   interface{ Read([]byte) (int, error); Write([]byte) (int, error) }
+	capW *bytes.Buffer
+}
+
+func (t *teeRW) Read(b []byte) (int, error) { return t.rw.Read(b) }
+func (t *teeRW) Write(b []byte) (int, error) {
+	t.capW.Write(b)
+	return t.rw.Write(b)
+}


### PR DESCRIPTION
## Summary

Fixes 5 cross-stack BLOCKERs surfaced by R2 review that made
Go-daemon ↔ Rust-client pairing **impossible** to complete.

Sister PR (Rust): https://github.com/piaobeizu/tether-app/pull/22
Spec prose fix: https://github.com/piaobeizu/tether-doc/pull/12
Parallel branch: `wt-integration-fix` (separate PR pair).

## Architectural decisions

| Choice | Picked | Rejected | Why |
|---|---|---|---|
| Wire format | **JSONL envelope** `{kind,keyVersion=0,ciphertext,ts}\n` | Rust's raw 4-byte length-prefix | `keyVersion=0` matches §3.3.1 wider envelope shape and §14 OQ ratification. Plain JSON line on the wire is easier to debug + future-proofs the encrypted-from-frame-3 path. |
| Canonical body | **Full-fields-included** with omit-when-empty | Hand-built omit-fields | Spec §3.1/§3.2 mandates `model`, `osVersion`, `appVersion` as optional in `deviceMetadata`. Rust already serializes them. Go must too. |
| `pair.complete` AEAD | **XChaCha20-Poly1305 over empty plaintext, 24B random nonce, AD = transcript_hash \|\| "tether-pair-complete-v1"** | No tag (status quo) | Spec §3.4 mandates. Without it, a forged complete from any in-path actor that survived TLS lets attacker-mediated keys be accepted. |
| Replay reason | Reuse existing `protocol-violation` reason for non-monotonic ts | New `replay` reason | Spec §3.5 reason set is closed; Go FSM already maps `ErrReplay` → `protocol-violation`. Rust check_replay_and_advance returns `Envelope("replay: ...")` — surfaced as the same protocol-violation class. |

## What changed in this repo (Go side)

- `internal/pair/pair.go`: `InviteFrame` / `AcceptFrame` gain
  `Model` / `OSVersion` / `AppVersion` fields (omit-when-empty).
  `CompleteFrame` gains `Nonce` / `Tag` / `LongTermKeyID` /
  `Registered{Initiator,Responder}DeviceID`.
- `internal/pair/transcript.go`: `canonicalBody` for invite/accept
  emits the full-fields form. `decodeInviteBody` / `decodeAcceptBody`
  / `decodeCompleteBody` read the new fields.
- `internal/pair/sas.go`: adds `SealCompleteTag` + `OpenCompleteTag` +
  `ErrCompleteAEAD` for the §3.4 AEAD authenticator.
- `internal/pair/server.go`: reorder per C3 — `DeriveLongTermKey` →
  `Registry.Save` → `Audit` → seal AEAD → `writeFrame(complete)`. Add
  500ms drain-wait after the final write so the daemon's session-close
  doesn't race the client's read.
- `internal/pair/client.go`: verify the AEAD tag on receipt; mismatch
  → `ReasonCertError` + abort, no Result return.
- `internal/pair/{sas,transcript,complete_aead,wire_cross_stack}_test.go`:
  cross-stack goldens + AEAD verify + rogue-complete e2e.

## Cross-stack golden values pinned

| Vector | Inputs | Expected output |
|---|---|---|
| `SAS_CrossStackGolden` | `shared = [0x01;32]`, `transcript = [0x02;32]` | `"J8LNUS"` |
| `ConfirmMAC_CrossStackGolden` | `sas_key = [0xAA;32]`, `transcript = [0xBB;32]` | initiator: `1392c88c645a6088be25b285b47d52a88215b4f82a927e14844fa24f080033dd` <br> responder: `3e9f0fe0cb6d6b48aa8d43d47786bbaa5a7bc4c8b308c23abc1bab681d550117` |
| `CanonicalBody_InviteFullFields` | pubkey=[0xAB;32], nonce=[0xCD;16], ts=1714000000000, all metadata fields populated | `{"deviceId":"device-desktop-aaaa","deviceMetadata":{"appVersion":"tether 0.1.0-dev","displayName":"Kang's MacBook","kind":"desktop","model":"MBP","osVersion":"macOS 14.5"},"ephemeralPubkey":"q6urq6urq6urq6urq6urq6urq6urq6urq6urq6urq6s","nonce":"zc3Nzc3Nzc3Nzc3Nzc3NzQ","ts":1714000000000,"type":"pair.invite","v":1}` |

The Rust side pins the same input vectors + same expected outputs;
divergence trips both suites simultaneously.

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test ./...` clean (full suite — daemon glue tests pass thanks to drain-wait)
- [x] `go test -race -count=10 ./internal/pair/...` clean
- [x] Rust + TS sister PR: `cargo build --lib`, `cargo test --lib`, `npx tsc --noEmit`, `npm test` all clean
- [x] New cross-stack golden tests pass byte-for-byte on both sides
- [x] `TestServer_RogueComplete_Rejects` confirms a flipped AEAD tag
       trips `ErrCompleteAEAD`; no registry record is written

🤖 Generated with [Claude Code](https://claude.com/claude-code)