### PR TITLE
feat(mcp): v0.4 per-task MCP lifecycle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## v0.3.4 — tether doctor MCP health (unreleased)
+
+### Added
+- Three new `tether doctor` checks for MCP subsystem health:
+  - `mcp-settings-inject` — verifies `~/.claude/settings.json` contains the
+    tether-managed `mcpServers.tether` entry; fails with actionable message if
+    absent (run `tether server` to inject)
+  - `mcp-api-tokens` — reports count of external API tokens in
+    `~/.tether/api-tokens.json`; informational (OK) when file is absent or empty
+  - `mcp-loopback` — TCP-connects to the MCP loopback port (default 8899,
+    read from settings); informational (OK) when server is not running
+
+### Fixed
+- `checkCCSettingsHooks` was reading `~/.config/claude/settings.json` instead of
+  `~/.claude/settings.json`; hooks check now reads the correct file so it no
+  longer always reports "hook not found" on a correctly configured system
+
 ## v0.3.3 — OAuth 2.1 PKCE (unreleased)
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,26 @@
 # Changelog
 
+## v0.3.3 — OAuth 2.1 PKCE (unreleased)
+
+### Added
+- `internal/auth/oauth/` — OAuth 2.1 Authorization Code + PKCE (S256) flow
+  - `GET /.well-known/oauth-authorization-server` — RFC 8414 discovery metadata
+  - `GET /oauth/authorize` — PKCE validation + `html/template` approval page (XSS-safe)
+  - `POST /oauth/authorize` — allow/deny form handler
+  - `POST /oauth/token` — auth code exchange; issues 24h Bearer token via `apitoken.Store`
+- `apitoken.TokenSource` typed constant (`TokenSourceManual` / `TokenSourceOAuth`), `ExpiresAt` field, `CreateWithTTL`, `StartEviction` background eviction goroutine
+- `MCPHTTPSHandler` — IP rate limiter (5 failures/60s → 429 for 5 min, bounded map)
+- Structured audit log events: `oauth.authorize.{allowed,denied,invalid_req_id}`, `oauth.token.{issued,invalid_grant}`, `mcp.bearer.{auth_ok,auth_failed,rate_limited}`
+
+### Security
+- `redirect_uri` restricted to loopback (localhost / 127.0.0.1) — prevents exfiltration
+- Approval page uses `html/template` (XSS-safe `client_id` rendering)
+- PKCE `plain` method rejected per OAuth 2.1 §7.5.1
+- Auth codes: single-use, 256-bit entropy, deleted on mismatch or expiry
+
+### Changed
+- `auth.State.isExempt` — exact-path exemptions for `/oauth/authorize`, `/oauth/token`, `/.well-known/oauth-authorization-server`
+
 ## v0.3.2 (unreleased)
 
 ### Added

--- a/internal/agent/cc_settings.go
+++ b/internal/agent/cc_settings.go
@@ -138,10 +138,13 @@ func deleteHookList(settings map[string]any, kind string) {
 	}
 }
 
-// InjectMCPServer adds mcpServers.tether to ~/.claude/settings.json.
-// It removes any existing _tether_managed entry first (idempotent).
-// token is the per-daemon bearer token injected into the Authorization header.
-func InjectMCPServer(port int, token string) error {
+// InjectMCPServer adds an MCP server entry under the given name key to
+// ~/.claude/settings.json.  name is typically "tether" for the global
+// singleton or "tether-<slug>" for a per-task instance.
+//
+// The function removes any existing entry with the same name first so the
+// operation is idempotent.  token is the per-daemon bearer token.
+func InjectMCPServer(port int, token, name string) error {
 	path, err := ccSettingsPath()
 	if err != nil {
 		return err
@@ -150,14 +153,14 @@ func InjectMCPServer(port int, token string) error {
 	if err != nil {
 		settings = map[string]any{}
 	}
-	removeManagedMCPServer(settings)
+	removeMCPServerByName(settings, name)
 
 	mcpServers, _ := settings["mcpServers"].(map[string]any)
 	if mcpServers == nil {
 		mcpServers = map[string]any{}
 		settings["mcpServers"] = mcpServers
 	}
-	mcpServers["tether"] = map[string]any{
+	mcpServers[name] = map[string]any{
 		TetherManagedKey: true,
 		"type":           "http",
 		"url":            fmt.Sprintf("http://127.0.0.1:%d/mcp", port),
@@ -168,8 +171,9 @@ func InjectMCPServer(port int, token string) error {
 	return saveSettings(path, settings)
 }
 
-// RemoveMCPServer removes the tether-managed mcpServers.tether entry from settings.json.
-func RemoveMCPServer() error {
+// RemoveMCPServer removes the named tether-managed mcpServers entry from
+// settings.json.  name should match what was passed to InjectMCPServer.
+func RemoveMCPServer(name string) error {
 	path, err := ccSettingsPath()
 	if err != nil {
 		return err
@@ -178,10 +182,12 @@ func RemoveMCPServer() error {
 	if err != nil {
 		return nil // absent = nothing to clean up
 	}
-	removeManagedMCPServer(settings)
+	removeMCPServerByName(settings, name)
 	return saveSettings(path, settings)
 }
 
+// removeManagedMCPServer removes ALL tether-managed mcpServers entries
+// (used only by the legacy path; prefer removeMCPServerByName for targeted removal).
 func removeManagedMCPServer(settings map[string]any) {
 	mcpServers, _ := settings["mcpServers"].(map[string]any)
 	if mcpServers == nil {
@@ -192,6 +198,23 @@ func removeManagedMCPServer(settings map[string]any) {
 			if managed, _ := m[TetherManagedKey].(bool); managed {
 				delete(mcpServers, k)
 			}
+		}
+	}
+	if len(mcpServers) == 0 {
+		delete(settings, "mcpServers")
+	}
+}
+
+// removeMCPServerByName removes the single named entry if it carries
+// TetherManagedKey=true.  Does nothing if absent or not managed.
+func removeMCPServerByName(settings map[string]any, name string) {
+	mcpServers, _ := settings["mcpServers"].(map[string]any)
+	if mcpServers == nil {
+		return
+	}
+	if m, ok := mcpServers[name].(map[string]any); ok {
+		if managed, _ := m[TetherManagedKey].(bool); managed {
+			delete(mcpServers, name)
 		}
 	}
 	if len(mcpServers) == 0 {

--- a/internal/agent/cc_settings_test.go
+++ b/internal/agent/cc_settings_test.go
@@ -18,7 +18,7 @@ func TestInjectAndRemoveMCPServer(t *testing.T) {
 	const port = 8899
 	const token = "testtoken123"
 
-	if err := InjectMCPServer(port, token); err != nil {
+	if err := InjectMCPServer(port, token, "tether"); err != nil {
 		t.Fatalf("InjectMCPServer: %v", err)
 	}
 
@@ -48,7 +48,7 @@ func TestInjectAndRemoveMCPServer(t *testing.T) {
 	}
 
 	// Idempotent re-inject — must not duplicate.
-	if err := InjectMCPServer(port, token); err != nil {
+	if err := InjectMCPServer(port, token, "tether"); err != nil {
 		t.Fatalf("second InjectMCPServer: %v", err)
 	}
 	data2, _ := os.ReadFile(filepath.Join(dir, ".claude", "settings.json"))
@@ -60,7 +60,7 @@ func TestInjectAndRemoveMCPServer(t *testing.T) {
 	}
 
 	// Remove.
-	if err := RemoveMCPServer(); err != nil {
+	if err := RemoveMCPServer("tether"); err != nil {
 		t.Fatalf("RemoveMCPServer: %v", err)
 	}
 	data3, _ := os.ReadFile(filepath.Join(dir, ".claude", "settings.json"))

--- a/internal/auth/apitoken/store.go
+++ b/internal/auth/apitoken/store.go
@@ -1,6 +1,7 @@
 package apitoken
 
 import (
+	"context"
 	"crypto/rand"
 	"crypto/sha256"
 	"crypto/subtle"
@@ -28,14 +29,28 @@ var (
 	ErrNotFound      = errors.New("apitoken: not found")
 )
 
+// TokenSource identifies who created a token.
+type TokenSource string
+
+const (
+	TokenSourceManual TokenSource = ""      // created via /api/v1/mcp/tokens
+	TokenSourceOAuth  TokenSource = "oauth" // issued via OAuth 2.1 PKCE flow
+
+	MaxOAuthTokens = 500
+)
+
+var ErrStoreFull = fmt.Errorf("apitoken: oauth store full (max %d)", MaxOAuthTokens)
+
 // Token is the on-disk record. Raw token is never stored — only its SHA-256 hash.
 // SHA-256 without salt is appropriate here: tokens are 32 random bytes (256-bit
 // entropy), so pre-image resistance suffices and rainbow tables are infeasible.
 type Token struct {
-	ID        string    `json:"id"`
-	Name      string    `json:"name"`
-	Hash      string    `json:"hash"`
-	CreatedAt time.Time `json:"created_at"`
+	ID        string      `json:"id"`
+	Name      string      `json:"name"`
+	Hash      string      `json:"hash"`
+	CreatedAt time.Time   `json:"created_at"`
+	ExpiresAt *time.Time  `json:"expires_at,omitempty"`
+	Source    TokenSource `json:"source,omitempty"`
 }
 
 // View is what List returns: no hash, no raw, safe to serialize to clients.
@@ -122,6 +137,55 @@ func (s *Store) Create(name string) (rawToken string, tok Token, err error) {
 	return raw, tok, nil
 }
 
+// CreateWithTTL creates a token with a finite TTL. Use TokenSourceOAuth for
+// OAuth-issued tokens; they are capped at MaxOAuthTokens with lazy eviction.
+func (s *Store) CreateWithTTL(name string, src TokenSource, ttl time.Duration) (rawToken string, tok Token, err error) {
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return "", Token{}, ErrNameRequired
+	}
+	if len(name) > MaxNameLen {
+		return "", Token{}, ErrNameTooLong
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if src == TokenSourceOAuth {
+		if s.countOAuthLocked() >= MaxOAuthTokens {
+			s.evictExpiredLocked()
+			if s.countOAuthLocked() >= MaxOAuthTokens {
+				return "", Token{}, ErrStoreFull
+			}
+		}
+	}
+
+	raw, err := randHex(32)
+	if err != nil {
+		return "", Token{}, err
+	}
+	id, err := randHex(13)
+	if err != nil {
+		return "", Token{}, err
+	}
+	sum := sha256.Sum256([]byte(raw))
+	exp := time.Now().UTC().Add(ttl)
+	tok = Token{
+		ID:        id,
+		Name:      name,
+		Hash:      hex.EncodeToString(sum[:]),
+		CreatedAt: time.Now().UTC(),
+		ExpiresAt: &exp,
+		Source:    src,
+	}
+	s.toks = append(s.toks, tok)
+	if err := s.persistLocked(); err != nil {
+		s.toks = s.toks[:len(s.toks)-1]
+		return "", Token{}, err
+	}
+	return raw, tok, nil
+}
+
 // List returns metadata for every stored token — no hash, no raw.
 func (s *Store) List() []View {
 	s.mu.RLock()
@@ -162,6 +226,9 @@ func (s *Store) Validate(raw string) bool {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 	for _, t := range s.toks {
+		if t.ExpiresAt != nil && time.Now().After(*t.ExpiresAt) {
+			continue
+		}
 		if subtle.ConstantTimeCompare([]byte(got), []byte(t.Hash)) == 1 {
 			return true
 		}
@@ -182,6 +249,9 @@ func (s *Store) LookupByRaw(raw string) (id, name string, ok bool) {
 	var match Token
 	matched := 0
 	for _, t := range s.toks {
+		if t.ExpiresAt != nil && time.Now().After(*t.ExpiresAt) {
+			continue
+		}
 		if subtle.ConstantTimeCompare([]byte(got), []byte(t.Hash)) == 1 {
 			match = t
 			matched = 1
@@ -191,6 +261,28 @@ func (s *Store) LookupByRaw(raw string) (id, name string, ok bool) {
 		return match.ID, match.Name, true
 	}
 	return "", "", false
+}
+
+func (s *Store) evictExpiredLocked() {
+	now := time.Now()
+	kept := s.toks[:0]
+	for _, t := range s.toks {
+		if t.ExpiresAt != nil && now.After(*t.ExpiresAt) {
+			continue
+		}
+		kept = append(kept, t)
+	}
+	s.toks = kept
+}
+
+func (s *Store) countOAuthLocked() int {
+	n := 0
+	for _, t := range s.toks {
+		if t.Source == TokenSourceOAuth {
+			n++
+		}
+	}
+	return n
 }
 
 // persistLocked writes atomically with fsync. Caller MUST hold s.mu write lock.
@@ -245,4 +337,26 @@ func randHex(nBytes int) (string, error) {
 		return "", fmt.Errorf("apitoken: rand: %w", err)
 	}
 	return hex.EncodeToString(b), nil
+}
+
+// StartEviction starts a background goroutine that removes expired tokens
+// every 5 minutes. It runs until ctx is cancelled.
+func (s *Store) StartEviction(ctx context.Context) {
+	go func() {
+		ticker := time.NewTicker(5 * time.Minute)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				s.mu.Lock()
+				s.evictExpiredLocked()
+				if err := s.persistLocked(); err != nil {
+					slog.Warn("apitoken: eviction persist failed", "err", err)
+				}
+				s.mu.Unlock()
+			}
+		}
+	}()
 }

--- a/internal/auth/apitoken/store_test.go
+++ b/internal/auth/apitoken/store_test.go
@@ -2,10 +2,12 @@ package apitoken_test
 
 import (
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/piaobeizu/tether/internal/auth/apitoken"
 )
@@ -163,5 +165,95 @@ func TestStore_OpenCreatesParentDirWith0700(t *testing.T) {
 	}
 	if info.Mode().Perm() != 0o700 {
 		t.Fatalf("parent dir mode: %o, want 0700", info.Mode().Perm())
+	}
+}
+
+func TestCreateWithTTL_IssuedTokenIsValid(t *testing.T) {
+	dir := t.TempDir()
+	s, err := apitoken.Open(filepath.Join(dir, "tokens.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	raw, tok, err := s.CreateWithTTL("cursor", apitoken.TokenSourceOAuth, time.Hour)
+	if err != nil {
+		t.Fatalf("CreateWithTTL: %v", err)
+	}
+	if tok.Source != apitoken.TokenSourceOAuth {
+		t.Errorf("source = %q, want %q", tok.Source, apitoken.TokenSourceOAuth)
+	}
+	if tok.ExpiresAt == nil {
+		t.Fatal("ExpiresAt should not be nil")
+	}
+	if !s.Validate(raw) {
+		t.Error("fresh token should validate")
+	}
+}
+
+func TestCreateWithTTL_ExpiredTokenSkipped(t *testing.T) {
+	dir := t.TempDir()
+	s, err := apitoken.Open(filepath.Join(dir, "tokens.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	raw, _, err := s.CreateWithTTL("goose", apitoken.TokenSourceOAuth, -time.Second)
+	if err != nil {
+		t.Fatalf("CreateWithTTL: %v", err)
+	}
+	if s.Validate(raw) {
+		t.Error("expired token should not validate")
+	}
+	_, _, ok := s.LookupByRaw(raw)
+	if ok {
+		t.Error("LookupByRaw should return false for expired token")
+	}
+}
+
+func TestCreateWithTTL_ManualTokenNeverExpires(t *testing.T) {
+	dir := t.TempDir()
+	s, err := apitoken.Open(filepath.Join(dir, "tokens.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	raw, tok, err := s.Create("manual")
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if tok.ExpiresAt != nil {
+		t.Errorf("manual token should have nil ExpiresAt, got %v", tok.ExpiresAt)
+	}
+	if !s.Validate(raw) {
+		t.Error("manual token should always validate")
+	}
+}
+
+func TestCreateWithTTL_EvictsExpiredAtCap(t *testing.T) {
+	dir := t.TempDir()
+	s, err := apitoken.Open(filepath.Join(dir, "tokens.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	for i := 0; i < apitoken.MaxOAuthTokens; i++ {
+		if _, _, err := s.CreateWithTTL(fmt.Sprintf("c%d", i), apitoken.TokenSourceOAuth, -time.Second); err != nil {
+			t.Fatalf("fill: %v", err)
+		}
+	}
+	if _, _, err := s.CreateWithTTL("new", apitoken.TokenSourceOAuth, time.Hour); err != nil {
+		t.Fatalf("post-eviction create: %v", err)
+	}
+}
+
+func TestCreateWithTTL_ErrStoreFullWhenNoneExpired(t *testing.T) {
+	dir := t.TempDir()
+	s, err := apitoken.Open(filepath.Join(dir, "tokens.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	for i := 0; i < apitoken.MaxOAuthTokens; i++ {
+		if _, _, err := s.CreateWithTTL(fmt.Sprintf("c%d", i), apitoken.TokenSourceOAuth, time.Hour); err != nil {
+			t.Fatalf("fill: %v", err)
+		}
+	}
+	if _, _, err := s.CreateWithTTL("overflow", apitoken.TokenSourceOAuth, time.Hour); !errors.Is(err, apitoken.ErrStoreFull) {
+		t.Errorf("want ErrStoreFull, got %v", err)
 	}
 }

--- a/internal/auth/middleware.go
+++ b/internal/auth/middleware.go
@@ -116,10 +116,18 @@ func (s *State) isExempt(r *http.Request) bool {
 		p == "/",
 		p == "/mcp",
 		strings.HasPrefix(p, "/mcp/"),
+		p == "/oauth/authorize",
+		p == "/oauth/token",
+		p == "/.well-known/oauth-authorization-server",
 		hasSuffix(p, ".js", ".css", ".ico", ".png", ".svg", ".woff2", ".woff", ".ttf", ".webmanifest"):
 		return true
 	}
 	return false
+}
+
+// IsExemptForTest exposes isExempt for whitebox testing.
+func (s *State) IsExemptForTest(r *http.Request) bool {
+	return s.isExempt(r)
 }
 
 func isAPIorWT(r *http.Request) bool {

--- a/internal/auth/middleware_test.go
+++ b/internal/auth/middleware_test.go
@@ -58,3 +58,32 @@ func TestMiddleware_MCPLookAlikeNotExempt(t *testing.T) {
 		t.Fatalf("'/mcpadmin' must NOT be exempt (got code=%d, innerCalled=%v)", rr.Code, innerCalled)
 	}
 }
+
+func TestIsExempt_OAuthAndWellKnownExact(t *testing.T) {
+	s := auth.NewState("tok", []byte("secret01secret02secret03secret04"))
+
+	exempt := []string{
+		"/oauth/authorize",
+		"/oauth/token",
+		"/.well-known/oauth-authorization-server",
+	}
+	notExempt := []string{
+		"/.well-known/other",
+		"/.well-known/",
+		"/oauth/",
+		"/api/v1/mcp/tokens",
+	}
+
+	for _, p := range exempt {
+		req := httptest.NewRequest("GET", p, nil)
+		if !s.IsExemptForTest(req) {
+			t.Errorf("path %q should be exempt", p)
+		}
+	}
+	for _, p := range notExempt {
+		req := httptest.NewRequest("GET", p, nil)
+		if s.IsExemptForTest(req) {
+			t.Errorf("path %q should NOT be exempt", p)
+		}
+	}
+}

--- a/internal/auth/oauth/handlers.go
+++ b/internal/auth/oauth/handlers.go
@@ -1,0 +1,260 @@
+package oauth
+
+import (
+	"encoding/json"
+	"html/template"
+	"log/slog"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/piaobeizu/tether/internal/auth/apitoken"
+)
+
+// Handlers provides the three OAuth 2.1 endpoint handlers.
+type Handlers struct {
+	codes  *CodeStore
+	tokens *apitoken.Store
+	issuer string
+	log    *slog.Logger
+}
+
+// NewHandlers creates Handlers. issuer must be https://<host>[:<port>].
+func NewHandlers(codes *CodeStore, tokens *apitoken.Store, issuer string) *Handlers {
+	return &Handlers{codes: codes, tokens: tokens, issuer: issuer, log: slog.Default()}
+}
+
+// Metadata returns the /.well-known/oauth-authorization-server handler (RFC 8414).
+func (h *Handlers) Metadata() http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"issuer":                                h.issuer,
+			"authorization_endpoint":                h.issuer + "/oauth/authorize",
+			"token_endpoint":                        h.issuer + "/oauth/token",
+			"response_types_supported":              []string{"code"},
+			"grant_types_supported":                 []string{"authorization_code"},
+			"code_challenge_methods_supported":      []string{"S256"},
+			"token_endpoint_auth_methods_supported": []string{"none"},
+			"scopes_supported":                      []string{"mcp"},
+		})
+	})
+}
+
+var approvalTmpl = template.Must(template.New("approval").Parse(`<!DOCTYPE html>
+<html><head><meta charset="utf-8">
+<title>tether — Authorize App</title>
+<style>body{font-family:sans-serif;max-width:480px;margin:4rem auto;padding:1rem}
+button{margin-right:1rem;padding:.5rem 1.5rem;font-size:1rem;cursor:pointer}</style>
+</head><body>
+<h2>tether — Authorize App</h2>
+<p><strong>{{.ClientID}}</strong> is requesting access to tether.</p>
+<p>Scope: <code>{{.Scope}}</code></p>
+<form method="POST" action="/oauth/authorize">
+  <input type="hidden" name="req_id" value="{{.ReqID}}">
+  <button name="action" value="allow" type="submit">Allow</button>
+  <button name="action" value="deny" type="submit">Deny</button>
+</form>
+</body></html>`))
+
+// Authorize handles GET (show approval page) and POST (allow/deny submit).
+func (h *Handlers) Authorize() http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodGet:
+			h.authorizeGet(w, r)
+		case http.MethodPost:
+			h.authorizePost(w, r)
+		default:
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		}
+	})
+}
+
+func (h *Handlers) authorizeGet(w http.ResponseWriter, r *http.Request) {
+	q := r.URL.Query()
+	if q.Get("response_type") != "code" {
+		http.Error(w, "invalid_request: response_type must be code", http.StatusBadRequest)
+		return
+	}
+	redirectURI := q.Get("redirect_uri")
+	if !isLoopback(redirectURI) {
+		http.Error(w, "invalid_request: redirect_uri must be loopback (localhost or 127.0.0.1)", http.StatusBadRequest)
+		return
+	}
+	clientID := q.Get("client_id")
+	challenge := q.Get("code_challenge")
+	state := q.Get("state")
+	if challenge == "" {
+		oauthRedirectError(w, r, redirectURI, "invalid_request", "code_challenge required", state)
+		return
+	}
+	if q.Get("code_challenge_method") != "S256" {
+		oauthRedirectError(w, r, redirectURI, "invalid_request", "only S256 supported", state)
+		return
+	}
+	scope := q.Get("scope")
+	if scope != "mcp" {
+		scope = "mcp"
+	}
+	reqID, err := h.codes.StorePending(clientID, redirectURI, challenge, scope, state)
+	if err != nil {
+		h.log.Error("oauth.authorize.store_failed", "err", err)
+		http.Error(w, "server_error", http.StatusInternalServerError)
+		return
+	}
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	_ = approvalTmpl.Execute(w, struct {
+		ClientID string
+		Scope    string
+		ReqID    string
+	}{clientID, scope, reqID})
+}
+
+func (h *Handlers) authorizePost(w http.ResponseWriter, r *http.Request) {
+	if err := r.ParseForm(); err != nil {
+		http.Error(w, "bad request", http.StatusBadRequest)
+		return
+	}
+	reqID := r.FormValue("req_id")
+	action := r.FormValue("action")
+	ip := remoteIP(r)
+
+	p, err := h.codes.ConsumePending(reqID)
+	if err != nil {
+		h.log.Warn("oauth.authorize.invalid_req_id", "remote_ip", ip)
+		http.Error(w, "invalid or expired authorization request", http.StatusBadRequest)
+		return
+	}
+	if action == "deny" {
+		h.log.Info("oauth.authorize.denied", "client_id", p.ClientID, "remote_ip", ip)
+		oauthRedirectError(w, r, p.RedirectURI, "access_denied", "", p.State)
+		return
+	}
+	code, err := h.codes.StoreCode(p)
+	if err != nil {
+		h.log.Error("oauth.authorize.store_code_failed", "err", err)
+		http.Error(w, "server_error", http.StatusInternalServerError)
+		return
+	}
+	h.log.Info("oauth.authorize.allowed", "client_id", p.ClientID, "scope", p.Scope, "remote_ip", ip)
+	u, _ := url.Parse(p.RedirectURI)
+	qv := u.Query()
+	qv.Set("code", code)
+	if p.State != "" {
+		qv.Set("state", p.State)
+	}
+	u.RawQuery = qv.Encode()
+	http.Redirect(w, r, u.String(), http.StatusFound)
+}
+
+// Token handles POST /oauth/token — exchanges an auth code for a Bearer token.
+func (h *Handlers) Token() http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+		r.Body = http.MaxBytesReader(w, r.Body, 8192)
+		if err := r.ParseForm(); err != nil {
+			oauthTokenError(w, "invalid_request", "malformed body")
+			return
+		}
+		if r.FormValue("grant_type") != "authorization_code" {
+			oauthTokenError(w, "unsupported_grant_type", "only authorization_code is supported")
+			return
+		}
+		clientID := r.FormValue("client_id")
+		redirectURI := r.FormValue("redirect_uri")
+		verifier := r.FormValue("code_verifier")
+
+		p, err := h.codes.ConsumeCode(r.FormValue("code"))
+		if err != nil {
+			h.log.Warn("oauth.token.invalid_grant", "reason", "code_not_found", "client_id", clientID)
+			oauthTokenError(w, "invalid_grant", "code not found or expired")
+			return
+		}
+		if p.ClientID != clientID {
+			h.log.Warn("oauth.token.invalid_grant", "reason", "client_id_mismatch", "client_id", clientID)
+			oauthTokenError(w, "invalid_grant", "client_id mismatch")
+			return
+		}
+		if p.RedirectURI != redirectURI {
+			h.log.Warn("oauth.token.invalid_grant", "reason", "redirect_uri_mismatch", "client_id", clientID)
+			oauthTokenError(w, "invalid_grant", "redirect_uri mismatch")
+			return
+		}
+		if !VerifyS256(verifier, p.Challenge) {
+			h.log.Warn("oauth.token.invalid_grant", "reason", "pkce_failure", "client_id", clientID)
+			oauthTokenError(w, "invalid_grant", "code_verifier mismatch")
+			return
+		}
+		raw, tok, err := h.tokens.CreateWithTTL(clientID, apitoken.TokenSourceOAuth, 24*time.Hour)
+		if err != nil {
+			h.log.Error("oauth.token.store_failed", "err", err)
+			http.Error(w, "server_error", http.StatusInternalServerError)
+			return
+		}
+		h.log.Info("oauth.token.issued", "client_id", clientID, "token_id", tok.ID, "expires_at", tok.ExpiresAt)
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"access_token": raw,
+			"token_type":   "Bearer",
+			"expires_in":   int64(24 * time.Hour / time.Second),
+			"scope":        p.Scope,
+		})
+	})
+}
+
+func isLoopback(rawURL string) bool {
+	if rawURL == "" {
+		return false
+	}
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return false
+	}
+	h := u.Hostname()
+	return h == "localhost" || h == "127.0.0.1"
+}
+
+func oauthRedirectError(w http.ResponseWriter, r *http.Request, redirectURI, errCode, desc, state string) {
+	u, _ := url.Parse(redirectURI)
+	q := u.Query()
+	q.Set("error", errCode)
+	if desc != "" {
+		q.Set("error_description", desc)
+	}
+	if state != "" {
+		q.Set("state", state)
+	}
+	u.RawQuery = q.Encode()
+	http.Redirect(w, r, u.String(), http.StatusFound)
+}
+
+func oauthTokenError(w http.ResponseWriter, errCode, desc string) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusBadRequest)
+	_ = json.NewEncoder(w).Encode(map[string]string{
+		"error":             errCode,
+		"error_description": desc,
+	})
+}
+
+func remoteIP(r *http.Request) string {
+	if h := r.Header.Get("X-Real-IP"); h != "" {
+		return h
+	}
+	addr := r.RemoteAddr
+	// IPv6: [::1]:port
+	if strings.HasPrefix(addr, "[") {
+		if end := strings.Index(addr, "]"); end > 0 {
+			return addr[1:end]
+		}
+	}
+	if i := strings.LastIndex(addr, ":"); i > 0 {
+		return addr[:i]
+	}
+	return addr
+}

--- a/internal/auth/oauth/handlers.go
+++ b/internal/auth/oauth/handlers.go
@@ -216,7 +216,7 @@ func isLoopback(rawURL string) bool {
 		return false
 	}
 	h := u.Hostname()
-	return h == "localhost" || h == "127.0.0.1"
+	return h == "localhost" || h == "127.0.0.1" || h == "::1"
 }
 
 func oauthRedirectError(w http.ResponseWriter, r *http.Request, redirectURI, errCode, desc, state string) {
@@ -243,9 +243,6 @@ func oauthTokenError(w http.ResponseWriter, errCode, desc string) {
 }
 
 func remoteIP(r *http.Request) string {
-	if h := r.Header.Get("X-Real-IP"); h != "" {
-		return h
-	}
 	addr := r.RemoteAddr
 	// IPv6: [::1]:port
 	if strings.HasPrefix(addr, "[") {

--- a/internal/auth/oauth/handlers_test.go
+++ b/internal/auth/oauth/handlers_test.go
@@ -1,0 +1,394 @@
+package oauth_test
+
+import (
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/piaobeizu/tether/internal/auth/apitoken"
+	"github.com/piaobeizu/tether/internal/auth/oauth"
+)
+
+func makeHandlers(t *testing.T) (*oauth.Handlers, *apitoken.Store) {
+	t.Helper()
+	tokens, err := apitoken.Open(filepath.Join(t.TempDir(), "tokens.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	cs := oauth.NewCodeStore()
+	h := oauth.NewHandlers(cs, tokens, "https://localhost:8897")
+	return h, tokens
+}
+
+func pkceTestPair() (verifier, challenge string) {
+	verifier = "dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk"
+	sum := sha256.Sum256([]byte(verifier))
+	challenge = base64.RawURLEncoding.EncodeToString(sum[:])
+	return
+}
+
+// --- Metadata ---
+
+func TestMetadata(t *testing.T) {
+	h, _ := makeHandlers(t)
+	req := httptest.NewRequest("GET", "/.well-known/oauth-authorization-server", nil)
+	w := httptest.NewRecorder()
+	h.Metadata().ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d", w.Code)
+	}
+	var m map[string]any
+	if err := json.NewDecoder(w.Body).Decode(&m); err != nil {
+		t.Fatal(err)
+	}
+	if m["issuer"] != "https://localhost:8897" {
+		t.Errorf("issuer = %v", m["issuer"])
+	}
+	methods, _ := m["code_challenge_methods_supported"].([]any)
+	if len(methods) != 1 || methods[0] != "S256" {
+		t.Errorf("methods = %v", methods)
+	}
+}
+
+// --- Authorize GET ---
+
+func authorizeURL(challenge string, extra url.Values) string {
+	v := url.Values{
+		"response_type":         {"code"},
+		"client_id":             {"test-client"},
+		"redirect_uri":          {"http://localhost:12345/callback"},
+		"code_challenge":        {challenge},
+		"code_challenge_method": {"S256"},
+	}
+	for k, vals := range extra {
+		v[k] = vals
+	}
+	return "/oauth/authorize?" + v.Encode()
+}
+
+func TestAuthorizeGet_ValidRequest_ShowsApprovalPage(t *testing.T) {
+	h, _ := makeHandlers(t)
+	_, challenge := pkceTestPair()
+	req := httptest.NewRequest("GET", authorizeURL(challenge, nil), nil)
+	w := httptest.NewRecorder()
+	h.Authorize().ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", w.Code, w.Body.String())
+	}
+	body := w.Body.String()
+	if !strings.Contains(body, "test-client") {
+		t.Error("approval page should display client_id")
+	}
+	if !strings.Contains(body, `name="req_id"`) {
+		t.Error("form should contain req_id hidden input")
+	}
+}
+
+func TestAuthorizeGet_XSSClientID_IsEscaped(t *testing.T) {
+	h, _ := makeHandlers(t)
+	_, challenge := pkceTestPair()
+	xssID := `<script>alert(1)</script>`
+	req := httptest.NewRequest("GET", authorizeURL(challenge, url.Values{"client_id": {xssID}}), nil)
+	w := httptest.NewRecorder()
+	h.Authorize().ServeHTTP(w, req)
+
+	body := w.Body.String()
+	if strings.Contains(body, "<script>") {
+		t.Error("client_id must be HTML-escaped in the approval page")
+	}
+}
+
+func TestAuthorizeGet_NonLoopbackRedirectURI_Rejects(t *testing.T) {
+	h, _ := makeHandlers(t)
+	_, challenge := pkceTestPair()
+	req := httptest.NewRequest("GET", authorizeURL(challenge, url.Values{"redirect_uri": {"https://evil.example.com/steal"}}), nil)
+	w := httptest.NewRecorder()
+	h.Authorize().ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("want 400, got %d", w.Code)
+	}
+}
+
+func TestAuthorizeGet_MissingCodeChallenge_Redirects(t *testing.T) {
+	h, _ := makeHandlers(t)
+	// No code_challenge but valid redirect_uri → redirect with error
+	v := url.Values{
+		"response_type":         {"code"},
+		"client_id":             {"c"},
+		"redirect_uri":          {"http://localhost:12345/callback"},
+		"code_challenge_method": {"S256"},
+	}
+	req := httptest.NewRequest("GET", "/oauth/authorize?"+v.Encode(), nil)
+	w := httptest.NewRecorder()
+	h.Authorize().ServeHTTP(w, req)
+
+	if w.Code != http.StatusFound {
+		t.Fatalf("want 302, got %d", w.Code)
+	}
+	loc := w.Header().Get("Location")
+	if !strings.Contains(loc, "error=invalid_request") {
+		t.Errorf("expected error in redirect, got %s", loc)
+	}
+}
+
+func TestAuthorizeGet_PlainPKCE_Rejects(t *testing.T) {
+	h, _ := makeHandlers(t)
+	_, challenge := pkceTestPair()
+	req := httptest.NewRequest("GET", authorizeURL(challenge, url.Values{"code_challenge_method": {"plain"}}), nil)
+	w := httptest.NewRecorder()
+	h.Authorize().ServeHTTP(w, req)
+
+	if w.Code != http.StatusFound {
+		t.Fatalf("want 302, got %d", w.Code)
+	}
+	if !strings.Contains(w.Header().Get("Location"), "error=invalid_request") {
+		t.Error("plain PKCE should produce invalid_request redirect")
+	}
+}
+
+// --- Authorize POST ---
+
+func reqIDFromApprovalPage(t *testing.T, h *oauth.Handlers) string {
+	t.Helper()
+	_, challenge := pkceTestPair()
+	req := httptest.NewRequest("GET", authorizeURL(challenge, nil), nil)
+	w := httptest.NewRecorder()
+	h.Authorize().ServeHTTP(w, req)
+	body := w.Body.String()
+	start := strings.Index(body, `name="req_id" value="`)
+	if start < 0 {
+		t.Fatal("req_id not found in approval page")
+	}
+	start += len(`name="req_id" value="`)
+	end := strings.Index(body[start:], `"`)
+	return body[start : start+end]
+}
+
+func TestAuthorizePost_Allow_IssuesCodeAndRedirects(t *testing.T) {
+	h, _ := makeHandlers(t)
+	reqID := reqIDFromApprovalPage(t, h)
+
+	form := url.Values{"req_id": {reqID}, "action": {"allow"}}
+	req := httptest.NewRequest("POST", "/oauth/authorize", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	w := httptest.NewRecorder()
+	h.Authorize().ServeHTTP(w, req)
+
+	if w.Code != http.StatusFound {
+		t.Fatalf("want 302, got %d: %s", w.Code, w.Body.String())
+	}
+	loc := w.Header().Get("Location")
+	if !strings.HasPrefix(loc, "http://localhost:12345/callback?") {
+		t.Errorf("unexpected redirect: %s", loc)
+	}
+	u, _ := url.Parse(loc)
+	if u.Query().Get("code") == "" {
+		t.Error("redirect should contain code param")
+	}
+}
+
+func TestAuthorizePost_Deny_RedirectsWithAccessDenied(t *testing.T) {
+	h, _ := makeHandlers(t)
+	reqID := reqIDFromApprovalPage(t, h)
+
+	form := url.Values{"req_id": {reqID}, "action": {"deny"}}
+	req := httptest.NewRequest("POST", "/oauth/authorize", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	w := httptest.NewRecorder()
+	h.Authorize().ServeHTTP(w, req)
+
+	if w.Code != http.StatusFound {
+		t.Fatalf("want 302, got %d", w.Code)
+	}
+	if !strings.Contains(w.Header().Get("Location"), "error=access_denied") {
+		t.Errorf("expected access_denied in redirect, got %s", w.Header().Get("Location"))
+	}
+}
+
+func TestAuthorizePost_ExpiredReqID_Returns400(t *testing.T) {
+	h, _ := makeHandlers(t)
+	form := url.Values{"req_id": {"doesnotexist"}, "action": {"allow"}}
+	req := httptest.NewRequest("POST", "/oauth/authorize", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	w := httptest.NewRecorder()
+	h.Authorize().ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("want 400, got %d", w.Code)
+	}
+}
+
+// --- Token endpoint ---
+
+// fullPKCECode performs GET+POST authorize and returns the issued code + verifier.
+func fullPKCECode(t *testing.T, h *oauth.Handlers) (code, verifier string) {
+	t.Helper()
+	verifier, challenge := pkceTestPair()
+
+	v := url.Values{
+		"response_type":         {"code"},
+		"client_id":             {"cursor"},
+		"redirect_uri":          {"http://localhost:12345/callback"},
+		"code_challenge":        {challenge},
+		"code_challenge_method": {"S256"},
+		"state":                 {"xyz"},
+	}
+	req := httptest.NewRequest("GET", "/oauth/authorize?"+v.Encode(), nil)
+	w := httptest.NewRecorder()
+	h.Authorize().ServeHTTP(w, req)
+	body := w.Body.String()
+	start := strings.Index(body, `name="req_id" value="`)
+	start += len(`name="req_id" value="`)
+	end := strings.Index(body[start:], `"`)
+	reqID := body[start : start+end]
+
+	form := url.Values{"req_id": {reqID}, "action": {"allow"}}
+	req2 := httptest.NewRequest("POST", "/oauth/authorize", strings.NewReader(form.Encode()))
+	req2.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	w2 := httptest.NewRecorder()
+	h.Authorize().ServeHTTP(w2, req2)
+	loc := w2.Header().Get("Location")
+	u, _ := url.Parse(loc)
+	return u.Query().Get("code"), verifier
+}
+
+func TestToken_HappyPath(t *testing.T) {
+	h, tokens := makeHandlers(t)
+	code, verifier := fullPKCECode(t, h)
+
+	form := url.Values{
+		"grant_type":    {"authorization_code"},
+		"code":          {code},
+		"code_verifier": {verifier},
+		"redirect_uri":  {"http://localhost:12345/callback"},
+		"client_id":     {"cursor"},
+	}
+	req := httptest.NewRequest("POST", "/oauth/token", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	w := httptest.NewRecorder()
+	h.Token().ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("want 200, got %d: %s", w.Code, w.Body.String())
+	}
+	var resp map[string]any
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatal(err)
+	}
+	raw, _ := resp["access_token"].(string)
+	if raw == "" {
+		t.Fatal("expected non-empty access_token")
+	}
+	if resp["token_type"] != "Bearer" {
+		t.Errorf("token_type = %v", resp["token_type"])
+	}
+	if resp["expires_in"] != float64(86400) {
+		t.Errorf("expires_in = %v, want 86400", resp["expires_in"])
+	}
+	if !tokens.Validate(raw) {
+		t.Error("issued token should be valid in apitoken store")
+	}
+}
+
+func TestToken_Replay_Returns400(t *testing.T) {
+	h, _ := makeHandlers(t)
+	code, verifier := fullPKCECode(t, h)
+
+	exchange := func() int {
+		form := url.Values{
+			"grant_type":    {"authorization_code"},
+			"code":          {code},
+			"code_verifier": {verifier},
+			"redirect_uri":  {"http://localhost:12345/callback"},
+			"client_id":     {"cursor"},
+		}
+		req := httptest.NewRequest("POST", "/oauth/token", strings.NewReader(form.Encode()))
+		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+		w := httptest.NewRecorder()
+		h.Token().ServeHTTP(w, req)
+		return w.Code
+	}
+	if exchange() != http.StatusOK {
+		t.Fatal("first exchange should succeed")
+	}
+	if exchange() != http.StatusBadRequest {
+		t.Fatal("replay should return 400")
+	}
+}
+
+func TestToken_WrongVerifier_Returns400(t *testing.T) {
+	h, _ := makeHandlers(t)
+	code, _ := fullPKCECode(t, h)
+
+	form := url.Values{
+		"grant_type":    {"authorization_code"},
+		"code":          {code},
+		"code_verifier": {"wrong-verifier"},
+		"redirect_uri":  {"http://localhost:12345/callback"},
+		"client_id":     {"cursor"},
+	}
+	req := httptest.NewRequest("POST", "/oauth/token", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	w := httptest.NewRecorder()
+	h.Token().ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("want 400, got %d", w.Code)
+	}
+	body, _ := io.ReadAll(w.Body)
+	if !strings.Contains(string(body), "invalid_grant") {
+		t.Errorf("want invalid_grant in body, got: %s", body)
+	}
+}
+
+func TestToken_ClientIDMismatch_Returns400(t *testing.T) {
+	h, _ := makeHandlers(t)
+	code, verifier := fullPKCECode(t, h)
+
+	form := url.Values{
+		"grant_type":    {"authorization_code"},
+		"code":          {code},
+		"code_verifier": {verifier},
+		"redirect_uri":  {"http://localhost:12345/callback"},
+		"client_id":     {"wrong-client"},
+	}
+	req := httptest.NewRequest("POST", "/oauth/token", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	w := httptest.NewRecorder()
+	h.Token().ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("want 400, got %d", w.Code)
+	}
+}
+
+func TestToken_RedirectURIMismatch_Returns400(t *testing.T) {
+	h, _ := makeHandlers(t)
+	code, verifier := fullPKCECode(t, h)
+
+	form := url.Values{
+		"grant_type":    {"authorization_code"},
+		"code":          {code},
+		"code_verifier": {verifier},
+		"redirect_uri":  {"http://localhost:9999/other"},
+		"client_id":     {"cursor"},
+	}
+	req := httptest.NewRequest("POST", "/oauth/token", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	w := httptest.NewRecorder()
+	h.Token().ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("want 400, got %d", w.Code)
+	}
+}

--- a/internal/auth/oauth/pkce.go
+++ b/internal/auth/oauth/pkce.go
@@ -1,0 +1,18 @@
+package oauth
+
+import (
+	"crypto/sha256"
+	"encoding/base64"
+)
+
+// VerifyS256 returns true iff BASE64URL(SHA256(verifier)) == challenge.
+// Both inputs must be non-empty. Only S256 is supported (plain is rejected
+// per OAuth 2.1 §7.5.1).
+func VerifyS256(verifier, challenge string) bool {
+	if verifier == "" || challenge == "" {
+		return false
+	}
+	sum := sha256.Sum256([]byte(verifier))
+	got := base64.RawURLEncoding.EncodeToString(sum[:])
+	return got == challenge
+}

--- a/internal/auth/oauth/pkce_test.go
+++ b/internal/auth/oauth/pkce_test.go
@@ -1,0 +1,36 @@
+package oauth_test
+
+import (
+	"crypto/sha256"
+	"encoding/base64"
+	"testing"
+
+	"github.com/piaobeizu/tether/internal/auth/oauth"
+)
+
+func TestVerifyS256_Valid(t *testing.T) {
+	verifier := "dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk"
+	sum := sha256.Sum256([]byte(verifier))
+	challenge := base64.RawURLEncoding.EncodeToString(sum[:])
+	if !oauth.VerifyS256(verifier, challenge) {
+		t.Error("expected true for correct S256 pair")
+	}
+}
+
+func TestVerifyS256_WrongVerifier(t *testing.T) {
+	verifier := "dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk"
+	sum := sha256.Sum256([]byte(verifier))
+	challenge := base64.RawURLEncoding.EncodeToString(sum[:])
+	if oauth.VerifyS256("wrong-verifier", challenge) {
+		t.Error("expected false for wrong verifier")
+	}
+}
+
+func TestVerifyS256_EmptyInputs(t *testing.T) {
+	if oauth.VerifyS256("", "anything") {
+		t.Error("empty verifier should return false")
+	}
+	if oauth.VerifyS256("anything", "") {
+		t.Error("empty challenge should return false")
+	}
+}

--- a/internal/auth/oauth/store.go
+++ b/internal/auth/oauth/store.go
@@ -1,0 +1,124 @@
+package oauth
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"errors"
+	"sync"
+	"time"
+)
+
+const defaultTTL = 5 * time.Minute
+
+// ErrNotFound is returned when a code or pending request is absent or expired.
+var ErrNotFound = errors.New("oauth: not found or expired")
+
+// PendingRequest holds the parameters from GET /oauth/authorize.
+type PendingRequest struct {
+	ClientID    string
+	RedirectURI string
+	Challenge   string
+	Scope       string
+	State       string
+}
+
+type pendingEntry struct {
+	PendingRequest
+	expiresAt time.Time
+}
+
+type codeEntry struct {
+	PendingRequest
+	expiresAt time.Time
+}
+
+// CodeStore manages pending requests and single-use auth codes in memory.
+// All state is cleared on daemon restart.
+type CodeStore struct {
+	ttl     time.Duration
+	mu      sync.Mutex
+	pending map[string]pendingEntry
+	codes   map[string]codeEntry
+}
+
+// NewCodeStore returns a CodeStore with the default 5-minute TTL.
+func NewCodeStore() *CodeStore {
+	return NewCodeStoreWithTTL(defaultTTL)
+}
+
+// NewCodeStoreWithTTL allows overriding TTL for tests.
+func NewCodeStoreWithTTL(ttl time.Duration) *CodeStore {
+	return &CodeStore{
+		ttl:     ttl,
+		pending: make(map[string]pendingEntry),
+		codes:   make(map[string]codeEntry),
+	}
+}
+
+// StorePending stores the authorization request and returns a random req_id.
+func (s *CodeStore) StorePending(clientID, redirectURI, challenge, scope, state string) (reqID string, err error) {
+	id, err := randID()
+	if err != nil {
+		return "", err
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.pending[id] = pendingEntry{
+		PendingRequest: PendingRequest{
+			ClientID:    clientID,
+			RedirectURI: redirectURI,
+			Challenge:   challenge,
+			Scope:       scope,
+			State:       state,
+		},
+		expiresAt: time.Now().Add(s.ttl),
+	}
+	return id, nil
+}
+
+// ConsumePending retrieves and deletes the pending request for reqID.
+// Returns ErrNotFound if absent or expired.
+func (s *CodeStore) ConsumePending(reqID string) (PendingRequest, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	e, ok := s.pending[reqID]
+	delete(s.pending, reqID)
+	if !ok || time.Now().After(e.expiresAt) {
+		return PendingRequest{}, ErrNotFound
+	}
+	return e.PendingRequest, nil
+}
+
+// StoreCode stores a single-use auth code for the given pending request.
+func (s *CodeStore) StoreCode(p PendingRequest) (code string, err error) {
+	c, err := randID()
+	if err != nil {
+		return "", err
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.codes[c] = codeEntry{PendingRequest: p, expiresAt: time.Now().Add(s.ttl)}
+	return c, nil
+}
+
+// ConsumeCode retrieves and deletes the auth code (single-use).
+// Returns ErrNotFound if absent or expired. The code is always deleted,
+// even on expiry, to prevent timing attacks.
+func (s *CodeStore) ConsumeCode(code string) (PendingRequest, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	e, ok := s.codes[code]
+	delete(s.codes, code) // always delete
+	if !ok || time.Now().After(e.expiresAt) {
+		return PendingRequest{}, ErrNotFound
+	}
+	return e.PendingRequest, nil
+}
+
+func randID() (string, error) {
+	b := make([]byte, 32)
+	if _, err := rand.Read(b); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(b), nil
+}

--- a/internal/auth/oauth/store_test.go
+++ b/internal/auth/oauth/store_test.go
@@ -1,0 +1,81 @@
+package oauth_test
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/piaobeizu/tether/internal/auth/oauth"
+)
+
+func TestCodeStore_PendingHappyPath(t *testing.T) {
+	s := oauth.NewCodeStore()
+	reqID, err := s.StorePending("cursor", "http://localhost:1234/cb", "challenge", "mcp", "state1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	p, err := s.ConsumePending(reqID)
+	if err != nil {
+		t.Fatalf("ConsumePending: %v", err)
+	}
+	if p.ClientID != "cursor" || p.RedirectURI != "http://localhost:1234/cb" {
+		t.Errorf("unexpected pending: %+v", p)
+	}
+	// Second consume must fail (single-use).
+	if _, err := s.ConsumePending(reqID); !errors.Is(err, oauth.ErrNotFound) {
+		t.Errorf("second consume: want ErrNotFound, got %v", err)
+	}
+}
+
+func TestCodeStore_PendingExpiry(t *testing.T) {
+	s := oauth.NewCodeStoreWithTTL(-time.Second) // already expired
+	reqID, err := s.StorePending("goose", "http://localhost:5678/cb", "c", "mcp", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := s.ConsumePending(reqID); !errors.Is(err, oauth.ErrNotFound) {
+		t.Errorf("want ErrNotFound for expired pending, got %v", err)
+	}
+}
+
+func TestCodeStore_AuthCodeHappyPath(t *testing.T) {
+	s := oauth.NewCodeStore()
+	p := oauth.PendingRequest{
+		ClientID:    "cursor",
+		RedirectURI: "http://localhost:1234/cb",
+		Challenge:   "challenge",
+		Scope:       "mcp",
+		State:       "s",
+	}
+	code, err := s.StoreCode(p)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, err := s.ConsumeCode(code)
+	if err != nil {
+		t.Fatalf("ConsumeCode: %v", err)
+	}
+	if got.ClientID != "cursor" {
+		t.Errorf("unexpected client_id: %s", got.ClientID)
+	}
+	// Replay must fail.
+	if _, err := s.ConsumeCode(code); !errors.Is(err, oauth.ErrNotFound) {
+		t.Errorf("replay: want ErrNotFound, got %v", err)
+	}
+}
+
+func TestCodeStore_AuthCodeExpiry(t *testing.T) {
+	s := oauth.NewCodeStoreWithTTL(-time.Second)
+	p := oauth.PendingRequest{ClientID: "x", RedirectURI: "http://localhost/cb", Challenge: "c", Scope: "mcp"}
+	code, _ := s.StoreCode(p)
+	if _, err := s.ConsumeCode(code); !errors.Is(err, oauth.ErrNotFound) {
+		t.Errorf("want ErrNotFound for expired code, got %v", err)
+	}
+}
+
+func TestCodeStore_UnknownReqID(t *testing.T) {
+	s := oauth.NewCodeStore()
+	if _, err := s.ConsumePending("doesnotexist"); !errors.Is(err, oauth.ErrNotFound) {
+		t.Errorf("want ErrNotFound, got %v", err)
+	}
+}

--- a/internal/doctor/doctor.go
+++ b/internal/doctor/doctor.go
@@ -7,6 +7,7 @@ import (
 	"encoding/pem"
 	"fmt"
 	"net"
+	"net/url"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -39,6 +40,9 @@ func Run(port int, verbose bool) Report {
 		checkCertState(verbose),
 		checkPortBindable(port, verbose),
 		checkCCSettingsHooks(verbose),
+		checkMCPSettingsInject(verbose),
+		checkMCPAPITokens(verbose),
+		checkMCPLoopback(verbose),
 	}
 
 	ok := true
@@ -137,6 +141,119 @@ func checkPortBindable(port int, verbose bool) CheckResult {
 	}
 	_ = l.Close()
 	r := CheckResult{Name: "port-bindable", OK: true, Message: fmt.Sprintf("port %d available", port)}
+	if verbose {
+		r.Detail = addr
+	}
+	return r
+}
+
+// checkMCPSettingsInject verifies that ~/.claude/settings.json contains the
+// tether-managed mcpServers.tether entry injected by `tether server`.
+func checkMCPSettingsInject(verbose bool) CheckResult {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return CheckResult{Name: "mcp-settings-inject", OK: false, Message: "cannot determine home dir: " + err.Error()}
+	}
+	path := filepath.Join(home, ".claude", "settings.json")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return CheckResult{Name: "mcp-settings-inject", OK: false, Message: "~/.claude/settings.json not found — run `tether server` to inject"}
+	}
+	var settings map[string]any
+	if err := json.Unmarshal(data, &settings); err != nil {
+		return CheckResult{Name: "mcp-settings-inject", OK: false, Message: "~/.claude/settings.json: parse error: " + err.Error()}
+	}
+	mcpServers, _ := settings["mcpServers"].(map[string]any)
+	for _, v := range mcpServers {
+		if m, ok := v.(map[string]any); ok {
+			if managed, _ := m[agent.TetherManagedKey].(bool); managed {
+				mcpURL, _ := m["url"].(string)
+				r := CheckResult{Name: "mcp-settings-inject", OK: true, Message: "tether MCP server injected in settings.json"}
+				if verbose {
+					r.Detail = "url=" + mcpURL
+				}
+				return r
+			}
+		}
+	}
+	return CheckResult{Name: "mcp-settings-inject", OK: false, Message: "tether MCP server not in settings.json — run `tether server` to inject"}
+}
+
+// checkMCPAPITokens reports how many external API tokens are configured in
+// ~/.tether/api-tokens.json. A missing or empty file is not an error — it
+// just means no external MCP clients (Cursor, Goose) have been authorised yet.
+func checkMCPAPITokens(verbose bool) CheckResult {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return CheckResult{Name: "mcp-api-tokens", OK: true, Message: "cannot determine home dir: " + err.Error()}
+	}
+	path := filepath.Join(home, ".tether", "api-tokens.json")
+	data, err := os.ReadFile(path)
+	if os.IsNotExist(err) {
+		return CheckResult{Name: "mcp-api-tokens", OK: true, Message: "no external API tokens yet (create via POST /api/v1/mcp/tokens or OAuth flow)"}
+	}
+	if err != nil {
+		return CheckResult{Name: "mcp-api-tokens", OK: true, Message: "api-tokens.json unreadable: " + err.Error()}
+	}
+	var file struct {
+		Tokens []struct{ ID string } `json:"tokens"`
+	}
+	if err := json.Unmarshal(data, &file); err != nil {
+		return CheckResult{Name: "mcp-api-tokens", OK: true, Message: "api-tokens.json: parse error (file may be corrupt)"}
+	}
+	n := len(file.Tokens)
+	if n == 0 {
+		return CheckResult{Name: "mcp-api-tokens", OK: true, Message: "api-tokens.json exists, no external tokens yet"}
+	}
+	r := CheckResult{Name: "mcp-api-tokens", OK: true, Message: fmt.Sprintf("%d external API token(s) configured", n)}
+	if verbose {
+		r.Detail = path
+	}
+	return r
+}
+
+// checkMCPLoopback attempts a TCP connection to the tether MCP loopback
+// endpoint. The port is read from mcpServers.tether.url in
+// ~/.claude/settings.json; falls back to :8899 if absent.
+// A failed connection is reported as a warning (OK=true) because doctor may
+// be run when the server is not started.
+func checkMCPLoopback(verbose bool) CheckResult {
+	port := 8899
+	home, _ := os.UserHomeDir()
+	if home != "" {
+		if data, err := os.ReadFile(filepath.Join(home, ".claude", "settings.json")); err == nil {
+			var settings map[string]any
+			if json.Unmarshal(data, &settings) == nil {
+				if mcpServers, _ := settings["mcpServers"].(map[string]any); mcpServers != nil {
+					for _, v := range mcpServers {
+						if m, ok := v.(map[string]any); ok {
+							if managed, _ := m[agent.TetherManagedKey].(bool); managed {
+								if rawURL, _ := m["url"].(string); rawURL != "" {
+									if u, err := url.Parse(rawURL); err == nil {
+										if p, err := net.LookupPort("tcp", u.Port()); err == nil && p > 0 {
+											port = p
+										}
+									}
+								}
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+
+	addr := fmt.Sprintf("127.0.0.1:%d", port)
+	conn, err := net.DialTimeout("tcp", addr, 2*time.Second)
+	if err != nil {
+		return CheckResult{
+			Name:    "mcp-loopback",
+			OK:      true,
+			Message: fmt.Sprintf("MCP loopback not reachable at %s (is `tether server` running?)", addr),
+		}
+	}
+	_ = conn.Close()
+	r := CheckResult{Name: "mcp-loopback", OK: true, Message: fmt.Sprintf("MCP loopback reachable at %s", addr)}
 	if verbose {
 		r.Detail = addr
 	}

--- a/internal/doctor/doctor.go
+++ b/internal/doctor/doctor.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strconv"
 	"time"
 
 	"github.com/piaobeizu/tether/internal/agent"
@@ -164,16 +165,14 @@ func checkMCPSettingsInject(verbose bool) CheckResult {
 		return CheckResult{Name: "mcp-settings-inject", OK: false, Message: "~/.claude/settings.json: parse error: " + err.Error()}
 	}
 	mcpServers, _ := settings["mcpServers"].(map[string]any)
-	for _, v := range mcpServers {
-		if m, ok := v.(map[string]any); ok {
-			if managed, _ := m[agent.TetherManagedKey].(bool); managed {
-				mcpURL, _ := m["url"].(string)
-				r := CheckResult{Name: "mcp-settings-inject", OK: true, Message: "tether MCP server injected in settings.json"}
-				if verbose {
-					r.Detail = "url=" + mcpURL
-				}
-				return r
+	if entry, ok := mcpServers["tether"].(map[string]any); ok {
+		if managed, _ := entry[agent.TetherManagedKey].(bool); managed {
+			mcpURL, _ := entry["url"].(string)
+			r := CheckResult{Name: "mcp-settings-inject", OK: true, Message: "tether MCP server injected in settings.json"}
+			if verbose {
+				r.Detail = "url=" + mcpURL
 			}
+			return r
 		}
 	}
 	return CheckResult{Name: "mcp-settings-inject", OK: false, Message: "tether MCP server not in settings.json — run `tether server` to inject"}
@@ -199,7 +198,7 @@ func checkMCPAPITokens(verbose bool) CheckResult {
 		Tokens []struct{ ID string } `json:"tokens"`
 	}
 	if err := json.Unmarshal(data, &file); err != nil {
-		return CheckResult{Name: "mcp-api-tokens", OK: true, Message: "api-tokens.json: parse error (file may be corrupt)"}
+		return CheckResult{Name: "mcp-api-tokens", OK: false, Message: "api-tokens.json: parse error (file may be corrupt): " + err.Error()}
 	}
 	n := len(file.Tokens)
 	if n == 0 {
@@ -230,7 +229,7 @@ func checkMCPLoopback(verbose bool) CheckResult {
 							if managed, _ := m[agent.TetherManagedKey].(bool); managed {
 								if rawURL, _ := m["url"].(string); rawURL != "" {
 									if u, err := url.Parse(rawURL); err == nil {
-										if p, err := net.LookupPort("tcp", u.Port()); err == nil && p > 0 {
+										if p, err := strconv.Atoi(u.Port()); err == nil && p > 0 {
 											port = p
 										}
 									}
@@ -267,10 +266,11 @@ func checkCCSettingsHooks(verbose bool) CheckResult {
 	if err != nil {
 		return CheckResult{Name: "cc-settings-hooks", OK: false, Message: "cannot determine home dir: " + err.Error()}
 	}
-	path := filepath.Join(home, ".config", "claude", "settings.json")
+	// Claude Code reads ~/.claude/settings.json (user-level), not ~/.config/claude/settings.json.
+	path := filepath.Join(home, ".claude", "settings.json")
 	data, err := os.ReadFile(path)
 	if err != nil {
-		return CheckResult{Name: "cc-settings-hooks", OK: false, Message: "settings.json not found — run `tether server` to inject hook"}
+		return CheckResult{Name: "cc-settings-hooks", OK: false, Message: "~/.claude/settings.json not found — run `tether server` to inject hook"}
 	}
 	var settings map[string]any
 	if err := json.Unmarshal(data, &settings); err != nil {

--- a/internal/doctor/doctor_test.go
+++ b/internal/doctor/doctor_test.go
@@ -1,0 +1,160 @@
+package doctor
+
+import (
+	"encoding/json"
+	"fmt"
+	"net"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/piaobeizu/tether/internal/agent"
+)
+
+// writeJSON writes v as JSON to path, creating parent dirs.
+func writeJSON(t *testing.T, path string, v any) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	data, err := json.Marshal(v)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestCheckMCPSettingsInject_Injected(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, ".claude", "settings.json")
+	writeJSON(t, path, map[string]any{
+		"mcpServers": map[string]any{
+			"tether": map[string]any{
+				agent.TetherManagedKey: true,
+				"type":                 "http",
+				"url":                  "http://127.0.0.1:8899/mcp",
+			},
+		},
+	})
+	// Point home to temp dir by temporarily overriding UserHomeDir via env.
+	t.Setenv("HOME", dir)
+	r := checkMCPSettingsInject(false)
+	if !r.OK {
+		t.Errorf("expected OK=true, message=%q", r.Message)
+	}
+}
+
+func TestCheckMCPSettingsInject_Missing(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	r := checkMCPSettingsInject(false)
+	if r.OK {
+		t.Errorf("expected OK=false when settings.json absent, got message=%q", r.Message)
+	}
+}
+
+func TestCheckMCPSettingsInject_NotInjected(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, ".claude", "settings.json")
+	writeJSON(t, path, map[string]any{
+		"mcpServers": map[string]any{
+			"other": map[string]any{"url": "http://example.com"},
+		},
+	})
+	t.Setenv("HOME", dir)
+	r := checkMCPSettingsInject(false)
+	if r.OK {
+		t.Errorf("expected OK=false when no tether entry, got message=%q", r.Message)
+	}
+}
+
+func TestCheckMCPAPITokens_NoFile(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	r := checkMCPAPITokens(false)
+	if !r.OK {
+		t.Errorf("missing api-tokens.json should not be an error: %q", r.Message)
+	}
+}
+
+func TestCheckMCPAPITokens_WithTokens(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, ".tether", "api-tokens.json")
+	writeJSON(t, path, map[string]any{
+		"tokens": []map[string]any{
+			{"id": "tok1", "name": "cursor", "hash": "abc"},
+			{"id": "tok2", "name": "goose", "hash": "def"},
+		},
+	})
+	t.Setenv("HOME", dir)
+	r := checkMCPAPITokens(false)
+	if !r.OK {
+		t.Errorf("expected OK=true: %q", r.Message)
+	}
+	if r.Message != "2 external API token(s) configured" {
+		t.Errorf("unexpected message: %q", r.Message)
+	}
+}
+
+func TestCheckMCPAPITokens_EmptyStore(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, ".tether", "api-tokens.json")
+	writeJSON(t, path, map[string]any{"tokens": []any{}})
+	t.Setenv("HOME", dir)
+	r := checkMCPAPITokens(false)
+	if !r.OK {
+		t.Errorf("empty store should not be an error: %q", r.Message)
+	}
+}
+
+func TestCheckMCPLoopback_NotRunning(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	// No server is listening — expect a warning (OK=true, informational).
+	r := checkMCPLoopback(false)
+	if !r.OK {
+		t.Errorf("unreachable loopback should be OK=true (warning), got: %q", r.Message)
+	}
+}
+
+func TestCheckMCPLoopback_Running(t *testing.T) {
+	// Start a throwaway TCP listener on an ephemeral port.
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer l.Close()
+	port := l.Addr().(*net.TCPAddr).Port
+
+	// Inject settings pointing at our listener.
+	dir := t.TempDir()
+	path := filepath.Join(dir, ".claude", "settings.json")
+	writeJSON(t, path, map[string]any{
+		"mcpServers": map[string]any{
+			"tether": map[string]any{
+				agent.TetherManagedKey: true,
+				"url": fmt.Sprintf("http://127.0.0.1:%d/mcp", port),
+			},
+		},
+	})
+	t.Setenv("HOME", dir)
+
+	r := checkMCPLoopback(false)
+	if !r.OK {
+		t.Errorf("expected OK=true with running listener: %q", r.Message)
+	}
+	if r.Message == "" || contains(r.Message, "not reachable") {
+		t.Errorf("expected reachable message, got: %q", r.Message)
+	}
+}
+
+func contains(s, sub string) bool {
+	return len(s) >= len(sub) && (s == sub || len(sub) == 0 ||
+		func() bool {
+			for i := 0; i <= len(s)-len(sub); i++ {
+				if s[i:i+len(sub)] == sub {
+					return true
+				}
+			}
+			return false
+		}())
+}

--- a/internal/mcp/instance/instance.go
+++ b/internal/mcp/instance/instance.go
@@ -1,0 +1,322 @@
+// Package instance provides per-task MCP lifecycle management.
+//
+// Each active polyforge task gets its own MCPInstance: isolated child
+// processes, a dedicated loopback port, a fresh bearer token, and builtin
+// tools scoped to the task's worktree path.  The global singleton MCP stack
+// (package server) is unaffected and continues to serve non-task sessions.
+package instance
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/subtle"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"log/slog"
+	"net"
+	"net/http"
+	"sync"
+	"time"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+
+	"github.com/piaobeizu/tether/internal/agent"
+	"github.com/piaobeizu/tether/internal/mcp/builtin"
+	"github.com/piaobeizu/tether/internal/mcp/gateway"
+	mcphost "github.com/piaobeizu/tether/internal/mcp/host"
+	mcpreg "github.com/piaobeizu/tether/internal/mcp/registry"
+	"github.com/piaobeizu/tether/internal/permission"
+)
+
+// InstanceConfig carries everything needed to spin up a per-task MCP stack.
+type InstanceConfig struct {
+	// TaskID is the canonical polyforge task ID (e.g. "t-01KRD1GYDZK5T1TW32RFAREEQV").
+	TaskID string
+	// TaskSlug is the human-readable slug used in settings keys
+	// (e.g. "mcp-lifecycle" → mcpServers entry key "tether-mcp-lifecycle").
+	TaskSlug string
+	// WsRoot is the absolute path to the task's worktree / workspace root.
+	// Builtin tools (workspace_read_file etc.) are scoped to this directory.
+	WsRoot string
+	// Port is the loopback port to bind.  0 = OS-assigned free port (recommended).
+	Port int
+	// PermManager is the shared permission gate.  Required.
+	PermManager *permission.Manager
+	// Logger is the history logger for the MCP host.  Nil = noop.
+	Logger mcphost.HistoryLogger
+	// SkipInject suppresses ~/.claude/settings.json mutation.
+	// Set true in CI and unit tests.
+	SkipInject bool
+}
+
+// MCPInstance is a self-contained MCP stack scoped to one polyforge task.
+// Create with New(); call Start() to bind and serve; call Stop() to tear down.
+//
+// All exported fields are read-only after Start() returns successfully.
+type MCPInstance struct {
+	// TaskID is the polyforge task identifier.
+	TaskID string
+	// TaskSlug is the human-readable slug.
+	TaskSlug string
+	// WsRoot is the resolved workspace root used by builtin tools.
+	WsRoot string
+	// Port is the loopback port this instance is listening on.
+	// Populated after Start() returns.
+	Port int
+	// Token is the bearer token required to authenticate against the loopback.
+	// Populated after New() returns.
+	Token string
+
+	// internal wiring
+	mgr      *mcphost.Manager
+	reg      *mcpreg.Registry
+	srv      *mcp.Server
+	loopback *loopback
+
+	skipInject bool
+	started    bool
+	mu         sync.Mutex
+}
+
+// New constructs (but does not start) an MCPInstance from cfg.
+// Returns an error if the configuration is invalid (e.g. unresolvable WsRoot,
+// empty TaskID/TaskSlug, nil PermManager).
+func New(cfg InstanceConfig) (*MCPInstance, error) {
+	if cfg.TaskID == "" {
+		return nil, fmt.Errorf("mcp/instance: TaskID is required")
+	}
+	if cfg.TaskSlug == "" {
+		return nil, fmt.Errorf("mcp/instance: TaskSlug is required")
+	}
+	if cfg.PermManager == nil {
+		return nil, fmt.Errorf("mcp/instance: PermManager is required")
+	}
+
+	logger := cfg.Logger
+	if logger == nil {
+		logger = mcphost.NoopLogger()
+	}
+
+	token, err := generateToken()
+	if err != nil {
+		return nil, fmt.Errorf("mcp/instance: token generation: %w", err)
+	}
+
+	// Build the MCP sub-stack: registry → manager → builtin registry → gateway → server.
+	reg := mcpreg.New()
+	mgr := mcphost.NewManager(reg, logger)
+
+	bi, err := builtin.New(cfg.WsRoot)
+	if err != nil {
+		return nil, fmt.Errorf("mcp/instance: builtin registry: %w", err)
+	}
+
+	gw := gateway.New(mgr, reg, cfg.PermManager, logger)
+	srv := buildServer(gw, bi, reg, cfg.TaskSlug)
+
+	lb, err := newLoopback(cfg.Port, srv, token)
+	if err != nil {
+		return nil, fmt.Errorf("mcp/instance: loopback init: %w", err)
+	}
+
+	return &MCPInstance{
+		TaskID:     cfg.TaskID,
+		TaskSlug:   cfg.TaskSlug,
+		WsRoot:     cfg.WsRoot,
+		Port:       lb.port,
+		Token:      token,
+		mgr:        mgr,
+		reg:        reg,
+		srv:        srv,
+		loopback:   lb,
+		skipInject: cfg.SkipInject,
+	}, nil
+}
+
+// Start binds the loopback listener, starts any configured extra servers,
+// and injects the mcpServers entry into ~/.claude/settings.json.
+// It is idempotent: calling Start() on an already-started instance is a no-op.
+func (i *MCPInstance) Start(ctx context.Context, extraServers map[string]mcphost.ServerConfig) error {
+	i.mu.Lock()
+	defer i.mu.Unlock()
+	if i.started {
+		return nil
+	}
+
+	if len(extraServers) > 0 {
+		cfg := &mcphost.Config{Servers: extraServers}
+		if err := i.mgr.Start(ctx, cfg); err != nil {
+			return fmt.Errorf("mcp/instance %s: start extra servers: %w", i.TaskSlug, err)
+		}
+	}
+
+	if err := i.loopback.Start(); err != nil {
+		i.mgr.StopAll()
+		return fmt.Errorf("mcp/instance %s: loopback listen: %w", i.TaskSlug, err)
+	}
+
+	if !i.skipInject {
+		name := "tether-" + i.TaskSlug
+		if err := agent.InjectMCPServer(i.Port, i.Token, name); err != nil {
+			// Non-fatal: log and continue.  The caller can fall back or retry.
+			slog.Warn("mcp/instance: settings inject failed",
+				"task_slug", i.TaskSlug,
+				"err", err)
+		}
+	}
+
+	i.started = true
+	slog.Info("mcp/instance: started",
+		"task_id", i.TaskID,
+		"task_slug", i.TaskSlug,
+		"port", i.Port)
+	return nil
+}
+
+// Stop drains active sessions (within the context deadline), kills child
+// processes, and removes the settings.json entry.
+// Calling Stop() on an instance that was never started is a no-op.
+func (i *MCPInstance) Stop(ctx context.Context) error {
+	i.mu.Lock()
+	defer i.mu.Unlock()
+	if !i.started {
+		return nil
+	}
+
+	var errs []error
+
+	if err := i.loopback.Stop(ctx); err != nil {
+		errs = append(errs, fmt.Errorf("loopback shutdown: %w", err))
+	}
+	i.mgr.StopAll()
+
+	if !i.skipInject {
+		name := "tether-" + i.TaskSlug
+		if err := agent.RemoveMCPServer(name); err != nil {
+			errs = append(errs, fmt.Errorf("settings cleanup: %w", err))
+		}
+	}
+
+	i.started = false
+	slog.Info("mcp/instance: stopped",
+		"task_id", i.TaskID,
+		"task_slug", i.TaskSlug)
+
+	if len(errs) > 0 {
+		return fmt.Errorf("mcp/instance %s stop: %v", i.TaskSlug, errs)
+	}
+	return nil
+}
+
+// Server returns the underlying *mcp.Server so callers can mount it on
+// additional HTTP handlers (e.g. the HTTPS /mcp route).
+// Valid after New(); do not call AddTool/RemoveTool directly.
+func (i *MCPInstance) Server() *mcp.Server { return i.srv }
+
+// buildServer constructs a *mcp.Server wired to the gateway and builtins.
+// This is an instance-scoped variant of server.BuildMCPServer; it lives here
+// to avoid an import cycle (server ← instance ← server).
+func buildServer(gw *gateway.Gateway, bi *builtin.Registry, reg *mcpreg.Registry, taskSlug string) *mcp.Server {
+	srv := mcp.NewServer(
+		&mcp.Implementation{Name: "tether-" + taskSlug, Version: "v0.4.0"},
+		nil,
+	)
+
+	addOne := func(entry mcpreg.ToolEntry) {
+		t := entry.Tool
+		t.Name = entry.PrefixedName
+		srv.AddTool(&t, func(ctx context.Context, req *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+			return gw.CallTool(ctx, gateway.CallRequest{
+				ToolName:  entry.PrefixedName,
+				Arguments: req.Params.Arguments,
+			})
+		})
+	}
+
+	for _, e := range gw.ListToolsSnapshot() {
+		addOne(e)
+	}
+	bi.RegisterInto(srv)
+
+	reg.AddObserver(func(e mcpreg.RegistryEvent) {
+		if len(e.Removed) > 0 {
+			names := make([]string, len(e.Removed))
+			for idx, t := range e.Removed {
+				names[idx] = t.PrefixedName
+			}
+			srv.RemoveTools(names...)
+		}
+		for _, entry := range e.Added {
+			addOne(entry)
+		}
+	})
+
+	return srv
+}
+
+// loopback is a minimal bearer-auth HTTP wrapper around an *mcp.Server,
+// equivalent to server.MCPLoopback but scoped to one instance.
+type loopback struct {
+	srv     *http.Server
+	ln      net.Listener
+	port    int
+	token   string
+	handler http.Handler
+}
+
+func newLoopback(port int, mcpSrv *mcp.Server, token string) (*loopback, error) {
+	ln, err := net.Listen("tcp", fmt.Sprintf("127.0.0.1:%d", port))
+	if err != nil {
+		return nil, err
+	}
+	actualPort := ln.Addr().(*net.TCPAddr).Port
+
+	sdkHandler := mcp.NewStreamableHTTPHandler(
+		func(_ *http.Request) *mcp.Server { return mcpSrv },
+		&mcp.StreamableHTTPOptions{SessionTimeout: 30 * time.Minute},
+	)
+	l := &loopback{token: token, handler: sdkHandler, ln: ln, port: actualPort}
+	mux := http.NewServeMux()
+	mux.Handle("/mcp", l)
+	mux.Handle("/mcp/", l)
+	l.srv = &http.Server{
+		Handler:           mux,
+		ReadHeaderTimeout: 30 * time.Second,
+	}
+	return l, nil
+}
+
+func (l *loopback) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	got := r.Header.Get("Authorization")
+	want := "Bearer " + l.token
+	if subtle.ConstantTimeCompare([]byte(got), []byte(want)) != 1 {
+		http.Error(w, "unauthorized", http.StatusUnauthorized)
+		return
+	}
+	l.handler.ServeHTTP(w, r)
+}
+
+func (l *loopback) Start() error {
+	go func() {
+		if err := l.srv.Serve(l.ln); err != nil && err != http.ErrServerClosed {
+			slog.Error("mcp/instance: loopback serve error", "err", err)
+		}
+	}()
+	return nil
+}
+
+func (l *loopback) Stop(ctx context.Context) error {
+	return l.srv.Shutdown(ctx)
+}
+
+// generateToken returns a cryptographically random 32-byte hex string.
+func generateToken() (string, error) {
+	b := make([]byte, 32)
+	if _, err := io.ReadFull(rand.Reader, b); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(b), nil
+}
+
+

--- a/internal/mcp/instance/instance_test.go
+++ b/internal/mcp/instance/instance_test.go
@@ -1,0 +1,99 @@
+package instance_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/piaobeizu/tether/internal/mcp/instance"
+	"github.com/piaobeizu/tether/internal/permission"
+)
+
+func newPermManager() *permission.Manager {
+	return permission.New()
+}
+
+func TestNew_validation(t *testing.T) {
+	pm := newPermManager()
+
+	t.Run("TaskID empty", func(t *testing.T) {
+		_, err := instance.New(instance.InstanceConfig{
+			TaskID:      "",
+			TaskSlug:    "test-slug",
+			PermManager: pm,
+			SkipInject:  true,
+		})
+		if err == nil {
+			t.Fatal("expected error for empty TaskID")
+		}
+	})
+
+	t.Run("TaskSlug empty", func(t *testing.T) {
+		_, err := instance.New(instance.InstanceConfig{
+			TaskID:      "t-01TESTID",
+			TaskSlug:    "",
+			PermManager: pm,
+			SkipInject:  true,
+		})
+		if err == nil {
+			t.Fatal("expected error for empty TaskSlug")
+		}
+	})
+
+	t.Run("PermManager nil", func(t *testing.T) {
+		_, err := instance.New(instance.InstanceConfig{
+			TaskID:      "t-01TESTID",
+			TaskSlug:    "test-slug",
+			PermManager: nil,
+			SkipInject:  true,
+		})
+		if err == nil {
+			t.Fatal("expected error for nil PermManager")
+		}
+	})
+}
+
+func TestStartStop(t *testing.T) {
+	pm := newPermManager()
+
+	inst, err := instance.New(instance.InstanceConfig{
+		TaskID:      "t-01STARTSTOP",
+		TaskSlug:    "start-stop-test",
+		WsRoot:      t.TempDir(),
+		PermManager: pm,
+		SkipInject:  true,
+		Port:        0, // OS-assigned
+	})
+	if err != nil {
+		t.Fatalf("New() error: %v", err)
+	}
+
+	if inst.Token == "" {
+		t.Fatal("Token should be non-empty after New()")
+	}
+
+	ctx := context.Background()
+	if err := inst.Start(ctx, nil); err != nil {
+		t.Fatalf("Start() error: %v", err)
+	}
+
+	if inst.Port <= 0 {
+		t.Fatalf("Port should be > 0 after Start(), got %d", inst.Port)
+	}
+
+	// Start is idempotent
+	if err := inst.Start(ctx, nil); err != nil {
+		t.Fatalf("second Start() should be a no-op, got error: %v", err)
+	}
+
+	stopCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+	if err := inst.Stop(stopCtx); err != nil {
+		t.Fatalf("Stop() error: %v", err)
+	}
+
+	// Stop twice is a no-op
+	if err := inst.Stop(stopCtx); err != nil {
+		t.Fatalf("second Stop() should be a no-op, got error: %v", err)
+	}
+}

--- a/internal/mcp/lifecycle/manager.go
+++ b/internal/mcp/lifecycle/manager.go
@@ -1,0 +1,151 @@
+// Package lifecycle provides the LifecycleManager — a thread-safe registry
+// of per-task MCPInstances.  It is the integration point between the tether
+// REST API (task MCP endpoints) and the per-task MCP stacks defined in
+// internal/mcp/instance.
+package lifecycle
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/piaobeizu/tether/internal/mcp/host"
+	"github.com/piaobeizu/tether/internal/mcp/instance"
+	"github.com/piaobeizu/tether/internal/permission"
+)
+
+// TaskConfig carries the parameters needed to start a per-task MCPInstance.
+type TaskConfig struct {
+	// TaskID is the canonical polyforge task ID.
+	TaskID string
+	// TaskSlug is the human-readable slug (used as the settings key suffix).
+	TaskSlug string
+	// WsRoot is the absolute path to the task's worktree / workspace root.
+	WsRoot string
+	// ExtraServers are optional stdio MCP server processes to start for this task.
+	ExtraServers map[string]host.ServerConfig
+	// PermManager is shared across all instances; must not be nil.
+	PermManager *permission.Manager
+	// Logger is the history logger.  Nil = noop.
+	Logger host.HistoryLogger
+	// SkipInject suppresses ~/.claude/settings.json mutation (tests/CI).
+	SkipInject bool
+}
+
+// LifecycleManager maintains a map of active per-task MCPInstances and ensures
+// at most one instance per task is running at any time.
+type LifecycleManager struct {
+	mu        sync.RWMutex
+	instances map[string]*instance.MCPInstance // keyed by TaskID
+}
+
+// New creates an empty LifecycleManager.
+func New() *LifecycleManager {
+	return &LifecycleManager{
+		instances: make(map[string]*instance.MCPInstance),
+	}
+}
+
+// StartTask creates and starts an MCPInstance for the given task.
+// If an instance for TaskID already exists and is running, it is stopped first
+// before the new one is started (handles resume-with-new-config).
+// Returns the started instance so callers can read Port and Token.
+func (m *LifecycleManager) StartTask(ctx context.Context, cfg TaskConfig) (*instance.MCPInstance, error) {
+	if cfg.TaskID == "" {
+		return nil, fmt.Errorf("lifecycle: TaskID is required")
+	}
+	if cfg.TaskSlug == "" {
+		return nil, fmt.Errorf("lifecycle: TaskSlug is required")
+	}
+	if cfg.PermManager == nil {
+		return nil, fmt.Errorf("lifecycle: PermManager is required")
+	}
+
+	// Stop any existing instance for this task first (idempotent restart).
+	m.mu.Lock()
+	existing, exists := m.instances[cfg.TaskID]
+	if exists {
+		delete(m.instances, cfg.TaskID)
+	}
+	m.mu.Unlock()
+
+	if exists {
+		stopCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+		defer cancel()
+		_ = existing.Stop(stopCtx) // best-effort; proceed regardless
+	}
+
+	inst, err := instance.New(instance.InstanceConfig{
+		TaskID:      cfg.TaskID,
+		TaskSlug:    cfg.TaskSlug,
+		WsRoot:      cfg.WsRoot,
+		PermManager: cfg.PermManager,
+		Logger:      cfg.Logger,
+		SkipInject:  cfg.SkipInject,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("lifecycle: new instance for %s: %w", cfg.TaskSlug, err)
+	}
+
+	if err := inst.Start(ctx, cfg.ExtraServers); err != nil {
+		return nil, fmt.Errorf("lifecycle: start instance for %s: %w", cfg.TaskSlug, err)
+	}
+
+	m.mu.Lock()
+	m.instances[cfg.TaskID] = inst
+	m.mu.Unlock()
+
+	return inst, nil
+}
+
+// StopTask shuts down the running MCPInstance for taskID.
+// Returns an error if no instance is found or shutdown fails.
+func (m *LifecycleManager) StopTask(ctx context.Context, taskID string) error {
+	m.mu.Lock()
+	inst, ok := m.instances[taskID]
+	if ok {
+		delete(m.instances, taskID)
+	}
+	m.mu.Unlock()
+
+	if !ok {
+		return fmt.Errorf("lifecycle: no instance for task %s", taskID)
+	}
+	return inst.Stop(ctx)
+}
+
+// Get returns the active instance for taskID, or (nil, false) if absent.
+func (m *LifecycleManager) Get(taskID string) (*instance.MCPInstance, bool) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	inst, ok := m.instances[taskID]
+	return inst, ok
+}
+
+// Active returns a snapshot of all currently running instances.
+func (m *LifecycleManager) Active() []*instance.MCPInstance {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	out := make([]*instance.MCPInstance, 0, len(m.instances))
+	for _, inst := range m.instances {
+		out = append(out, inst)
+	}
+	return out
+}
+
+// StopAll shuts down all running instances.  Intended for daemon shutdown.
+// Best-effort: errors are logged but not aggregated.
+func (m *LifecycleManager) StopAll(ctx context.Context) {
+	m.mu.Lock()
+	ids := make([]string, 0, len(m.instances))
+	for id := range m.instances {
+		ids = append(ids, id)
+	}
+	m.mu.Unlock()
+
+	for _, id := range ids {
+		_ = m.StopTask(ctx, id)
+	}
+}
+

--- a/internal/mcp/lifecycle/manager_test.go
+++ b/internal/mcp/lifecycle/manager_test.go
@@ -1,0 +1,111 @@
+package lifecycle_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/piaobeizu/tether/internal/mcp/lifecycle"
+	"github.com/piaobeizu/tether/internal/permission"
+)
+
+func newPermManager() *permission.Manager {
+	return permission.New()
+}
+
+func baseConfig(t *testing.T, pm *permission.Manager, taskID, slug string) lifecycle.TaskConfig {
+	t.Helper()
+	return lifecycle.TaskConfig{
+		TaskID:      taskID,
+		TaskSlug:    slug,
+		WsRoot:      t.TempDir(),
+		PermManager: pm,
+		SkipInject:  true,
+	}
+}
+
+func TestStartStopTask(t *testing.T) {
+	pm := newPermManager()
+	lm := lifecycle.New()
+	ctx := context.Background()
+
+	cfg := baseConfig(t, pm, "t-01LMTEST1", "lm-test-1")
+	inst, err := lm.StartTask(ctx, cfg)
+	if err != nil {
+		t.Fatalf("StartTask() error: %v", err)
+	}
+
+	if inst.Port <= 0 {
+		t.Fatalf("instance Port should be > 0, got %d", inst.Port)
+	}
+	if inst.Token == "" {
+		t.Fatal("instance Token should be non-empty")
+	}
+
+	got, ok := lm.Get(cfg.TaskID)
+	if !ok {
+		t.Fatal("Get() should return true after StartTask")
+	}
+	if got != inst {
+		t.Fatal("Get() returned different instance than StartTask")
+	}
+
+	stopCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+	if err := lm.StopTask(stopCtx, cfg.TaskID); err != nil {
+		t.Fatalf("StopTask() error: %v", err)
+	}
+
+	_, ok = lm.Get(cfg.TaskID)
+	if ok {
+		t.Fatal("Get() should return false after StopTask")
+	}
+}
+
+func TestStopNonExistent(t *testing.T) {
+	lm := lifecycle.New()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	err := lm.StopTask(ctx, "t-NONEXISTENT")
+	if err == nil {
+		t.Fatal("StopTask on unknown ID should return error")
+	}
+}
+
+func TestStopAll(t *testing.T) {
+	pm := newPermManager()
+	lm := lifecycle.New()
+	ctx := context.Background()
+
+	cfg1 := baseConfig(t, pm, "t-01STOPALL1", "stopall-1")
+	cfg2 := baseConfig(t, pm, "t-01STOPALL2", "stopall-2")
+
+	if _, err := lm.StartTask(ctx, cfg1); err != nil {
+		t.Fatalf("StartTask(1) error: %v", err)
+	}
+	if _, err := lm.StartTask(ctx, cfg2); err != nil {
+		t.Fatalf("StartTask(2) error: %v", err)
+	}
+
+	if len(lm.Active()) != 2 {
+		t.Fatalf("expected 2 active instances, got %d", len(lm.Active()))
+	}
+
+	stopCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+	lm.StopAll(stopCtx)
+
+	if len(lm.Active()) != 0 {
+		t.Fatalf("expected 0 active instances after StopAll, got %d", len(lm.Active()))
+	}
+
+	_, ok := lm.Get(cfg1.TaskID)
+	if ok {
+		t.Fatal("Get(cfg1) should return false after StopAll")
+	}
+	_, ok = lm.Get(cfg2.TaskID)
+	if ok {
+		t.Fatal("Get(cfg2) should return false after StopAll")
+	}
+}

--- a/internal/server/lifecycle.go
+++ b/internal/server/lifecycle.go
@@ -23,6 +23,7 @@ import (
 	"github.com/piaobeizu/tether/internal/mcp/builtin"
 	mcpgw "github.com/piaobeizu/tether/internal/mcp/gateway"
 	mcphost "github.com/piaobeizu/tether/internal/mcp/host"
+	mcplifecycle "github.com/piaobeizu/tether/internal/mcp/lifecycle"
 	mcpreg "github.com/piaobeizu/tether/internal/mcp/registry"
 	"github.com/piaobeizu/tether/internal/permission"
 	"github.com/piaobeizu/tether/internal/permission/cchook"
@@ -54,6 +55,10 @@ type Config struct {
 
 	// v0.3.2: external client API token store
 	APITokensPath string // path to api-tokens.json; "" = ~/.tether/api-tokens.json
+
+	// v0.4: per-task MCP lifecycle manager.
+	// If nil, Run() initialises one and stores it here.
+	MCPLifecycle *mcplifecycle.LifecycleManager
 }
 
 func (c *Config) addr() string { return fmt.Sprintf(":%d", c.Port) }
@@ -170,11 +175,16 @@ func Run(cfg *Config) error {
 		return fmt.Errorf("mcp loopback: %w", err)
 	}
 	if !cfg.SkipMCPInject {
-		if err := agent.InjectMCPServer(mcpPort, bearerToken); err != nil {
+		if err := agent.InjectMCPServer(mcpPort, bearerToken, "tether"); err != nil {
 			mcpMgr.StopAll()
 			_ = loopback.Stop(context.Background())
 			return fmt.Errorf("mcp settings inject: %w", err)
 		}
+	}
+
+	// Step 3c: per-task MCP lifecycle manager (v0.4).
+	if cfg.MCPLifecycle == nil {
+		cfg.MCPLifecycle = mcplifecycle.New()
 	}
 
 	// Step 4: load or generate cert.
@@ -287,10 +297,14 @@ func Run(cfg *Config) error {
 	// MCP shutdown: drain → stop children → housekeeping.
 	drainCtx, drainCancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer drainCancel()
+
+	// v0.4: stop per-task instances before global stack.
+	cfg.MCPLifecycle.StopAll(drainCtx)
+
 	_ = loopback.Stop(drainCtx)
 	mcpMgr.StopAll()
 	if !cfg.SkipMCPInject {
-		_ = agent.RemoveMCPServer()
+		_ = agent.RemoveMCPServer("tether")
 	}
 	_ = os.Remove(mcpTokenPath)
 

--- a/internal/server/lifecycle.go
+++ b/internal/server/lifecycle.go
@@ -19,6 +19,7 @@ import (
 	"github.com/piaobeizu/tether/internal/agent"
 	"github.com/piaobeizu/tether/internal/auth"
 	"github.com/piaobeizu/tether/internal/auth/apitoken"
+	"github.com/piaobeizu/tether/internal/auth/oauth"
 	"github.com/piaobeizu/tether/internal/mcp/builtin"
 	mcpgw "github.com/piaobeizu/tether/internal/mcp/gateway"
 	mcphost "github.com/piaobeizu/tether/internal/mcp/host"
@@ -70,6 +71,9 @@ func (c *Config) devFrontend() string {
 // Run executes the §10.A.4 startup sequence, blocks until SIGINT/SIGTERM,
 // then performs graceful shutdown (≤5s per K.1.5).
 func Run(cfg *Config) error {
+	runCtx, runCancel := context.WithCancel(context.Background())
+	defer runCancel()
+
 	// Step 1: resolve cc binary path + build session registry.
 	ccPath := resolveClaudePath()
 	if cfg.Registry == nil {
@@ -215,9 +219,24 @@ func Run(cfg *Config) error {
 	if err != nil {
 		return fmt.Errorf("api-tokens store: %w", err)
 	}
+	apiTokens.StartEviction(runCtx)
+
+	// Step 4e: OAuth 2.1 PKCE handlers (v0.3.3).
+	oauthHost := "127.0.0.1"
+	if h := os.Getenv("TETHER_HOST"); h != "" {
+		oauthHost = h
+	}
+	var oauthIssuer string
+	if cfg.Port == 443 {
+		oauthIssuer = "https://" + oauthHost
+	} else {
+		oauthIssuer = fmt.Sprintf("https://%s:%d", oauthHost, cfg.Port)
+	}
+	oauthCS := oauth.NewCodeStore()
+	oauthH := oauth.NewHandlers(oauthCS, apiTokens, oauthIssuer)
 
 	// Step 5: build and start listeners.
-	srv := newServer(cfg, bundle, pm, authState, mcpSrv, apiTokens)
+	srv := newServer(cfg, bundle, pm, authState, mcpSrv, apiTokens, oauthH)
 
 	errCh := make(chan error, 2)
 

--- a/internal/server/mcp_https.go
+++ b/internal/server/mcp_https.go
@@ -58,7 +58,7 @@ func (l *ipLimiter) record(ip string) bool {
 		e.windowStart = time.Now()
 	}
 	e.failures++
-	if e.failures > 5 {
+	if e.failures >= 5 {
 		e.blockedUntil = time.Now().Add(5 * time.Minute)
 		return true
 	}

--- a/internal/server/mcp_https.go
+++ b/internal/server/mcp_https.go
@@ -7,11 +7,74 @@ import (
 	"net"
 	"net/http"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 	"github.com/piaobeizu/tether/internal/auth/apitoken"
 )
+
+type ipEntry struct {
+	failures     int
+	windowStart  time.Time
+	blockedUntil time.Time
+}
+
+type ipLimiter struct {
+	mu      sync.Mutex
+	entries map[string]*ipEntry
+}
+
+func newIPLimiter() *ipLimiter {
+	return &ipLimiter{entries: make(map[string]*ipEntry)}
+}
+
+// record is called on every Bearer auth failure for the given IP.
+// Returns true if the IP is now rate-limited (429).
+func (l *ipLimiter) record(ip string) bool {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	// Sweep to bound map size under DDoS.
+	if len(l.entries) > 10_000 {
+		now := time.Now()
+		for k, e := range l.entries {
+			if now.After(e.blockedUntil) && now.After(e.windowStart.Add(60*time.Second)) {
+				delete(l.entries, k)
+			}
+		}
+	}
+
+	e, ok := l.entries[ip]
+	if !ok {
+		e = &ipEntry{windowStart: time.Now()}
+		l.entries[ip] = e
+	}
+	if time.Now().Before(e.blockedUntil) {
+		return true
+	}
+	if time.Since(e.windowStart) > 60*time.Second {
+		e.failures = 0
+		e.windowStart = time.Now()
+	}
+	e.failures++
+	if e.failures > 5 {
+		e.blockedUntil = time.Now().Add(5 * time.Minute)
+		return true
+	}
+	return false
+}
+
+// isBlocked returns true if the IP is currently in a block window.
+func (l *ipLimiter) isBlocked(ip string) bool {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	e, ok := l.entries[ip]
+	if !ok {
+		return false
+	}
+	return time.Now().Before(e.blockedUntil)
+}
 
 // MCPHTTPSHandler returns an http.Handler that validates a Bearer token
 // against store before delegating to the shared mcp.Server's streamable
@@ -20,18 +83,37 @@ func MCPHTTPSHandler(mcpSrv *mcp.Server, store *apitoken.Store, logger *slog.Log
 	if logger == nil {
 		logger = slog.Default()
 	}
-	sdkHandler := mcp.NewStreamableHTTPHandler(
-		func(_ *http.Request) *mcp.Server { return mcpSrv },
-		&mcp.StreamableHTTPOptions{SessionTimeout: 30 * time.Minute},
-	)
+	limiter := newIPLimiter()
+	var sdkHandler http.Handler
+	if mcpSrv != nil {
+		sdkHandler = mcp.NewStreamableHTTPHandler(
+			func(_ *http.Request) *mcp.Server { return mcpSrv },
+			&mcp.StreamableHTTPOptions{SessionTimeout: 30 * time.Minute},
+		)
+	}
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		requestID := newRequestID()
+		ip := sanitiseAddr(r.RemoteAddr)
+
+		if limiter.isBlocked(ip) {
+			logger.Warn("mcp.bearer.rate_limited",
+				"request_id", requestID,
+				"remote_addr", ip)
+			http.Error(w, "too many requests", http.StatusTooManyRequests)
+			return
+		}
+
 		raw, reason := extractBearer(r)
 		if reason != "" {
 			logger.Warn("mcp.apitoken.auth_failed",
 				"request_id", requestID,
-				"remote_addr", sanitiseAddr(r.RemoteAddr),
+				"remote_addr", ip,
 				"reason", reason)
+			if limiter.record(ip) {
+				logger.Warn("mcp.bearer.rate_limited", "remote_addr", ip)
+				http.Error(w, "too many requests", http.StatusTooManyRequests)
+				return
+			}
 			http.Error(w, "unauthorized", http.StatusUnauthorized)
 			return
 		}
@@ -39,8 +121,13 @@ func MCPHTTPSHandler(mcpSrv *mcp.Server, store *apitoken.Store, logger *slog.Log
 		if !ok {
 			logger.Warn("mcp.apitoken.auth_failed",
 				"request_id", requestID,
-				"remote_addr", sanitiseAddr(r.RemoteAddr),
+				"remote_addr", ip,
 				"reason", "unknown_token")
+			if limiter.record(ip) {
+				logger.Warn("mcp.bearer.rate_limited", "remote_addr", ip)
+				http.Error(w, "too many requests", http.StatusTooManyRequests)
+				return
+			}
 			http.Error(w, "unauthorized", http.StatusUnauthorized)
 			return
 		}
@@ -48,8 +135,10 @@ func MCPHTTPSHandler(mcpSrv *mcp.Server, store *apitoken.Store, logger *slog.Log
 			"request_id", requestID,
 			"id", id,
 			"name", name,
-			"remote_addr", sanitiseAddr(r.RemoteAddr))
-		sdkHandler.ServeHTTP(w, r)
+			"remote_addr", ip)
+		if sdkHandler != nil {
+			sdkHandler.ServeHTTP(w, r)
+		}
 	})
 }
 

--- a/internal/server/mcp_https_test.go
+++ b/internal/server/mcp_https_test.go
@@ -233,3 +233,46 @@ func sha256Hex(raw string) string {
 	sum := sha256.Sum256([]byte(raw))
 	return hex.EncodeToString(sum[:])
 }
+
+func TestIPLimiter_BlocksAfterFiveFailures(t *testing.T) {
+	store, _ := apitoken.Open(filepath.Join(t.TempDir(), "t.json"))
+	h := server.MCPHTTPSHandler(nil, store, slog.Default())
+
+	makeReq := func() int {
+		req := httptest.NewRequest("POST", "/mcp", nil)
+		req.RemoteAddr = "10.0.0.1:9999"
+		w := httptest.NewRecorder()
+		h.ServeHTTP(w, req)
+		return w.Code
+	}
+
+	for i := 0; i < 5; i++ {
+		code := makeReq()
+		if code != http.StatusUnauthorized {
+			t.Fatalf("failure %d: want 401, got %d", i+1, code)
+		}
+	}
+	if code := makeReq(); code != http.StatusTooManyRequests {
+		t.Errorf("6th request: want 429, got %d", code)
+	}
+}
+
+func TestIPLimiter_DifferentIPsAreIndependent(t *testing.T) {
+	store, _ := apitoken.Open(filepath.Join(t.TempDir(), "t.json"))
+	h := server.MCPHTTPSHandler(nil, store, slog.Default())
+
+	makeReqFrom := func(ip string) int {
+		req := httptest.NewRequest("POST", "/mcp", nil)
+		req.RemoteAddr = ip + ":9999"
+		w := httptest.NewRecorder()
+		h.ServeHTTP(w, req)
+		return w.Code
+	}
+
+	for i := 0; i < 5; i++ {
+		makeReqFrom("10.0.0.1")
+	}
+	if code := makeReqFrom("10.0.0.2"); code == http.StatusTooManyRequests {
+		t.Error("10.0.0.2 should not be rate-limited")
+	}
+}

--- a/internal/server/mcp_https_test.go
+++ b/internal/server/mcp_https_test.go
@@ -234,7 +234,7 @@ func sha256Hex(raw string) string {
 	return hex.EncodeToString(sum[:])
 }
 
-func TestIPLimiter_BlocksAfterFiveFailures(t *testing.T) {
+func TestIPLimiter_BlocksOnFifthFailure(t *testing.T) {
 	store, _ := apitoken.Open(filepath.Join(t.TempDir(), "t.json"))
 	h := server.MCPHTTPSHandler(nil, store, slog.Default())
 
@@ -246,7 +246,8 @@ func TestIPLimiter_BlocksAfterFiveFailures(t *testing.T) {
 		return w.Code
 	}
 
-	for i := 0; i < 5; i++ {
+	// First 4 failures return 401; 5th triggers the block (429).
+	for i := 0; i < 4; i++ {
 		code := makeReq()
 		if code != http.StatusUnauthorized {
 			t.Fatalf("failure %d: want 401, got %d", i+1, code)

--- a/internal/server/mux.go
+++ b/internal/server/mux.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/piaobeizu/tether/internal/auth"
 	"github.com/piaobeizu/tether/internal/auth/apitoken"
+	"github.com/piaobeizu/tether/internal/auth/oauth"
 	"github.com/piaobeizu/tether/internal/permission"
 	"github.com/piaobeizu/tether/internal/session"
 	"github.com/piaobeizu/tether/internal/skill"
@@ -31,7 +32,7 @@ import (
 //	/wt/shell       → PTY shell channel stub (s6)
 //	/wt/events      → broadcast events channel (s4)
 //	/wt/_smoke      → WT bidi pure-byte echo (D-22 §6 #2 acceptance gate)
-func buildMux(cfg *Config, bundle CertBundle, wts *webtransport.Server, reg *session.Registry, pm *permission.Manager, authState *auth.State, mcpSrv *mcp.Server, mcpTokens *apitoken.Store) http.Handler {
+func buildMux(cfg *Config, bundle CertBundle, wts *webtransport.Server, reg *session.Registry, pm *permission.Manager, authState *auth.State, mcpSrv *mcp.Server, mcpTokens *apitoken.Store, oauthH *oauth.Handlers) http.Handler {
 	mux := http.NewServeMux()
 
 	derHex := HashHex(bundle.DER)
@@ -126,6 +127,13 @@ func buildMux(cfg *Config, bundle CertBundle, wts *webtransport.Server, reg *ses
 		mux.Handle("/mcp", mcpH)
 		mux.Handle("/mcp/", mcpH)
 		RegisterMCPTokensAPI(mux, mcpTokens, nil)
+	}
+
+	// OAuth 2.1 PKCE endpoints (v0.3.3). Auth middleware exempts these paths.
+	if oauthH != nil {
+		mux.Handle("/.well-known/oauth-authorization-server", oauthH.Metadata())
+		mux.Handle("/oauth/authorize", oauthH.Authorize())
+		mux.Handle("/oauth/token", oauthH.Token())
 	}
 
 	mux.HandleFunc("/api/v1/", func(w http.ResponseWriter, _ *http.Request) {

--- a/internal/server/mux.go
+++ b/internal/server/mux.go
@@ -14,6 +14,7 @@ import (
 	"github.com/piaobeizu/tether/internal/auth"
 	"github.com/piaobeizu/tether/internal/auth/apitoken"
 	"github.com/piaobeizu/tether/internal/auth/oauth"
+	mcplifecycle "github.com/piaobeizu/tether/internal/mcp/lifecycle"
 	"github.com/piaobeizu/tether/internal/permission"
 	"github.com/piaobeizu/tether/internal/session"
 	"github.com/piaobeizu/tether/internal/skill"
@@ -32,7 +33,7 @@ import (
 //	/wt/shell       → PTY shell channel stub (s6)
 //	/wt/events      → broadcast events channel (s4)
 //	/wt/_smoke      → WT bidi pure-byte echo (D-22 §6 #2 acceptance gate)
-func buildMux(cfg *Config, bundle CertBundle, wts *webtransport.Server, reg *session.Registry, pm *permission.Manager, authState *auth.State, mcpSrv *mcp.Server, mcpTokens *apitoken.Store, oauthH *oauth.Handlers) http.Handler {
+func buildMux(cfg *Config, bundle CertBundle, wts *webtransport.Server, reg *session.Registry, pm *permission.Manager, authState *auth.State, mcpSrv *mcp.Server, mcpTokens *apitoken.Store, oauthH *oauth.Handlers, lm *mcplifecycle.LifecycleManager) http.Handler {
 	mux := http.NewServeMux()
 
 	derHex := HashHex(bundle.DER)
@@ -134,6 +135,11 @@ func buildMux(cfg *Config, bundle CertBundle, wts *webtransport.Server, reg *ses
 		mux.Handle("/.well-known/oauth-authorization-server", oauthH.Metadata())
 		mux.Handle("/oauth/authorize", oauthH.Authorize())
 		mux.Handle("/oauth/token", oauthH.Token())
+	}
+
+	// v0.4: per-task MCP lifecycle endpoints.
+	if lm != nil {
+		registerTaskMCPAPI(mux, lm, pm)
 	}
 
 	mux.HandleFunc("/api/v1/", func(w http.ResponseWriter, _ *http.Request) {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/piaobeizu/tether/internal/auth"
 	"github.com/piaobeizu/tether/internal/auth/apitoken"
+	"github.com/piaobeizu/tether/internal/auth/oauth"
 	"github.com/piaobeizu/tether/internal/permission"
 )
 
@@ -24,7 +25,7 @@ type Server struct {
 
 // newServer constructs (but does not start) the dual-listener server.
 // Call Start() to bind and serve.
-func newServer(cfg *Config, bundle CertBundle, pm *permission.Manager, authState *auth.State, mcpSrv *mcp.Server, mcpTokens *apitoken.Store) *Server {
+func newServer(cfg *Config, bundle CertBundle, pm *permission.Manager, authState *auth.State, mcpSrv *mcp.Server, mcpTokens *apitoken.Store, oauthH *oauth.Handlers) *Server {
 	addr := cfg.addr()
 
 	// When ACME is active, certmagic provides a tls.Config with GetCertificate
@@ -70,7 +71,7 @@ func newServer(cfg *Config, bundle CertBundle, pm *permission.Manager, authState
 		CheckOrigin: func(r *http.Request) bool { return originAllowed(r.Header.Get("Origin"), cfg.Port) },
 	}
 
-	mux := buildMux(cfg, bundle, wts, cfg.Registry, pm, authState, mcpSrv, mcpTokens)
+	mux := buildMux(cfg, bundle, wts, cfg.Registry, pm, authState, mcpSrv, mcpTokens, oauthH)
 
 	tcpServer := &http.Server{
 		Addr:      addr,

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -71,7 +71,7 @@ func newServer(cfg *Config, bundle CertBundle, pm *permission.Manager, authState
 		CheckOrigin: func(r *http.Request) bool { return originAllowed(r.Header.Get("Origin"), cfg.Port) },
 	}
 
-	mux := buildMux(cfg, bundle, wts, cfg.Registry, pm, authState, mcpSrv, mcpTokens, oauthH)
+	mux := buildMux(cfg, bundle, wts, cfg.Registry, pm, authState, mcpSrv, mcpTokens, oauthH, cfg.MCPLifecycle)
 
 	tcpServer := &http.Server{
 		Addr:      addr,

--- a/internal/server/task_mcp.go
+++ b/internal/server/task_mcp.go
@@ -1,0 +1,136 @@
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"strings"
+	"time"
+
+	mcphost "github.com/piaobeizu/tether/internal/mcp/host"
+	mcplifecycle "github.com/piaobeizu/tether/internal/mcp/lifecycle"
+	"github.com/piaobeizu/tether/internal/permission"
+)
+
+// registerTaskMCPAPI mounts the per-task MCP lifecycle REST endpoints.
+//
+//	POST   /api/v1/tasks/{id}/mcp   → start a per-task MCPInstance
+//	DELETE /api/v1/tasks/{id}/mcp   → stop the instance for task {id}
+//	GET    /api/v1/tasks/{id}/mcp   → inspect the running instance (port, token)
+func registerTaskMCPAPI(mux *http.ServeMux, lm *mcplifecycle.LifecycleManager, pm *permission.Manager) {
+	mux.HandleFunc("/api/v1/tasks/", func(w http.ResponseWriter, r *http.Request) {
+		// ServeMux routes all /api/v1/tasks/{...} paths here.
+		// We only handle paths of the form /api/v1/tasks/{id}/mcp.
+		path := strings.TrimPrefix(r.URL.Path, "/api/v1/tasks/")
+		parts := strings.SplitN(path, "/", 2)
+		if len(parts) != 2 || parts[1] != "mcp" {
+			http.NotFound(w, r)
+			return
+		}
+		taskID := parts[0]
+		if taskID == "" {
+			http.Error(w, "task id required", http.StatusBadRequest)
+			return
+		}
+
+		switch r.Method {
+		case http.MethodPost:
+			handleTaskMCPStart(w, r, taskID, lm, pm)
+		case http.MethodDelete:
+			handleTaskMCPStop(w, r, taskID, lm)
+		case http.MethodGet:
+			handleTaskMCPGet(w, r, taskID, lm)
+		default:
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		}
+	})
+}
+
+// startTaskMCPRequest is the POST body for starting a per-task MCP instance.
+type startTaskMCPRequest struct {
+	// TaskSlug is the human-readable slug used as the settings key suffix.
+	TaskSlug string `json:"slug"`
+	// WsRoot is the absolute filesystem path for the task's workspace.
+	WsRoot string `json:"ws_root"`
+	// ExtraServers are optional additional stdio MCP servers for this task.
+	ExtraServers map[string]mcphost.ServerConfig `json:"extra_servers,omitempty"`
+	// SkipInject suppresses settings.json mutation (useful in CI).
+	SkipInject bool `json:"skip_inject,omitempty"`
+}
+
+// startTaskMCPResponse is the POST response body.
+type startTaskMCPResponse struct {
+	TaskID   string `json:"task_id"`
+	TaskSlug string `json:"task_slug"`
+	Port     int    `json:"port"`
+	Token    string `json:"token"`
+}
+
+func handleTaskMCPStart(w http.ResponseWriter, r *http.Request, taskID string, lm *mcplifecycle.LifecycleManager, pm *permission.Manager) {
+	var req startTaskMCPRequest
+	if err := json.NewDecoder(http.MaxBytesReader(w, r.Body, 64*1024)).Decode(&req); err != nil {
+		http.Error(w, "bad request: "+err.Error(), http.StatusBadRequest)
+		return
+	}
+	if req.TaskSlug == "" {
+		http.Error(w, "slug is required", http.StatusBadRequest)
+		return
+	}
+	if req.WsRoot == "" {
+		http.Error(w, "ws_root is required", http.StatusBadRequest)
+		return
+	}
+
+	inst, err := lm.StartTask(r.Context(), mcplifecycle.TaskConfig{
+		TaskID:       taskID,
+		TaskSlug:     req.TaskSlug,
+		WsRoot:       req.WsRoot,
+		ExtraServers: req.ExtraServers,
+		PermManager:  pm,
+		SkipInject:   req.SkipInject,
+	})
+	if err != nil {
+		slog.Error("task mcp: start failed", "task_id", taskID, "err", err)
+		http.Error(w, "failed to start MCP instance: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	_ = json.NewEncoder(w).Encode(startTaskMCPResponse{
+		TaskID:   inst.TaskID,
+		TaskSlug: inst.TaskSlug,
+		Port:     inst.Port,
+		Token:    inst.Token,
+	})
+}
+
+func handleTaskMCPStop(w http.ResponseWriter, r *http.Request, taskID string, lm *mcplifecycle.LifecycleManager) {
+	stopCtx, cancel := context.WithTimeout(r.Context(), 5*time.Second)
+	defer cancel()
+
+	if err := lm.StopTask(stopCtx, taskID); err != nil {
+		slog.Warn("task mcp: stop failed", "task_id", taskID, "err", err)
+		w.Header().Set("Content-Type", "application/json")
+		http.Error(w, `{"error":"not found"}`, http.StatusNotFound)
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+func handleTaskMCPGet(w http.ResponseWriter, r *http.Request, taskID string, lm *mcplifecycle.LifecycleManager) {
+	inst, ok := lm.Get(taskID)
+	if !ok {
+		http.NotFound(w, r)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(map[string]any{
+		"task_id":   inst.TaskID,
+		"task_slug": inst.TaskSlug,
+		"ws_root":   inst.WsRoot,
+		"port":      inst.Port,
+		"token":     inst.Token,
+	})
+}


### PR DESCRIPTION
## Summary

- `MCPInstance`: per-task isolated MCP stack, listener pre-bound at `New()` (eliminates freePort TOCTOU race)
- `LifecycleManager`: thread-safe registry, idempotent restart, `StopAll` for daemon shutdown
- REST API: `POST/DELETE/GET /api/v1/tasks/{id}/mcp`
- `cc_settings`: `InjectMCPServer`/`RemoveMCPServer` take explicit `name` param (`"tether"` for global, `"tether-<slug>"` for per-task)
- Security: `crypto/subtle` constant-time bearer token comparison; `ReadHeaderTimeout: 30s` on loopback server
- Tests: `instance_test.go` + `manager_test.go`

## Test plan
- [ ] `go build ./...` clean
- [ ] `go test ./...` all pass (13 packages)
- [ ] `POST /api/v1/tasks/{id}/mcp` starts instance, returns port + token
- [ ] `DELETE /api/v1/tasks/{id}/mcp` stops instance cleanly

---
_polyforge task: `t-01KRD1GYDZK5T1TW32RFAREEQV`_