### PR TITLE
v0.3.2 — Dynamic tool list + HTTPS /mcp + manual API tokens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,48 @@
 # Changelog
 
+## v0.3.2 (unreleased)
+
+### Added
+- HTTPS `/mcp` endpoint on the main port for external MCP clients (Cursor, Goose).
+  Protected by manually-issued Bearer tokens.
+- REST API `POST/GET/DELETE /api/v1/mcp/tokens` for managing external client tokens.
+  Tokens stored hashed (SHA-256) in `~/.tether/api-tokens.json` (mode 0600).
+- Audit log events `mcp.apitoken.{created,revoked,auth_ok,auth_failed}` (slog).
+- Dynamic tool list refresh: external clients and CC immediately see tools
+  added or removed by supervisor reconnects without needing to reconnect.
+
+### Changed
+- `/mcp` HTTPS endpoint no longer returns 501.
+- `BuildMCPServer` now takes a `*registry.Registry` to subscribe live tool updates.
+
+### Deferred to v0.3.3
+- Full OAuth 2.1 PKCE flow (`/oauth/authorize`, `/oauth/token`).
+- OAuth discovery endpoint (`/.well-known/oauth-authorization-server` — currently 404).
+- Token TTL, scope, dynamic client registration, web UI for token management.
+- Rate limiting on `/mcp` Bearer-validation failures.
+
+### Migration
+- Existing v0.3.1 deployments: no migration needed. CC loopback at
+  `127.0.0.1:8899/mcp` continues to work unchanged.
+- New file `~/.tether/api-tokens.json` is created lazily on first
+  `POST /api/v1/mcp/tokens`; include in backups if external clients are expected.
+
+### Security
+- Manual tokens are long-lived and all-scope. Use one token per external client;
+  revoke and recreate on suspected leak. See spec
+  `tether-doc/wiki/specs/2026-05-11-mcp-v032-design.md` §9 for the rotation
+  workflow.
+- Token-CRUD endpoints `/api/v1/mcp/tokens` are protected by the existing JWT
+  cookie middleware and `WithOriginGuard` CSRF posture (rejects POST/DELETE with
+  mismatched `Origin` header).
+
+## v0.3.1 (merged 2026-05-11)
+
+### Added
+- MCP loopback endpoint at `127.0.0.1:8899/mcp` for CC subprocess integration.
+- Builtin workspace tools (`workspace_read_file`, `workspace_list_files`, etc.).
+- CC settings injection into `~/.claude/settings.json` on daemon startup.
+
 ## v0.3.0 (unreleased)
 
 ### Changed

--- a/internal/auth/apitoken/store.go
+++ b/internal/auth/apitoken/store.go
@@ -1,0 +1,248 @@
+package apitoken
+
+import (
+	"crypto/rand"
+	"crypto/sha256"
+	"crypto/subtle"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+)
+
+const (
+	MaxTokens  = 100
+	MaxNameLen = 64
+)
+
+var (
+	ErrNameRequired  = errors.New("apitoken: name required")
+	ErrNameTooLong   = fmt.Errorf("apitoken: name exceeds %d chars", MaxNameLen)
+	ErrTooManyTokens = fmt.Errorf("apitoken: store full (max %d)", MaxTokens)
+	ErrNotFound      = errors.New("apitoken: not found")
+)
+
+// Token is the on-disk record. Raw token is never stored — only its SHA-256 hash.
+// SHA-256 without salt is appropriate here: tokens are 32 random bytes (256-bit
+// entropy), so pre-image resistance suffices and rainbow tables are infeasible.
+type Token struct {
+	ID        string    `json:"id"`
+	Name      string    `json:"name"`
+	Hash      string    `json:"hash"`
+	CreatedAt time.Time `json:"created_at"`
+}
+
+// View is what List returns: no hash, no raw, safe to serialize to clients.
+// Hash is intentionally always empty — the field exists only so that callers
+// can assert it is unset; it is never populated by List().
+type View struct {
+	ID        string    `json:"id"`
+	Name      string    `json:"name"`
+	CreatedAt time.Time `json:"created_at"`
+	Hash      string    `json:"-"` // always empty; never serialized
+}
+
+// Store is a thread-safe Token collection backed by a JSON file.
+type Store struct {
+	path string
+	mu   sync.RWMutex
+	toks []Token
+}
+
+// Open loads the store from path. Creates the parent directory (0700) if absent;
+// treats a missing file as an empty store. Returns error if file exists but is corrupt.
+func Open(path string) (*Store, error) {
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		return nil, fmt.Errorf("apitoken: mkdir parent: %w", err)
+	}
+	_ = os.Chmod(filepath.Dir(path), 0o700)
+
+	s := &Store{path: path}
+	data, err := os.ReadFile(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return s, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("apitoken: read %s: %w", path, err)
+	}
+	var file struct {
+		Tokens []Token `json:"tokens"`
+	}
+	if err := json.Unmarshal(data, &file); err != nil {
+		return nil, fmt.Errorf(
+			"apitoken: parse %s (file is corrupt; remove it or restore from backup): %w",
+			path, err)
+	}
+	s.toks = file.Tokens
+	return s, nil
+}
+
+// Create allocates a new token, returns its raw value once, and persists.
+func (s *Store) Create(name string) (rawToken string, tok Token, err error) {
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return "", Token{}, ErrNameRequired
+	}
+	if len(name) > MaxNameLen {
+		return "", Token{}, ErrNameTooLong
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if len(s.toks) >= MaxTokens {
+		return "", Token{}, ErrTooManyTokens
+	}
+
+	raw, err := randHex(32)
+	if err != nil {
+		return "", Token{}, err
+	}
+	id, err := randHex(13)
+	if err != nil {
+		return "", Token{}, err
+	}
+	sum := sha256.Sum256([]byte(raw))
+	tok = Token{
+		ID:        id,
+		Name:      name,
+		Hash:      hex.EncodeToString(sum[:]),
+		CreatedAt: time.Now().UTC(),
+	}
+	s.toks = append(s.toks, tok)
+	if err := s.persistLocked(); err != nil {
+		s.toks = s.toks[:len(s.toks)-1]
+		return "", Token{}, err
+	}
+	return raw, tok, nil
+}
+
+// List returns metadata for every stored token — no hash, no raw.
+func (s *Store) List() []View {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	out := make([]View, len(s.toks))
+	for i, t := range s.toks {
+		out[i] = View{ID: t.ID, Name: t.Name, CreatedAt: t.CreatedAt}
+	}
+	return out
+}
+
+// Revoke removes the token with the given id.
+func (s *Store) Revoke(id string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for i, t := range s.toks {
+		if t.ID == id {
+			prev := append([]Token(nil), s.toks...)
+			s.toks = append(s.toks[:i], s.toks[i+1:]...)
+			if err := s.persistLocked(); err != nil {
+				s.toks = prev
+				return err
+			}
+			return nil
+		}
+	}
+	return ErrNotFound
+}
+
+// Validate returns true iff raw matches a stored hash. Constant-time compare.
+func (s *Store) Validate(raw string) bool {
+	if raw == "" {
+		return false
+	}
+	sum := sha256.Sum256([]byte(raw))
+	got := hex.EncodeToString(sum[:])
+
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	for _, t := range s.toks {
+		if subtle.ConstantTimeCompare([]byte(got), []byte(t.Hash)) == 1 {
+			return true
+		}
+	}
+	return false
+}
+
+// LookupByRaw is like Validate but also returns the matching id + name for audit logs.
+func (s *Store) LookupByRaw(raw string) (id, name string, ok bool) {
+	if raw == "" {
+		return "", "", false
+	}
+	sum := sha256.Sum256([]byte(raw))
+	got := hex.EncodeToString(sum[:])
+
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	var match Token
+	matched := 0
+	for _, t := range s.toks {
+		if subtle.ConstantTimeCompare([]byte(got), []byte(t.Hash)) == 1 {
+			match = t
+			matched = 1
+		}
+	}
+	if matched == 1 {
+		return match.ID, match.Name, true
+	}
+	return "", "", false
+}
+
+// persistLocked writes atomically with fsync. Caller MUST hold s.mu write lock.
+func (s *Store) persistLocked() error {
+	dir := filepath.Dir(s.path)
+	tmp, err := os.CreateTemp(dir, "api-tokens-*.json")
+	if err != nil {
+		return fmt.Errorf("apitoken: temp file: %w", err)
+	}
+	tmpPath := tmp.Name()
+	if err := tmp.Chmod(0o600); err != nil {
+		tmp.Close()
+		os.Remove(tmpPath)
+		return fmt.Errorf("apitoken: chmod tmp: %w", err)
+	}
+	enc := json.NewEncoder(tmp)
+	enc.SetIndent("", "  ")
+	if err := enc.Encode(struct {
+		Tokens []Token `json:"tokens"`
+	}{s.toks}); err != nil {
+		tmp.Close()
+		os.Remove(tmpPath)
+		return fmt.Errorf("apitoken: encode: %w", err)
+	}
+	if err := tmp.Sync(); err != nil {
+		tmp.Close()
+		os.Remove(tmpPath)
+		return fmt.Errorf("apitoken: fsync tmp: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		os.Remove(tmpPath)
+		return fmt.Errorf("apitoken: close tmp: %w", err)
+	}
+	if err := os.Rename(tmpPath, s.path); err != nil {
+		os.Remove(tmpPath)
+		return fmt.Errorf("apitoken: rename: %w", err)
+	}
+	if d, err := os.Open(dir); err == nil {
+		if err := d.Sync(); err != nil {
+			slog.Warn("apitoken: parent dir fsync failed", "dir", dir, "err", err)
+		}
+		_ = d.Close()
+	} else {
+		slog.Warn("apitoken: could not open parent dir for fsync", "dir", dir, "err", err)
+	}
+	return nil
+}
+
+func randHex(nBytes int) (string, error) {
+	b := make([]byte, nBytes)
+	if _, err := rand.Read(b); err != nil {
+		return "", fmt.Errorf("apitoken: rand: %w", err)
+	}
+	return hex.EncodeToString(b), nil
+}

--- a/internal/auth/apitoken/store_test.go
+++ b/internal/auth/apitoken/store_test.go
@@ -1,0 +1,167 @@
+package apitoken_test
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/piaobeizu/tether/internal/auth/apitoken"
+)
+
+func newStore(t *testing.T) (*apitoken.Store, string) {
+	t.Helper()
+	dir := t.TempDir()
+	if err := os.Chmod(dir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(dir, "api-tokens.json")
+	s, err := apitoken.Open(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return s, path
+}
+
+func TestStore_CreateReturnsRawHexAndStoresHash(t *testing.T) {
+	s, _ := newStore(t)
+	raw, tok, err := s.Create("cursor-laptop")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(raw) != 64 {
+		t.Fatalf("raw should be 64 hex chars, got %d", len(raw))
+	}
+	if tok.Name != "cursor-laptop" {
+		t.Fatalf("name: %q", tok.Name)
+	}
+	if tok.Hash == "" || tok.Hash == raw {
+		t.Fatalf("hash must be set and != raw")
+	}
+	if tok.ID == "" {
+		t.Fatal("id must be set")
+	}
+}
+
+func TestStore_CreateRejectsEmptyName(t *testing.T) {
+	s, _ := newStore(t)
+	for _, name := range []string{"", "   ", "\t\n"} {
+		_, _, err := s.Create(name)
+		if !errors.Is(err, apitoken.ErrNameRequired) {
+			t.Fatalf("Create(%q) → %v; want ErrNameRequired", name, err)
+		}
+	}
+}
+
+func TestStore_CreateRejectsNameTooLong(t *testing.T) {
+	s, _ := newStore(t)
+	_, _, err := s.Create(strings.Repeat("a", 65))
+	if !errors.Is(err, apitoken.ErrNameTooLong) {
+		t.Fatalf("Create(65 chars) → %v; want ErrNameTooLong", err)
+	}
+}
+
+func TestStore_CreateEnforcesMaxTokens(t *testing.T) {
+	s, _ := newStore(t)
+	for i := 0; i < 100; i++ {
+		if _, _, err := s.Create("t"); err != nil {
+			t.Fatalf("Create #%d unexpected error: %v", i, err)
+		}
+	}
+	_, _, err := s.Create("overflow")
+	if !errors.Is(err, apitoken.ErrTooManyTokens) {
+		t.Fatalf("Create past cap → %v; want ErrTooManyTokens", err)
+	}
+}
+
+func TestStore_ValidateRoundTrip(t *testing.T) {
+	s, path := newStore(t)
+	raw, _, err := s.Create("name")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !s.Validate(raw) {
+		t.Fatal("Validate of freshly-created token must succeed")
+	}
+	s2, err := apitoken.Open(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !s2.Validate(raw) {
+		t.Fatal("Validate after round-trip must succeed")
+	}
+}
+
+func TestStore_RevokeRemovesEntry(t *testing.T) {
+	s, _ := newStore(t)
+	raw, tok, _ := s.Create("name")
+	if err := s.Revoke(tok.ID); err != nil {
+		t.Fatalf("Revoke: %v", err)
+	}
+	if s.Validate(raw) {
+		t.Fatal("Validate must fail after Revoke")
+	}
+	if err := s.Revoke(tok.ID); !errors.Is(err, apitoken.ErrNotFound) {
+		t.Fatalf("Revoke absent id → %v; want ErrNotFound", err)
+	}
+}
+
+func TestStore_ListOmitsHashAndRaw(t *testing.T) {
+	s, _ := newStore(t)
+	raw, _, _ := s.Create("name")
+	for _, tok := range s.List() {
+		if tok.Hash != "" {
+			t.Fatalf("List must not expose Hash field: %+v", tok)
+		}
+		if strings.Contains(tok.Name, raw) {
+			t.Fatal("paranoia: raw token text leaked into Name")
+		}
+	}
+}
+
+func TestStore_FilePermissionsAre0600(t *testing.T) {
+	s, path := newStore(t)
+	if _, _, err := s.Create("name"); err != nil {
+		t.Fatal(err)
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Mode().Perm() != 0o600 {
+		t.Fatalf("file mode: %o, want 0600", info.Mode().Perm())
+	}
+}
+
+func TestStore_OpenIgnoresLeftoverTmpFiles(t *testing.T) {
+	dir := t.TempDir()
+	stray := filepath.Join(dir, "api-tokens-leftover.json")
+	if err := os.WriteFile(stray, []byte("garbage"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(dir, "api-tokens.json")
+	s, err := apitoken.Open(path)
+	if err != nil {
+		t.Fatalf("Open with leftover tmp: %v", err)
+	}
+	if len(s.List()) != 0 {
+		t.Fatal("Open must ignore stray tmp files")
+	}
+}
+
+func TestStore_OpenCreatesParentDirWith0700(t *testing.T) {
+	dir := t.TempDir()
+	nested := filepath.Join(dir, "deep", "nest")
+	path := filepath.Join(nested, "api-tokens.json")
+	if _, err := apitoken.Open(path); err != nil {
+		t.Fatal(err)
+	}
+	info, err := os.Stat(nested)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Mode().Perm() != 0o700 {
+		t.Fatalf("parent dir mode: %o, want 0700", info.Mode().Perm())
+	}
+}

--- a/internal/auth/middleware.go
+++ b/internal/auth/middleware.go
@@ -114,6 +114,8 @@ func (s *State) isExempt(r *http.Request) bool {
 	case p == "/auth",
 		p == "/api/v1/auth/verify",
 		p == "/",
+		p == "/mcp",
+		strings.HasPrefix(p, "/mcp/"),
 		hasSuffix(p, ".js", ".css", ".ico", ".png", ".svg", ".woff2", ".woff", ".ttf", ".webmanifest"):
 		return true
 	}

--- a/internal/auth/middleware_test.go
+++ b/internal/auth/middleware_test.go
@@ -1,0 +1,60 @@
+package auth_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/piaobeizu/tether/internal/auth"
+)
+
+func TestMiddleware_MCPPathExempt(t *testing.T) {
+	s := auth.NewState("tok", []byte("0123456789abcdef0123456789abcdef"))
+	called := 0
+	h := s.Middleware(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		called++
+		w.WriteHeader(http.StatusOK)
+	}))
+	for _, p := range []string{"/mcp", "/mcp/foo", "/mcp/some/sub/path"} {
+		rr := httptest.NewRecorder()
+		req := httptest.NewRequest("GET", p, nil)
+		h.ServeHTTP(rr, req)
+		if rr.Code != http.StatusOK {
+			t.Fatalf("path %q: expected 200 (exempt), got %d", p, rr.Code)
+		}
+	}
+	if called != 3 {
+		t.Fatalf("inner handler hit %d times, want 3", called)
+	}
+}
+
+func TestMiddleware_APIv1MCPNotExempt(t *testing.T) {
+	s := auth.NewState("tok", []byte("0123456789abcdef0123456789abcdef"))
+	innerCalled := false
+	h := s.Middleware(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
+		innerCalled = true
+	}))
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest("POST", "/api/v1/mcp/tokens", nil)
+	h.ServeHTTP(rr, req)
+	if rr.Code != http.StatusUnauthorized {
+		t.Fatalf("unauth POST /api/v1/mcp/tokens: expected 401, got %d", rr.Code)
+	}
+	if innerCalled {
+		t.Fatal("inner handler must NOT be reached without a valid session cookie")
+	}
+}
+
+func TestMiddleware_MCPLookAlikeNotExempt(t *testing.T) {
+	s := auth.NewState("tok", []byte("0123456789abcdef0123456789abcdef"))
+	innerCalled := false
+	h := s.Middleware(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
+		innerCalled = true
+	}))
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/mcpadmin", nil)
+	h.ServeHTTP(rr, req)
+	if rr.Code == http.StatusOK || innerCalled {
+		t.Fatalf("'/mcpadmin' must NOT be exempt (got code=%d, innerCalled=%v)", rr.Code, innerCalled)
+	}
+}

--- a/internal/mcp/registry/registry.go
+++ b/internal/mcp/registry/registry.go
@@ -3,6 +3,7 @@ package registry
 
 import (
 	"fmt"
+	"log/slog"
 	"sync"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
@@ -17,11 +18,23 @@ type ToolEntry struct {
 	Tool         mcp.Tool
 }
 
+// RegistryEvent describes a tool-set change for a single server.
+type RegistryEvent struct {
+	Server  string
+	Added   []ToolEntry
+	Removed []ToolEntry
+}
+
+// Observer is a callback invoked after Register or Deregister mutates the
+// registry. Observers must be non-blocking. Panics are recovered and logged;
+// one bad observer must not prevent siblings from firing.
+type Observer func(RegistryEvent)
+
 // Registry maps prefixed tool names to their server and original name.
-// Register applies NamespacePrefix; callers pass raw tool lists.
 type Registry struct {
-	mu    sync.RWMutex
-	tools map[string]*ToolEntry // prefixed name → entry
+	mu        sync.RWMutex
+	tools     map[string]*ToolEntry
+	observers []Observer
 }
 
 // New returns an empty Registry.
@@ -29,28 +42,45 @@ func New() *Registry {
 	return &Registry{tools: make(map[string]*ToolEntry)}
 }
 
+// AddObserver registers fn to be invoked on every Register / Deregister,
+// after the write lock has been released.
+func (r *Registry) AddObserver(fn Observer) {
+	r.mu.Lock()
+	r.observers = append(r.observers, fn)
+	r.mu.Unlock()
+}
+
 // Register adds tools from serverCfg, applying namespace prefix.
 // Returns an error if any prefixed name already exists (no silent override).
 func (r *Registry) Register(serverCfg host.ServerConfig, tools []mcp.Tool) error {
 	prefix := host.NamespacePrefix(serverCfg)
+
 	r.mu.Lock()
-	defer r.mu.Unlock()
-	// Collision check first (all-or-nothing).
 	for _, t := range tools {
 		prefixed := prefix + t.Name
 		if existing, ok := r.tools[prefixed]; ok {
+			r.mu.Unlock()
 			return fmt.Errorf("mcp/registry: tool %q already registered by server %q",
 				prefixed, existing.ServerName)
 		}
 	}
+	added := make([]ToolEntry, 0, len(tools))
 	for _, t := range tools {
 		prefixed := prefix + t.Name
-		r.tools[prefixed] = &ToolEntry{
+		entry := &ToolEntry{
 			PrefixedName: prefixed,
 			OriginalName: t.Name,
 			ServerName:   serverCfg.Name,
 			Tool:         t,
 		}
+		r.tools[prefixed] = entry
+		added = append(added, *entry)
+	}
+	obsSnapshot := append([]Observer(nil), r.observers...)
+	r.mu.Unlock()
+
+	if len(added) > 0 {
+		notify(obsSnapshot, RegistryEvent{Server: serverCfg.Name, Added: added})
 	}
 	return nil
 }
@@ -58,11 +88,18 @@ func (r *Registry) Register(serverCfg host.ServerConfig, tools []mcp.Tool) error
 // Deregister removes all tools registered under serverName.
 func (r *Registry) Deregister(serverName string) {
 	r.mu.Lock()
-	defer r.mu.Unlock()
+	var removed []ToolEntry
 	for k, e := range r.tools {
 		if e.ServerName == serverName {
+			removed = append(removed, *e)
 			delete(r.tools, k)
 		}
+	}
+	obsSnapshot := append([]Observer(nil), r.observers...)
+	r.mu.Unlock()
+
+	if len(removed) > 0 {
+		notify(obsSnapshot, RegistryEvent{Server: serverName, Removed: removed})
 	}
 }
 
@@ -95,4 +132,17 @@ func (r *Registry) ListAll() []ToolEntry {
 		out = append(out, *e)
 	}
 	return out
+}
+
+func notify(observers []Observer, e RegistryEvent) {
+	for _, fn := range observers {
+		func() {
+			defer func() {
+				if rec := recover(); rec != nil {
+					slog.Error("mcp/registry: observer panicked", "panic", rec)
+				}
+			}()
+			fn(e)
+		}()
+	}
 }

--- a/internal/mcp/registry/registry_test.go
+++ b/internal/mcp/registry/registry_test.go
@@ -2,6 +2,8 @@
 package registry_test
 
 import (
+	"sync"
+	"sync/atomic"
 	"testing"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
@@ -85,4 +87,106 @@ func TestRegistryListAllEmptyAfterDeregister(t *testing.T) {
 	if len(entries) != 1 || entries[0].ServerName != "beta" {
 		t.Fatalf("expected only beta after deregister alpha: %+v", entries)
 	}
+}
+
+func TestRegistryAddObserverFiresOnRegisterAndDeregister(t *testing.T) {
+	r := registry.New()
+	var events []registry.RegistryEvent
+	var mu sync.Mutex
+	r.AddObserver(func(e registry.RegistryEvent) {
+		mu.Lock()
+		events = append(events, e)
+		mu.Unlock()
+	})
+
+	r.Register(host.ServerConfig{Name: "svc"}, tools("a", "b"))
+	r.Deregister("svc")
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(events) != 2 {
+		t.Fatalf("expected 2 events, got %d", len(events))
+	}
+	if events[0].Server != "svc" || len(events[0].Added) != 2 || len(events[0].Removed) != 0 {
+		t.Fatalf("event[0]: %+v", events[0])
+	}
+	if events[1].Server != "svc" || len(events[1].Added) != 0 || len(events[1].Removed) != 2 {
+		t.Fatalf("event[1]: %+v", events[1])
+	}
+}
+
+func TestRegistryReconnectPattern_FiresAddsAndRemoves(t *testing.T) {
+	r := registry.New()
+	var events []registry.RegistryEvent
+	r.AddObserver(func(e registry.RegistryEvent) { events = append(events, e) })
+
+	if err := r.Register(host.ServerConfig{Name: "svc"}, tools("a", "b")); err != nil {
+		t.Fatal(err)
+	}
+	r.Deregister("svc")
+	if err := r.Register(host.ServerConfig{Name: "svc"}, tools("b", "c")); err != nil {
+		t.Fatal(err)
+	}
+
+	if len(events) != 3 {
+		t.Fatalf("expected 3 events, got %d: %+v", len(events), events)
+	}
+	if events[0].Server != "svc" || len(events[0].Added) != 2 || len(events[0].Removed) != 0 {
+		t.Fatalf("event[0] (initial register): %+v", events[0])
+	}
+	if events[1].Server != "svc" || len(events[1].Added) != 0 || len(events[1].Removed) != 2 {
+		t.Fatalf("event[1] (deregister): %+v", events[1])
+	}
+	if events[2].Server != "svc" || len(events[2].Added) != 2 || len(events[2].Removed) != 0 {
+		t.Fatalf("event[2] (re-register): %+v", events[2])
+	}
+	addedNames := map[string]bool{}
+	for _, e := range events[2].Added {
+		addedNames[e.PrefixedName] = true
+	}
+	if !addedNames["svc_b"] || !addedNames["svc_c"] {
+		t.Fatalf("event[2] Added must include svc_b + svc_c, got %v", addedNames)
+	}
+}
+
+func TestRegistryRegister_CollisionOnExistingServerErrors(t *testing.T) {
+	r := registry.New()
+	if err := r.Register(host.ServerConfig{Name: "svc"}, tools("a")); err != nil {
+		t.Fatal(err)
+	}
+	if err := r.Register(host.ServerConfig{Name: "svc"}, tools("a")); err == nil {
+		t.Fatal("expected collision error on second Register of same server")
+	}
+}
+
+func TestRegistryObserverFanOut(t *testing.T) {
+	r := registry.New()
+	var c1, c2 atomic.Int32
+	r.AddObserver(func(e registry.RegistryEvent) { c1.Add(1) })
+	r.AddObserver(func(e registry.RegistryEvent) { c2.Add(1) })
+	r.Register(host.ServerConfig{Name: "svc"}, tools("a"))
+	if c1.Load() != 1 || c2.Load() != 1 {
+		t.Fatalf("both observers must fire: c1=%d c2=%d", c1.Load(), c2.Load())
+	}
+}
+
+func TestRegistryObserverPanicIsIsolated(t *testing.T) {
+	r := registry.New()
+	var goodFired atomic.Int32
+	r.AddObserver(func(e registry.RegistryEvent) { panic("boom") })
+	r.AddObserver(func(e registry.RegistryEvent) { goodFired.Add(1) })
+	r.Register(host.ServerConfig{Name: "svc"}, tools("a"))
+	if goodFired.Load() != 1 {
+		t.Fatalf("good observer must fire even when prior observer panics: %d", goodFired.Load())
+	}
+}
+
+func TestRegistryObserverFiresAfterLockRelease(t *testing.T) {
+	r := registry.New()
+	r.AddObserver(func(e registry.RegistryEvent) {
+		// If the write lock were still held, ListAll (which RLocks) would deadlock.
+		_ = r.ListAll()
+	})
+	r.Register(host.ServerConfig{Name: "svc"}, tools("a"))
+	// Reaching here without timeout proves observers run outside the write lock.
 }

--- a/internal/server/lifecycle.go
+++ b/internal/server/lifecycle.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/piaobeizu/tether/internal/agent"
 	"github.com/piaobeizu/tether/internal/auth"
+	"github.com/piaobeizu/tether/internal/auth/apitoken"
 	"github.com/piaobeizu/tether/internal/mcp/builtin"
 	mcpgw "github.com/piaobeizu/tether/internal/mcp/gateway"
 	mcphost "github.com/piaobeizu/tether/internal/mcp/host"
@@ -49,6 +50,9 @@ type Config struct {
 	MCPConfigPath string // path to [mcp.servers] config; "" = ~/.tether/config.json
 	WorkspaceRoot string // builtin tools workspace root; "" = ~/.tether/workspace
 	SkipMCPInject bool   // skip ~/.claude/settings.json injection (CI/test)
+
+	// v0.3.2: external client API token store
+	APITokensPath string // path to api-tokens.json; "" = ~/.tether/api-tokens.json
 }
 
 func (c *Config) addr() string { return fmt.Sprintf(":%d", c.Port) }
@@ -142,7 +146,7 @@ func Run(cfg *Config) error {
 		return fmt.Errorf("mcp builtin init: %w", err)
 	}
 	mcpGW := mcpgw.New(mcpMgr, mcpReg, pm, mcphost.NoopLogger())
-	mcpSrv := BuildMCPServer(mcpGW, builtins)
+	mcpSrv := BuildMCPServer(mcpGW, builtins, mcpReg)
 	bearerToken, err := generateBearerToken()
 	if err != nil {
 		return fmt.Errorf("bearer token: %w", err)
@@ -202,8 +206,18 @@ func Run(cfg *Config) error {
 	}
 	authState := auth.NewState(accessToken, jwtSecret)
 
+	// Step 4d: open API token store for external MCP clients (v0.3.2).
+	apiTokensPath := cfg.APITokensPath
+	if apiTokensPath == "" {
+		apiTokensPath = filepath.Join(tetherDir, "api-tokens.json")
+	}
+	apiTokens, err := apitoken.Open(apiTokensPath)
+	if err != nil {
+		return fmt.Errorf("api-tokens store: %w", err)
+	}
+
 	// Step 5: build and start listeners.
-	srv := newServer(cfg, bundle, pm, authState)
+	srv := newServer(cfg, bundle, pm, authState, mcpSrv, apiTokens)
 
 	errCh := make(chan error, 2)
 

--- a/internal/server/mcp_https.go
+++ b/internal/server/mcp_https.go
@@ -1,0 +1,87 @@
+package server
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"log/slog"
+	"net"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/piaobeizu/tether/internal/auth/apitoken"
+)
+
+// MCPHTTPSHandler returns an http.Handler that validates a Bearer token
+// against store before delegating to the shared mcp.Server's streamable
+// HTTP handler. Pass nil logger to use slog.Default().
+func MCPHTTPSHandler(mcpSrv *mcp.Server, store *apitoken.Store, logger *slog.Logger) http.Handler {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	sdkHandler := mcp.NewStreamableHTTPHandler(
+		func(_ *http.Request) *mcp.Server { return mcpSrv },
+		&mcp.StreamableHTTPOptions{SessionTimeout: 30 * time.Minute},
+	)
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestID := newRequestID()
+		raw, reason := extractBearer(r)
+		if reason != "" {
+			logger.Warn("mcp.apitoken.auth_failed",
+				"request_id", requestID,
+				"remote_addr", sanitiseAddr(r.RemoteAddr),
+				"reason", reason)
+			http.Error(w, "unauthorized", http.StatusUnauthorized)
+			return
+		}
+		id, name, ok := store.LookupByRaw(raw)
+		if !ok {
+			logger.Warn("mcp.apitoken.auth_failed",
+				"request_id", requestID,
+				"remote_addr", sanitiseAddr(r.RemoteAddr),
+				"reason", "unknown_token")
+			http.Error(w, "unauthorized", http.StatusUnauthorized)
+			return
+		}
+		logger.Info("mcp.apitoken.auth_ok",
+			"request_id", requestID,
+			"id", id,
+			"name", name,
+			"remote_addr", sanitiseAddr(r.RemoteAddr))
+		sdkHandler.ServeHTTP(w, r)
+	})
+}
+
+func extractBearer(r *http.Request) (raw string, reason string) {
+	h := r.Header.Get("Authorization")
+	if h == "" {
+		return "", "missing_header"
+	}
+	if !strings.HasPrefix(h, "Bearer ") {
+		return "", "bad_scheme"
+	}
+	raw = strings.TrimPrefix(h, "Bearer ")
+	if raw == "" {
+		return "", "bad_scheme"
+	}
+	return raw, ""
+}
+
+func sanitiseAddr(addr string) string {
+	if host, _, err := net.SplitHostPort(addr); err == nil {
+		return host
+	}
+	if i := strings.LastIndex(addr, ":"); i > 0 && !strings.Contains(addr, "]") {
+		return addr[:i]
+	}
+	return addr
+}
+
+func newRequestID() string {
+	b := make([]byte, 6)
+	if _, err := rand.Read(b); err != nil {
+		panic("mcp_https: crypto/rand unavailable: " + err.Error())
+	}
+	return hex.EncodeToString(b)
+}

--- a/internal/server/mcp_https_test.go
+++ b/internal/server/mcp_https_test.go
@@ -1,0 +1,235 @@
+package server_test
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/piaobeizu/tether/internal/auth/apitoken"
+	"github.com/piaobeizu/tether/internal/mcp/builtin"
+	"github.com/piaobeizu/tether/internal/mcp/gateway"
+	mcphost "github.com/piaobeizu/tether/internal/mcp/host"
+	mcpreg "github.com/piaobeizu/tether/internal/mcp/registry"
+	"github.com/piaobeizu/tether/internal/server"
+)
+
+// stubMgr / alwaysAllow / containsTool / toolNames are in testhelpers_test.go
+
+func buildTestMCPServer(t *testing.T) (*mcp.Server, *apitoken.Store) {
+	t.Helper()
+	reg := mcpreg.New()
+	gw := gateway.New(stubMgr{}, reg, alwaysAllow{}, mcphost.NoopLogger())
+	bi, err := builtin.New(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	srv := server.BuildMCPServer(gw, bi, reg)
+
+	store, err := apitoken.Open(filepath.Join(t.TempDir(), "api-tokens.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	return srv, store
+}
+
+func TestMCPHTTPS_NoAuthHeader_401(t *testing.T) {
+	srv, store := buildTestMCPServer(t)
+	h := server.MCPHTTPSHandler(srv, store, nil)
+	req := httptest.NewRequest("POST", "/mcp", strings.NewReader(`{"jsonrpc":"2.0"}`))
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+	if rr.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401, got %d", rr.Code)
+	}
+}
+
+func TestMCPHTTPS_BadBearer_401(t *testing.T) {
+	srv, store := buildTestMCPServer(t)
+	h := server.MCPHTTPSHandler(srv, store, nil)
+	req := httptest.NewRequest("POST", "/mcp", strings.NewReader(`{"jsonrpc":"2.0"}`))
+	req.Header.Set("Authorization", "Bearer not-a-real-token")
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+	if rr.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401, got %d", rr.Code)
+	}
+}
+
+func TestMCPHTTPS_ValidBearer_ReachesSDKHandler(t *testing.T) {
+	srv, store := buildTestMCPServer(t)
+	raw, _, err := store.Create("test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	h := server.MCPHTTPSHandler(srv, store, nil)
+
+	srvHTTP := httptest.NewServer(h)
+	defer srvHTTP.Close()
+
+	client := mcp.NewClient(&mcp.Implementation{Name: "ext"}, nil)
+	transport := &mcp.StreamableClientTransport{
+		Endpoint: srvHTTP.URL,
+		HTTPClient: &http.Client{
+			Transport: bearerInjector{token: raw, base: http.DefaultTransport},
+		},
+		DisableStandaloneSSE: true,
+	}
+	session, err := client.Connect(t.Context(), transport, nil)
+	if err != nil {
+		t.Fatalf("connect: %v", err)
+	}
+	defer session.Close()
+
+	got, err := session.ListTools(t.Context(), &mcp.ListToolsParams{})
+	if err != nil {
+		t.Fatalf("tools/list: %v", err)
+	}
+	found := false
+	for _, tl := range got.Tools {
+		if tl.Name == "workspace_list_files" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("workspace_list_files missing from tools/list; got %v", toolNames(got.Tools))
+	}
+}
+
+type bearerInjector struct {
+	token string
+	base  http.RoundTripper
+}
+
+func (b bearerInjector) RoundTrip(r *http.Request) (*http.Response, error) {
+	r = r.Clone(r.Context())
+	r.Header.Set("Authorization", "Bearer "+b.token)
+	return b.base.RoundTrip(r)
+}
+
+func TestMCPTokens_CreateRequiresName(t *testing.T) {
+	_, store := buildTestMCPServer(t)
+	mux := http.NewServeMux()
+	server.RegisterMCPTokensAPI(mux, store, nil)
+
+	req := httptest.NewRequest("POST", "/api/v1/mcp/tokens", strings.NewReader(`{"name":""}`))
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+	mux.ServeHTTP(rr, req)
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for empty name, got %d", rr.Code)
+	}
+}
+
+func TestMCPTokens_CreateReturnsTokenOnce(t *testing.T) {
+	_, store := buildTestMCPServer(t)
+	mux := http.NewServeMux()
+	server.RegisterMCPTokensAPI(mux, store, nil)
+
+	body := strings.NewReader(`{"name":"laptop"}`)
+	req := httptest.NewRequest("POST", "/api/v1/mcp/tokens", body)
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+	mux.ServeHTTP(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("create: %d body=%s", rr.Code, rr.Body.String())
+	}
+	var resp struct {
+		ID        string `json:"id"`
+		Name      string `json:"name"`
+		Token     string `json:"token"`
+		CreatedAt string `json:"created_at"`
+	}
+	if err := json.NewDecoder(rr.Body).Decode(&resp); err != nil {
+		t.Fatal(err)
+	}
+	if len(resp.Token) != 64 || resp.Name != "laptop" || resp.ID == "" {
+		t.Fatalf("response shape wrong: %+v", resp)
+	}
+
+	rr2 := httptest.NewRecorder()
+	mux.ServeHTTP(rr2, httptest.NewRequest("GET", "/api/v1/mcp/tokens", nil))
+	if rr2.Code != http.StatusOK {
+		t.Fatalf("list: %d", rr2.Code)
+	}
+	listBody := rr2.Body.String()
+	if strings.Contains(listBody, resp.Token) {
+		t.Fatal("list response leaked raw token")
+	}
+	if strings.Contains(listBody, "hash") {
+		t.Fatal("list response leaked hash field")
+	}
+}
+
+func TestMCPTokens_Delete_204Then404(t *testing.T) {
+	_, store := buildTestMCPServer(t)
+	raw, tok, _ := store.Create("name")
+	mux := http.NewServeMux()
+	server.RegisterMCPTokensAPI(mux, store, nil)
+
+	req := httptest.NewRequest("DELETE", "/api/v1/mcp/tokens/"+tok.ID, nil)
+	rr := httptest.NewRecorder()
+	mux.ServeHTTP(rr, req)
+	if rr.Code != http.StatusNoContent {
+		t.Fatalf("delete: %d", rr.Code)
+	}
+	if store.Validate(raw) {
+		t.Fatal("revoked token must fail Validate")
+	}
+
+	rr2 := httptest.NewRecorder()
+	mux.ServeHTTP(rr2, httptest.NewRequest("DELETE", "/api/v1/mcp/tokens/"+tok.ID, nil))
+	if rr2.Code != http.StatusNotFound {
+		t.Fatalf("delete missing: %d", rr2.Code)
+	}
+}
+
+func TestMCPHTTPS_AuditLogsOmitSecrets(t *testing.T) {
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+
+	srv, store := buildTestMCPServer(t)
+	raw, tok, _ := store.Create("laptop")
+
+	expectedHash := sha256Hex(raw)
+
+	h := server.MCPHTTPSHandler(srv, store, logger)
+	srvHTTP := httptest.NewServer(h)
+	defer srvHTTP.Close()
+
+	req, _ := http.NewRequest("POST", srvHTTP.URL+"/mcp", strings.NewReader(`{}`))
+	req.Header.Set("Authorization", "Bearer wrong")
+	_, _ = http.DefaultClient.Do(req)
+
+	req2, _ := http.NewRequest("POST", srvHTTP.URL+"/mcp", strings.NewReader(`{"jsonrpc":"2.0","method":"tools/list","id":1}`))
+	req2.Header.Set("Authorization", "Bearer "+raw)
+	_, _ = http.DefaultClient.Do(req2)
+
+	logs := buf.String()
+	if strings.Contains(logs, raw) {
+		t.Fatalf("audit log leaked raw token: %s", logs)
+	}
+	if strings.Contains(logs, expectedHash) {
+		t.Fatalf("audit log leaked token hash: %s", logs)
+	}
+	if !strings.Contains(logs, "mcp.apitoken.auth_failed") {
+		t.Fatal("missing auth_failed event")
+	}
+	if !strings.Contains(logs, "mcp.apitoken.auth_ok") {
+		t.Fatal("missing auth_ok event")
+	}
+	_ = tok
+}
+
+func sha256Hex(raw string) string {
+	sum := sha256.Sum256([]byte(raw))
+	return hex.EncodeToString(sum[:])
+}

--- a/internal/server/mcp_loopback.go
+++ b/internal/server/mcp_loopback.go
@@ -12,6 +12,7 @@ import (
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 	"github.com/piaobeizu/tether/internal/mcp/builtin"
 	"github.com/piaobeizu/tether/internal/mcp/gateway"
+	mcpreg "github.com/piaobeizu/tether/internal/mcp/registry"
 )
 
 // MCPLoopback serves the MCP Streamable HTTP endpoint on a plain HTTP loopback
@@ -23,25 +24,47 @@ type MCPLoopback struct {
 }
 
 // BuildMCPServer constructs the singleton *mcp.Server from gateway proxies and
-// builtins. Call once at daemon startup; all CC sessions share the same server
-// instance.
+// builtins. The server subscribes to registry changes so that supervisor
+// reconnects keep the tool list in sync without requiring clients to reconnect.
 //
-// NOTE: the tool list is snapshotted at construction time. Tools added by
-// supervisor reconnects after a child-server crash will not appear in
-// tools/list until the CC session reconnects. TODO(v0.4): wire srv.AddTool /
-// srv.RemoveTools to registry-change callbacks.
-func BuildMCPServer(gw *gateway.Gateway, bi *builtin.Registry) *mcp.Server {
-	srv := mcp.NewServer(&mcp.Implementation{Name: "tether", Version: "v0.3.1"}, nil)
-	for _, e := range gw.ListToolsSnapshot() {
-		entry := e // capture for closure
-		srv.AddTool(&entry.Tool, func(ctx context.Context, req *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+// Thread-safety: go-sdk Server.AddTool and Server.RemoveTools both route
+// through changeAndNotify which acquires the Server's internal mutex before
+// mutating tool state. The SDK automatically dispatches
+// notifications/tools/list_changed to every connected session.
+func BuildMCPServer(gw *gateway.Gateway, bi *builtin.Registry, reg *mcpreg.Registry) *mcp.Server {
+	srv := mcp.NewServer(&mcp.Implementation{Name: "tether", Version: "v0.3.2"}, nil)
+
+	addOne := func(entry mcpreg.ToolEntry) {
+		// Use a copy with the prefixed name so the tool appears with its
+		// namespaced name in tools/list (e.g. "svc_alpha" not "alpha").
+		t := entry.Tool
+		t.Name = entry.PrefixedName
+		srv.AddTool(&t, func(ctx context.Context, req *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 			return gw.CallTool(ctx, gateway.CallRequest{
 				ToolName:  entry.PrefixedName,
 				Arguments: req.Params.Arguments,
 			})
 		})
 	}
+
+	for _, e := range gw.ListToolsSnapshot() {
+		addOne(e)
+	}
 	bi.RegisterInto(srv)
+
+	reg.AddObserver(func(e mcpreg.RegistryEvent) {
+		if len(e.Removed) > 0 {
+			names := make([]string, len(e.Removed))
+			for i, t := range e.Removed {
+				names[i] = t.PrefixedName
+			}
+			srv.RemoveTools(names...)
+		}
+		for _, entry := range e.Added {
+			addOne(entry)
+		}
+	})
+
 	return srv
 }
 

--- a/internal/server/mcp_loopback_test.go
+++ b/internal/server/mcp_loopback_test.go
@@ -2,6 +2,7 @@ package server_test
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"testing"
@@ -30,7 +31,7 @@ func TestMCPLoopback_ToolsListAndCall(t *testing.T) {
 	const port = 19899
 	const token = "loopbacktesttoken"
 
-	mcpSrv := server.BuildMCPServer(gw, bi)
+	mcpSrv := server.BuildMCPServer(gw, bi, reg)
 	loop := server.NewMCPLoopback(port, mcpSrv, token)
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -100,4 +101,88 @@ func (bt *bearerTransport) RoundTrip(r *http.Request) (*http.Response, error) {
 	r = r.Clone(r.Context())
 	r.Header.Set("Authorization", "Bearer "+bt.token)
 	return bt.base.RoundTrip(r)
+}
+
+func TestBuildMCPServer_ObservesRegistryChanges(t *testing.T) {
+	reg := registry.New()
+	gw := gateway.New(stubMgr{}, reg, alwaysAllow{}, host.NoopLogger())
+
+	noInput := json.RawMessage(`{"type":"object"}`)
+	makeTool := func(name string) mcp.Tool {
+		return mcp.Tool{Name: name, InputSchema: noInput}
+	}
+
+	cfg := host.ServerConfig{Name: "svc"}
+	if err := reg.Register(cfg, []mcp.Tool{makeTool("alpha"), makeTool("beta")}); err != nil {
+		t.Fatal(err)
+	}
+
+	bi, err := builtin.New(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	srv := server.BuildMCPServer(gw, bi, reg)
+
+	clientT, serverT := mcp.NewInMemoryTransports()
+	go func() { _ = srv.Run(t.Context(), serverT) }()
+
+	client := mcp.NewClient(&mcp.Implementation{Name: "test"}, nil)
+	session, err := client.Connect(t.Context(), clientT, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer session.Close()
+
+	got, err := session.ListTools(t.Context(), &mcp.ListToolsParams{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !containsTool(got.Tools, "svc_alpha") || !containsTool(got.Tools, "svc_beta") {
+		t.Fatalf("expected svc_alpha + svc_beta initially, got %v", toolNames(got.Tools))
+	}
+
+	reg.Deregister("svc")
+	if err := reg.Register(cfg, []mcp.Tool{makeTool("gamma"), makeTool("delta")}); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err = session.ListTools(t.Context(), &mcp.ListToolsParams{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if containsTool(got.Tools, "svc_alpha") || containsTool(got.Tools, "svc_beta") {
+		t.Fatalf("alpha/beta must be removed after reconnect, got %v", toolNames(got.Tools))
+	}
+	if !containsTool(got.Tools, "svc_gamma") || !containsTool(got.Tools, "svc_delta") {
+		t.Fatalf("expected svc_gamma + svc_delta after reconnect, got %v", toolNames(got.Tools))
+	}
+}
+
+func TestBuildMCPServer_ObserverLatencyBudget(t *testing.T) {
+	reg := registry.New()
+	gw := gateway.New(stubMgr{}, reg, alwaysAllow{}, host.NoopLogger())
+	bi, err := builtin.New(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = server.BuildMCPServer(gw, bi, reg)
+
+	noInput := json.RawMessage(`{"type":"object"}`)
+	cfg := host.ServerConfig{Name: "bulk"}
+	toolList := make([]mcp.Tool, 100)
+	for i := range toolList {
+		toolList[i] = mcp.Tool{Name: fmt.Sprintf("t%03d", i), InputSchema: noInput}
+	}
+
+	start := time.Now()
+	if err := reg.Register(cfg, toolList); err != nil {
+		t.Fatal(err)
+	}
+	reg.Deregister("bulk")
+	dur := time.Since(start)
+
+	if dur > 100*time.Millisecond {
+		t.Fatalf("observer batch (100 add + 100 remove) took %v, budget 100ms", dur)
+	}
 }

--- a/internal/server/mcp_tokens.go
+++ b/internal/server/mcp_tokens.go
@@ -1,0 +1,71 @@
+package server
+
+import (
+	"encoding/json"
+	"errors"
+	"log/slog"
+	"net/http"
+	"time"
+
+	"github.com/piaobeizu/tether/internal/auth/apitoken"
+)
+
+// RegisterMCPTokensAPI wires POST/GET/DELETE CRUD endpoints onto mux.
+// Pass nil logger to use slog.Default().
+func RegisterMCPTokensAPI(mux *http.ServeMux, store *apitoken.Store, logger *slog.Logger) {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	mux.HandleFunc("POST /api/v1/mcp/tokens", func(w http.ResponseWriter, r *http.Request) {
+		var body struct {
+			Name string `json:"name"`
+		}
+		if err := json.NewDecoder(http.MaxBytesReader(w, r.Body, 4096)).Decode(&body); err != nil {
+			http.Error(w, "bad request", http.StatusBadRequest)
+			return
+		}
+		raw, tok, err := store.Create(body.Name)
+		if err != nil {
+			switch {
+			case errors.Is(err, apitoken.ErrNameRequired) || errors.Is(err, apitoken.ErrNameTooLong):
+				http.Error(w, "name invalid", http.StatusBadRequest)
+			case errors.Is(err, apitoken.ErrTooManyTokens):
+				http.Error(w, "token store full", http.StatusConflict)
+			default:
+				slog.Error("mcp.apitoken.create failed", "err", err)
+				http.Error(w, "internal error", http.StatusInternalServerError)
+			}
+			return
+		}
+		logger.Info("mcp.apitoken.created", "id", tok.ID, "name", tok.Name)
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(struct {
+			ID        string    `json:"id"`
+			Name      string    `json:"name"`
+			Token     string    `json:"token"`
+			CreatedAt time.Time `json:"created_at"`
+		}{tok.ID, tok.Name, raw, tok.CreatedAt})
+	})
+
+	mux.HandleFunc("GET /api/v1/mcp/tokens", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(struct {
+			Tokens []apitoken.View `json:"tokens"`
+		}{store.List()})
+	})
+
+	mux.HandleFunc("DELETE /api/v1/mcp/tokens/{id}", func(w http.ResponseWriter, r *http.Request) {
+		id := r.PathValue("id")
+		if err := store.Revoke(id); err != nil {
+			if errors.Is(err, apitoken.ErrNotFound) {
+				http.Error(w, "not found", http.StatusNotFound)
+			} else {
+				slog.Error("mcp.apitoken.revoke failed", "id", id, "err", err)
+				http.Error(w, "internal error", http.StatusInternalServerError)
+			}
+			return
+		}
+		logger.Info("mcp.apitoken.revoked", "id", id)
+		w.WriteHeader(http.StatusNoContent)
+	})
+}

--- a/internal/server/mux.go
+++ b/internal/server/mux.go
@@ -8,9 +8,11 @@ import (
 	"net/http"
 	"os"
 
+	"github.com/modelcontextprotocol/go-sdk/mcp"
 	"github.com/quic-go/webtransport-go"
 
 	"github.com/piaobeizu/tether/internal/auth"
+	"github.com/piaobeizu/tether/internal/auth/apitoken"
 	"github.com/piaobeizu/tether/internal/permission"
 	"github.com/piaobeizu/tether/internal/session"
 	"github.com/piaobeizu/tether/internal/skill"
@@ -29,7 +31,7 @@ import (
 //	/wt/shell       → PTY shell channel stub (s6)
 //	/wt/events      → broadcast events channel (s4)
 //	/wt/_smoke      → WT bidi pure-byte echo (D-22 §6 #2 acceptance gate)
-func buildMux(cfg *Config, bundle CertBundle, wts *webtransport.Server, reg *session.Registry, pm *permission.Manager, authState *auth.State) http.Handler {
+func buildMux(cfg *Config, bundle CertBundle, wts *webtransport.Server, reg *session.Registry, pm *permission.Manager, authState *auth.State, mcpSrv *mcp.Server, mcpTokens *apitoken.Store) http.Handler {
 	mux := http.NewServeMux()
 
 	derHex := HashHex(bundle.DER)
@@ -116,7 +118,15 @@ func buildMux(cfg *Config, bundle CertBundle, wts *webtransport.Server, reg *ses
 		}
 	})
 
-	registerMCPStubs(mux)
+	// /mcp on HTTPS: served by MCPHTTPSHandler when store is configured (v0.3.2+).
+	// One handler instance is shared for both patterns so the SDK's session map
+	// is not split between /mcp and /mcp/ registrations.
+	if mcpSrv != nil && mcpTokens != nil {
+		mcpH := MCPHTTPSHandler(mcpSrv, mcpTokens, nil)
+		mux.Handle("/mcp", mcpH)
+		mux.Handle("/mcp/", mcpH)
+		RegisterMCPTokensAPI(mux, mcpTokens, nil)
+	}
 
 	mux.HandleFunc("/api/v1/", func(w http.ResponseWriter, _ *http.Request) {
 		http.Error(w, "not implemented", http.StatusNotImplemented)
@@ -129,13 +139,13 @@ func buildMux(cfg *Config, bundle CertBundle, wts *webtransport.Server, reg *ses
 	mux.Handle("/", newStaticHandler(cfg.DevFrontendURL))
 
 	// Wrap all routes: origin guard first, then auth middleware outermost.
-	return authState.Middleware(withOriginGuard(cfg.Port, mux))
+	return authState.Middleware(WithOriginGuard(cfg.Port, mux))
 }
 
-// withOriginGuard rejects non-safe-method requests (POST/PUT/PATCH/DELETE) whose
+// WithOriginGuard rejects non-safe-method requests (POST/PUT/PATCH/DELETE) whose
 // Origin header is present but not in the daemon's allowlist. Requests without an
 // Origin header (curl, other trusted clients) pass through unchanged.
-func withOriginGuard(port int, h http.Handler) http.Handler {
+func WithOriginGuard(port int, h http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.Method {
 		case http.MethodGet, http.MethodHead, http.MethodOptions:
@@ -150,15 +160,6 @@ func withOriginGuard(port int, h http.Handler) http.Handler {
 	})
 }
 
-// registerMCPStubs reserves MCP URL paths returning 501 until the v0.3 MCP host is implemented.
-// Do not use /mcp or /api/v1/mcp/* for any other purpose before then.
-func registerMCPStubs(mux *http.ServeMux) {
-	stub := func(w http.ResponseWriter, r *http.Request) {
-		http.Error(w, "not implemented: MCP host not yet active", http.StatusNotImplemented)
-	}
-	mux.HandleFunc("/mcp", stub)
-	mux.HandleFunc("/api/v1/mcp/", stub)
-}
 
 // originAllowed returns true when origin matches one of the daemon's own HTTPS
 // origins (127.0.0.1, localhost, or TETHER_HOST at the given port).

--- a/internal/server/mux_mcp_test.go
+++ b/internal/server/mux_mcp_test.go
@@ -1,27 +1,41 @@
-package server
+package server_test
 
 import (
 	"net/http"
 	"net/http/httptest"
+	"path/filepath"
+	"strings"
 	"testing"
+
+	"github.com/piaobeizu/tether/internal/auth/apitoken"
+	"github.com/piaobeizu/tether/internal/server"
 )
 
-func TestMCPPathsReturn501(t *testing.T) {
-	mux := http.NewServeMux()
-	registerMCPStubs(mux)
-
-	cases := []string{
-		"/mcp",
-		"/api/v1/mcp/",
-		"/api/v1/mcp/tools",
-		"/api/v1/mcp/anything",
+func TestTokensAPI_RejectsCrossOriginPost(t *testing.T) {
+	store, err := apitoken.Open(filepath.Join(t.TempDir(), "api-tokens.json"))
+	if err != nil {
+		t.Fatal(err)
 	}
-	for _, path := range cases {
-		rec := httptest.NewRecorder()
-		r := httptest.NewRequest(http.MethodGet, path, nil)
-		mux.ServeHTTP(rec, r)
-		if rec.Code != http.StatusNotImplemented {
-			t.Errorf("path %s: expected 501, got %d", path, rec.Code)
-		}
+	mux := http.NewServeMux()
+	server.RegisterMCPTokensAPI(mux, store, nil)
+	wrapped := server.WithOriginGuard(8898, mux)
+
+	// Cross-origin POST must be 403.
+	req := httptest.NewRequest("POST", "/api/v1/mcp/tokens", strings.NewReader(`{"name":"x"}`))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Origin", "https://evil.example.com")
+	rr := httptest.NewRecorder()
+	wrapped.ServeHTTP(rr, req)
+	if rr.Code != http.StatusForbidden {
+		t.Fatalf("cross-origin POST: expected 403, got %d", rr.Code)
+	}
+
+	// Origin-absent (curl/programmatic) must pass through.
+	req2 := httptest.NewRequest("POST", "/api/v1/mcp/tokens", strings.NewReader(`{"name":"x"}`))
+	req2.Header.Set("Content-Type", "application/json")
+	rr2 := httptest.NewRecorder()
+	wrapped.ServeHTTP(rr2, req2)
+	if rr2.Code == http.StatusForbidden {
+		t.Fatalf("Origin-absent POST: expected pass-through, got 403")
 	}
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -5,11 +5,13 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/modelcontextprotocol/go-sdk/mcp"
 	"github.com/quic-go/quic-go"
 	"github.com/quic-go/quic-go/http3"
 	"github.com/quic-go/webtransport-go"
 
 	"github.com/piaobeizu/tether/internal/auth"
+	"github.com/piaobeizu/tether/internal/auth/apitoken"
 	"github.com/piaobeizu/tether/internal/permission"
 )
 
@@ -22,7 +24,7 @@ type Server struct {
 
 // newServer constructs (but does not start) the dual-listener server.
 // Call Start() to bind and serve.
-func newServer(cfg *Config, bundle CertBundle, pm *permission.Manager, authState *auth.State) *Server {
+func newServer(cfg *Config, bundle CertBundle, pm *permission.Manager, authState *auth.State, mcpSrv *mcp.Server, mcpTokens *apitoken.Store) *Server {
 	addr := cfg.addr()
 
 	// When ACME is active, certmagic provides a tls.Config with GetCertificate
@@ -68,7 +70,7 @@ func newServer(cfg *Config, bundle CertBundle, pm *permission.Manager, authState
 		CheckOrigin: func(r *http.Request) bool { return originAllowed(r.Header.Get("Origin"), cfg.Port) },
 	}
 
-	mux := buildMux(cfg, bundle, wts, cfg.Registry, pm, authState)
+	mux := buildMux(cfg, bundle, wts, cfg.Registry, pm, authState, mcpSrv, mcpTokens)
 
 	tcpServer := &http.Server{
 		Addr:      addr,

--- a/internal/server/testhelpers_test.go
+++ b/internal/server/testhelpers_test.go
@@ -1,0 +1,36 @@
+package server_test
+
+import (
+	"context"
+
+	mcphost "github.com/piaobeizu/tether/internal/mcp/host"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/piaobeizu/tether/internal/permission"
+)
+
+type stubMgr struct{}
+
+func (stubMgr) GetConn(_ string) (mcphost.ServerConn, bool) { return nil, false }
+
+type alwaysAllow struct{}
+
+func (alwaysAllow) Check(_ context.Context, _ *permission.Request) (*permission.Decision, error) {
+	return &permission.Decision{Allow: true}, nil
+}
+
+func containsTool(ts []*mcp.Tool, name string) bool {
+	for _, t := range ts {
+		if t.Name == name {
+			return true
+		}
+	}
+	return false
+}
+
+func toolNames(ts []*mcp.Tool) []string {
+	out := make([]string, len(ts))
+	for i, t := range ts {
+		out[i] = t.Name
+	}
+	return out
+}

--- a/scripts/v032-smoke.sh
+++ b/scripts/v032-smoke.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# scripts/v032-smoke.sh — local validation of v0.3.2 endpoints.
+#
+# Required env:
+#   TETHER_HOST  (default 127.0.0.1)
+#   TETHER_PORT  (default 8898)
+#
+# Optional env for end-to-end token flow:
+#   TETHER_JWT   tether_session cookie value — obtain from browser dev tools
+#                after completing the /auth flow. Without it, only unauth
+#                checks run.
+set -euo pipefail
+
+HOST="${TETHER_HOST:-127.0.0.1}"
+PORT="${TETHER_PORT:-8898}"
+BASE="https://${HOST}:${PORT}"
+
+echo "smoke: connecting to ${BASE}"
+
+# 1. Daemon liveness.
+curl -sS -k "${BASE}/cert-hash" >/dev/null && echo "✓ daemon reachable"
+
+# 2. OAuth discovery must be 404 in v0.3.2.
+code=$(curl -sS -k -o /dev/null -w '%{http_code}' "${BASE}/.well-known/oauth-authorization-server")
+[[ "$code" == "404" ]] || { echo "✗ expected 404 from well-known, got $code"; exit 1; }
+echo "✓ /.well-known/oauth-authorization-server returns 404 (deferred to v0.3.3)"
+
+# 3. /mcp without Bearer must be 401.
+code=$(curl -sS -k -o /dev/null -w '%{http_code}' -X POST "${BASE}/mcp")
+[[ "$code" == "401" ]] || { echo "✗ expected 401 from /mcp without Bearer, got $code"; exit 1; }
+echo "✓ /mcp returns 401 without Bearer"
+
+# 4. End-to-end token flow (only if TETHER_JWT provided).
+if [[ -n "${TETHER_JWT:-}" ]]; then
+  TOKEN_RESP=$(curl -sS -k \
+    -H "Cookie: tether_session=${TETHER_JWT}" \
+    -H "Content-Type: application/json" \
+    -d '{"name":"v032-smoke"}' \
+    "${BASE}/api/v1/mcp/tokens")
+  RAW=$(echo "$TOKEN_RESP" | python3 -c 'import json,sys; print(json.load(sys.stdin)["token"])')
+  ID=$(echo "$TOKEN_RESP"  | python3 -c 'import json,sys; print(json.load(sys.stdin)["id"])')
+  echo "✓ created token id=${ID}"
+
+  curl -sS -k \
+    -H "Authorization: Bearer ${RAW}" \
+    -H "Content-Type: application/json" \
+    -d '{"jsonrpc":"2.0","method":"tools/list","id":1}' \
+    -X POST "${BASE}/mcp" | grep -q '"jsonrpc"' \
+    && echo "✓ /mcp tools/list succeeded with Bearer token"
+
+  curl -sS -k -X DELETE \
+    -H "Cookie: tether_session=${TETHER_JWT}" \
+    "${BASE}/api/v1/mcp/tokens/${ID}" -o /dev/null -w '  revoke HTTP status: %{http_code}\n'
+else
+  echo "ⓘ skipping token flow (set TETHER_JWT to run end-to-end)"
+fi
+
+echo "v0.3.2 smoke OK"


### PR DESCRIPTION
## Summary

**Slice A — 动态工具列表**
- `registry.Registry` 新增 `RegistryEvent` / `Observer` / `AddObserver` + panic-isolated `notify`
- `BuildMCPServer(gw, bi, reg)` 订阅 observer：supervisor 重连触发 `RemoveTools` + `AddTool`，无需客户端重连；go-sdk 自动推 `notifications/tools/list_changed`

**Slice B — HTTPS `/mcp` + 手动 API token**
- `internal/auth/apitoken`：SHA-256 哈希 token 存储，原子 fsync 写入，MaxTokens=100，文件权限 0600
- `MCPHTTPSHandler`：Bearer 鉴权 + 审计日志（不泄露原始 token 或 hash）
- `RegisterMCPTokensAPI`：`POST/GET/DELETE /api/v1/mcp/tokens`，错误正确映射（400/409/500）
- Auth middleware 豁免 `/mcp` + `/mcp/*`
- `buildMux`：`WithOriginGuard` 导出，`registerMCPStubs` 删除，单实例 handler（避免 session map 分裂）
- `lifecycle.go`：打开 `~/.tether/api-tokens.json`，穿透到 `newServer`

## Test plan

- [x] `go test -race ./...` — 所有包 PASS
- [x] `go vet ./...` — 无输出
- [x] Final code review (Opus) — APPROVED_WITH_MINOR，两个 Important 已修

## Deferred to v0.3.3

OAuth 2.1 PKCE、Token TTL/scope/web UI、Rate limiting

🤖 Generated with [Claude Code](https://claude.com/claude-code)