### PR TITLE
feat(mcp): v0.4 end-to-end — workspace_run_shell + per-task lifecycle smoke test + polyforge hookup

### DIFF
--- a/internal/mcp/builtin/workspace.go
+++ b/internal/mcp/builtin/workspace.go
@@ -13,12 +13,17 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"syscall"
 	"time"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
 
-const shellTimeout = 30 * time.Second
+const (
+	shellDefaultTimeout = 30 * time.Second
+	shellMaxTimeout     = 300 * time.Second
+	maxOutputBytes      = 4 << 20 // 4 MiB per stream
+)
 
 // Registry holds builtin MCP tool registrations scoped to a workspace root.
 type Registry struct {
@@ -71,8 +76,8 @@ func (r *Registry) RegisterInto(srv *mcp.Server) {
 
 	srv.AddTool(&mcp.Tool{
 		Name:        "workspace_run_shell",
-		Description: "Run a shell command inside the workspace. Returns stdout, stderr, and exit code as JSON.",
-		InputSchema: json.RawMessage(`{"type":"object","properties":{"command":{"type":"string","description":"Shell command to execute via sh -c"},"cwd":{"type":"string","description":"Working directory relative to workspace root (default: workspace root)"}},"required":["command"]}`),
+		Description: "Run a shell command inside the workspace (30s default timeout, max 300s). Returns stdout, stderr, exit_code, and truncated as JSON. Each output stream is capped at 4 MiB.",
+		InputSchema: json.RawMessage(`{"type":"object","properties":{"command":{"type":"string","description":"Shell command to execute via sh -c"},"cwd":{"type":"string","description":"Working directory relative to workspace root (default: workspace root)"},"timeout_secs":{"type":"integer","description":"Timeout in seconds (1–300, default 30)"}},"required":["command"]}`),
 	}, r.handleRunShell)
 }
 
@@ -124,17 +129,22 @@ func (r *Registry) handleListFiles(_ context.Context, req *mcp.CallToolRequest) 
 }
 
 type shellResult struct {
-	Stdout   string `json:"stdout"`
-	Stderr   string `json:"stderr"`
-	ExitCode int    `json:"exit_code"`
+	Stdout    string `json:"stdout"`
+	Stderr    string `json:"stderr"`
+	ExitCode  int    `json:"exit_code"`
+	Truncated bool   `json:"truncated,omitempty"`
 }
 
 func (r *Registry) handleRunShell(ctx context.Context, req *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	var params struct {
-		Command string `json:"command"`
-		Cwd     string `json:"cwd"`
+		Command     string `json:"command"`
+		Cwd         string `json:"cwd"`
+		TimeoutSecs int    `json:"timeout_secs"`
 	}
-	if err := json.Unmarshal(req.Params.Arguments, &params); err != nil || params.Command == "" {
+	if err := json.Unmarshal(req.Params.Arguments, &params); err != nil {
+		return errResult(fmt.Sprintf("workspace_run_shell: invalid arguments: %v", err)), nil
+	}
+	if params.Command == "" {
 		return errResult("workspace_run_shell: missing required field 'command'"), nil
 	}
 
@@ -147,32 +157,91 @@ func (r *Registry) handleRunShell(ctx context.Context, req *mcp.CallToolRequest)
 		cwd = resolved
 	}
 
-	ctx, cancel := context.WithTimeout(ctx, shellTimeout)
+	timeout := shellDefaultTimeout
+	if params.TimeoutSecs > 0 {
+		t := time.Duration(params.TimeoutSecs) * time.Second
+		if t > shellMaxTimeout {
+			t = shellMaxTimeout
+		}
+		timeout = t
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 
-	cmd := exec.CommandContext(ctx, "sh", "-c", params.Command)
+	cmd := exec.Command("sh", "-c", params.Command)
 	cmd.Dir = cwd
+	// Setpgid puts the child in its own process group so we can kill the
+	// entire group (child + any spawned subprocesses) on timeout.
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
 
-	var stdout, stderr bytes.Buffer
-	cmd.Stdout = &stdout
-	cmd.Stderr = &stderr
+	var stdoutBuf, stderrBuf bytes.Buffer
+	stdoutLW := &limitWriter{w: &stdoutBuf, remaining: maxOutputBytes}
+	stderrLW := &limitWriter{w: &stderrBuf, remaining: maxOutputBytes}
+	cmd.Stdout = stdoutLW
+	cmd.Stderr = stderrLW
+
+	if err := cmd.Start(); err != nil {
+		return errResult(fmt.Sprintf("workspace_run_shell: %v", err)), nil
+	}
+
+	done := make(chan error, 1)
+	go func() { done <- cmd.Wait() }()
+
+	var runErr error
+	select {
+	case runErr = <-done:
+		// normal completion
+	case <-ctx.Done():
+		// Kill the entire process group to avoid orphaned children.
+		if cmd.Process != nil {
+			_ = syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL)
+		}
+		<-done
+		return errResult("workspace_run_shell: timed out"), nil
+	}
 
 	exitCode := 0
-	if err := cmd.Run(); err != nil {
+	if runErr != nil {
 		var exitErr *exec.ExitError
-		if errors.As(err, &exitErr) {
+		if errors.As(runErr, &exitErr) {
 			exitCode = exitErr.ExitCode()
 		} else {
-			return errResult(fmt.Sprintf("workspace_run_shell: %v", err)), nil
+			return errResult(fmt.Sprintf("workspace_run_shell: %v", runErr)), nil
 		}
 	}
 
 	b, _ := json.Marshal(shellResult{
-		Stdout:   stdout.String(),
-		Stderr:   stderr.String(),
-		ExitCode: exitCode,
+		Stdout:    stdoutBuf.String(),
+		Stderr:    stderrBuf.String(),
+		ExitCode:  exitCode,
+		Truncated: stdoutLW.truncated || stderrLW.truncated,
 	})
 	return &mcp.CallToolResult{Content: []mcp.Content{&mcp.TextContent{Text: string(b)}}}, nil
+}
+
+// limitWriter caps writes at remaining bytes; excess bytes are silently
+// discarded (truncated=true). Always reports the full len(p) to callers so
+// exec's pipe machinery doesn't stall.
+type limitWriter struct {
+	w         *bytes.Buffer
+	remaining int64
+	truncated bool
+}
+
+func (lw *limitWriter) Write(p []byte) (int, error) {
+	orig := len(p)
+	if lw.remaining <= 0 {
+		lw.truncated = true
+		return orig, nil
+	}
+	if int64(len(p)) > lw.remaining {
+		p = p[:lw.remaining]
+		lw.truncated = true
+	}
+	n, err := lw.w.Write(p)
+	lw.remaining -= int64(n)
+	return orig, err
 }
 
 func errResult(msg string) *mcp.CallToolResult {

--- a/internal/mcp/builtin/workspace.go
+++ b/internal/mcp/builtin/workspace.go
@@ -4,15 +4,21 @@
 package builtin
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
+
+const shellTimeout = 30 * time.Second
 
 // Registry holds builtin MCP tool registrations scoped to a workspace root.
 type Registry struct {
@@ -48,7 +54,8 @@ func (r *Registry) SafeJoin(input string) (string, error) {
 	return resolved, nil
 }
 
-// RegisterInto adds workspace_read_file and workspace_list_files to srv.
+// RegisterInto adds workspace_read_file, workspace_list_files, and
+// workspace_run_shell to srv.
 func (r *Registry) RegisterInto(srv *mcp.Server) {
 	srv.AddTool(&mcp.Tool{
 		Name:        "workspace_read_file",
@@ -61,6 +68,12 @@ func (r *Registry) RegisterInto(srv *mcp.Server) {
 		Description: "List files and directories one level deep within the workspace.",
 		InputSchema: json.RawMessage(`{"type":"object","properties":{"dir":{"type":"string","description":"Relative directory path (default: workspace root)"}}}`),
 	}, r.handleListFiles)
+
+	srv.AddTool(&mcp.Tool{
+		Name:        "workspace_run_shell",
+		Description: "Run a shell command inside the workspace. Returns stdout, stderr, and exit code as JSON.",
+		InputSchema: json.RawMessage(`{"type":"object","properties":{"command":{"type":"string","description":"Shell command to execute via sh -c"},"cwd":{"type":"string","description":"Working directory relative to workspace root (default: workspace root)"}},"required":["command"]}`),
+	}, r.handleRunShell)
 }
 
 func (r *Registry) handleReadFile(_ context.Context, req *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
@@ -107,6 +120,58 @@ func (r *Registry) handleListFiles(_ context.Context, req *mcp.CallToolRequest) 
 		files[i] = fileEntry{Name: e.Name(), IsDir: e.IsDir()}
 	}
 	b, _ := json.Marshal(files)
+	return &mcp.CallToolResult{Content: []mcp.Content{&mcp.TextContent{Text: string(b)}}}, nil
+}
+
+type shellResult struct {
+	Stdout   string `json:"stdout"`
+	Stderr   string `json:"stderr"`
+	ExitCode int    `json:"exit_code"`
+}
+
+func (r *Registry) handleRunShell(ctx context.Context, req *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	var params struct {
+		Command string `json:"command"`
+		Cwd     string `json:"cwd"`
+	}
+	if err := json.Unmarshal(req.Params.Arguments, &params); err != nil || params.Command == "" {
+		return errResult("workspace_run_shell: missing required field 'command'"), nil
+	}
+
+	cwd := r.root
+	if params.Cwd != "" {
+		resolved, err := r.SafeJoin(params.Cwd)
+		if err != nil {
+			return errResult(fmt.Sprintf("workspace_run_shell: invalid cwd: %v", err)), nil
+		}
+		cwd = resolved
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, shellTimeout)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, "sh", "-c", params.Command)
+	cmd.Dir = cwd
+
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	exitCode := 0
+	if err := cmd.Run(); err != nil {
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) {
+			exitCode = exitErr.ExitCode()
+		} else {
+			return errResult(fmt.Sprintf("workspace_run_shell: %v", err)), nil
+		}
+	}
+
+	b, _ := json.Marshal(shellResult{
+		Stdout:   stdout.String(),
+		Stderr:   stderr.String(),
+		ExitCode: exitCode,
+	})
 	return &mcp.CallToolResult{Content: []mcp.Content{&mcp.TextContent{Text: string(b)}}}, nil
 }
 

--- a/internal/mcp/builtin/workspace_test.go
+++ b/internal/mcp/builtin/workspace_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
@@ -94,6 +95,92 @@ func TestListFiles_ReturnsDirEntries(t *testing.T) {
 	result := invokeBuiltin(t, srv, "workspace_list_files", args)
 	if result.IsError {
 		t.Fatalf("unexpected error: %v", result.Content)
+	}
+}
+
+func TestRunShell_Success(t *testing.T) {
+	root := t.TempDir()
+	srv := mcp.NewServer(&mcp.Implementation{Name: "test"}, nil)
+	reg, err := builtin.New(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	reg.RegisterInto(srv)
+
+	args, _ := json.Marshal(map[string]string{"command": "echo hello"})
+	result := invokeBuiltin(t, srv, "workspace_run_shell", args)
+	if result.IsError {
+		t.Fatalf("unexpected error: %v", result.Content)
+	}
+	var out struct {
+		Stdout   string `json:"stdout"`
+		ExitCode int    `json:"exit_code"`
+	}
+	if err := json.Unmarshal([]byte(result.Content[0].(*mcp.TextContent).Text), &out); err != nil {
+		t.Fatal(err)
+	}
+	if out.ExitCode != 0 {
+		t.Fatalf("expected exit_code 0, got %d", out.ExitCode)
+	}
+	if !strings.Contains(out.Stdout, "hello") {
+		t.Fatalf("expected stdout to contain 'hello', got %q", out.Stdout)
+	}
+}
+
+func TestRunShell_NonZeroExit(t *testing.T) {
+	root := t.TempDir()
+	srv := mcp.NewServer(&mcp.Implementation{Name: "test"}, nil)
+	reg, err := builtin.New(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	reg.RegisterInto(srv)
+
+	args, _ := json.Marshal(map[string]string{"command": "exit 42"})
+	result := invokeBuiltin(t, srv, "workspace_run_shell", args)
+	if result.IsError {
+		t.Fatalf("unexpected tool-level error: %v", result.Content)
+	}
+	var out struct {
+		ExitCode int `json:"exit_code"`
+	}
+	if err := json.Unmarshal([]byte(result.Content[0].(*mcp.TextContent).Text), &out); err != nil {
+		t.Fatal(err)
+	}
+	if out.ExitCode != 42 {
+		t.Fatalf("expected exit_code 42, got %d", out.ExitCode)
+	}
+}
+
+func TestRunShell_MissingCommand(t *testing.T) {
+	root := t.TempDir()
+	srv := mcp.NewServer(&mcp.Implementation{Name: "test"}, nil)
+	reg, err := builtin.New(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	reg.RegisterInto(srv)
+
+	args, _ := json.Marshal(map[string]string{})
+	result := invokeBuiltin(t, srv, "workspace_run_shell", args)
+	if !result.IsError {
+		t.Fatal("expected IsError=true for missing command")
+	}
+}
+
+func TestRunShell_CwdEscapeRejected(t *testing.T) {
+	root := t.TempDir()
+	srv := mcp.NewServer(&mcp.Implementation{Name: "test"}, nil)
+	reg, err := builtin.New(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	reg.RegisterInto(srv)
+
+	args, _ := json.Marshal(map[string]string{"command": "pwd", "cwd": "../../"})
+	result := invokeBuiltin(t, srv, "workspace_run_shell", args)
+	if !result.IsError {
+		t.Fatal("expected IsError=true for cwd traversal")
 	}
 }
 

--- a/internal/mcp/builtin/workspace_test.go
+++ b/internal/mcp/builtin/workspace_test.go
@@ -212,3 +212,55 @@ func invokeBuiltin(t *testing.T, srv *mcp.Server, toolName string, args json.Raw
 	}
 	return result
 }
+
+func TestRunShell_TruncatesLargeOutput(t *testing.T) {
+	root := t.TempDir()
+	srv := mcp.NewServer(&mcp.Implementation{Name: "test"}, nil)
+	reg, err := builtin.New(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	reg.RegisterInto(srv)
+
+	// Generate output larger than maxOutputBytes (4 MiB); dd writes 5 MiB zeros.
+	args, _ := json.Marshal(map[string]string{"command": "dd if=/dev/zero bs=1M count=5 2>/dev/null | cat"})
+	result := invokeBuiltin(t, srv, "workspace_run_shell", args)
+	if result.IsError {
+		t.Fatalf("unexpected tool error: %v", result.Content)
+	}
+	var out struct {
+		Stdout    string `json:"stdout"`
+		Truncated bool   `json:"truncated"`
+	}
+	if err := json.Unmarshal([]byte(result.Content[0].(*mcp.TextContent).Text), &out); err != nil {
+		t.Fatal(err)
+	}
+	if !out.Truncated {
+		t.Fatal("expected truncated=true for 5 MiB output")
+	}
+	if len(out.Stdout) > 4<<20+1 {
+		t.Fatalf("stdout exceeds 4 MiB cap: %d bytes", len(out.Stdout))
+	}
+}
+
+
+func TestRunShell_CustomTimeout(t *testing.T) {
+	root := t.TempDir()
+	srv := mcp.NewServer(&mcp.Implementation{Name: "test"}, nil)
+	reg, err := builtin.New(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	reg.RegisterInto(srv)
+
+	// 1s timeout, command sleeps 10s — should time out.
+	args, _ := json.Marshal(map[string]any{"command": "sleep 10", "timeout_secs": 1})
+	result := invokeBuiltin(t, srv, "workspace_run_shell", args)
+	if !result.IsError {
+		t.Fatal("expected IsError=true for timed-out command")
+	}
+	text := result.Content[0].(*mcp.TextContent).Text
+	if !strings.Contains(text, "timed out") {
+		t.Fatalf("expected 'timed out' in error, got %q", text)
+	}
+}

--- a/internal/server/mux.go
+++ b/internal/server/mux.go
@@ -139,7 +139,7 @@ func buildMux(cfg *Config, bundle CertBundle, wts *webtransport.Server, reg *ses
 
 	// v0.4: per-task MCP lifecycle endpoints.
 	if lm != nil {
-		registerTaskMCPAPI(mux, lm, pm)
+		RegisterTaskMCPAPI(mux, lm, pm)
 	}
 
 	mux.HandleFunc("/api/v1/", func(w http.ResponseWriter, _ *http.Request) {

--- a/internal/server/task_mcp.go
+++ b/internal/server/task_mcp.go
@@ -13,12 +13,12 @@ import (
 	"github.com/piaobeizu/tether/internal/permission"
 )
 
-// registerTaskMCPAPI mounts the per-task MCP lifecycle REST endpoints.
+// RegisterTaskMCPAPI mounts the per-task MCP lifecycle REST endpoints.
 //
 //	POST   /api/v1/tasks/{id}/mcp   → start a per-task MCPInstance
 //	DELETE /api/v1/tasks/{id}/mcp   → stop the instance for task {id}
 //	GET    /api/v1/tasks/{id}/mcp   → inspect the running instance (port, token)
-func registerTaskMCPAPI(mux *http.ServeMux, lm *mcplifecycle.LifecycleManager, pm *permission.Manager) {
+func RegisterTaskMCPAPI(mux *http.ServeMux, lm *mcplifecycle.LifecycleManager, pm *permission.Manager) {
 	mux.HandleFunc("/api/v1/tasks/", func(w http.ResponseWriter, r *http.Request) {
 		// ServeMux routes all /api/v1/tasks/{...} paths here.
 		// We only handle paths of the form /api/v1/tasks/{id}/mcp.

--- a/internal/server/task_mcp_test.go
+++ b/internal/server/task_mcp_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json" // for startInstanceReq body marshaling
 	"fmt"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -117,8 +118,8 @@ func TestTaskMCPLifecycle_ToolCallEndToEnd(t *testing.T) {
 	port := int(out["port"].(float64))
 	token := out["token"].(string)
 
-	// Small delay for the loopback goroutine to be ready.
-	time.Sleep(20 * time.Millisecond)
+	// Wait for loopback to be ready via retry-dial instead of a fixed sleep.
+	waitForPort(t, port, 200*time.Millisecond)
 
 	// Connect MCP client to the per-task loopback.
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
@@ -190,4 +191,20 @@ func TestTaskMCPLifecycle_MissingSlugRejected(t *testing.T) {
 	if resp.StatusCode != http.StatusBadRequest {
 		t.Fatalf("expected 400 for missing slug, got %d", resp.StatusCode)
 	}
+}
+
+// waitForPort retries a TCP dial until the port accepts connections or deadline.
+func waitForPort(t *testing.T, port int, deadline time.Duration) {
+	t.Helper()
+	addr := fmt.Sprintf("127.0.0.1:%d", port)
+	end := time.Now().Add(deadline)
+	for time.Now().Before(end) {
+		conn, err := net.DialTimeout("tcp", addr, 5*time.Millisecond)
+		if err == nil {
+			conn.Close()
+			return
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	t.Fatalf("port %d not ready after %v", port, deadline)
 }

--- a/internal/server/task_mcp_test.go
+++ b/internal/server/task_mcp_test.go
@@ -1,0 +1,193 @@
+package server_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json" // for startInstanceReq body marshaling
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	mcplifecycle "github.com/piaobeizu/tether/internal/mcp/lifecycle"
+	"github.com/piaobeizu/tether/internal/permission"
+	"github.com/piaobeizu/tether/internal/server"
+)
+
+// setupTaskMCPServer returns an httptest.Server with the task MCP REST API
+// mounted, plus the LifecycleManager so callers can inspect running instances.
+func setupTaskMCPServer(t *testing.T) (*httptest.Server, *mcplifecycle.LifecycleManager) {
+	t.Helper()
+	lm := mcplifecycle.New()
+	pm := permission.New()
+	mux := http.NewServeMux()
+	server.RegisterTaskMCPAPI(mux, lm, pm)
+	ts := httptest.NewServer(mux)
+	t.Cleanup(func() {
+		ts.Close()
+		ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+		defer cancel()
+		lm.StopAll(ctx)
+	})
+	return ts, lm
+}
+
+// startInstanceReq calls POST /api/v1/tasks/{id}/mcp with skip_inject=true.
+func startInstanceReq(t *testing.T, ts *httptest.Server, taskID, slug, wsRoot string) map[string]any {
+	t.Helper()
+	body, _ := json.Marshal(map[string]any{
+		"slug":         slug,
+		"ws_root":      wsRoot,
+		"skip_inject":  true,
+	})
+	resp, err := http.Post(
+		fmt.Sprintf("%s/api/v1/tasks/%s/mcp", ts.URL, taskID),
+		"application/json",
+		bytes.NewReader(body),
+	)
+	if err != nil {
+		t.Fatalf("POST task mcp: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("POST task mcp: expected 200, got %d", resp.StatusCode)
+	}
+	var out map[string]any
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	return out
+}
+
+func TestTaskMCPLifecycle_StartAndStop(t *testing.T) {
+	ts, lm := setupTaskMCPServer(t)
+	wsRoot := t.TempDir()
+	taskID := "t-smoke-001"
+
+	// Start an MCPInstance via REST.
+	out := startInstanceReq(t, ts, taskID, "smoke", wsRoot)
+	port := int(out["port"].(float64))
+	token := out["token"].(string)
+	if port == 0 || token == "" {
+		t.Fatalf("expected non-zero port and token, got port=%d token=%q", port, token)
+	}
+
+	// Verify LifecycleManager registered it.
+	if inst, ok := lm.Get(taskID); !ok || inst.Port != port {
+		t.Fatalf("instance not found in manager after start")
+	}
+
+	// GET inspect endpoint.
+	resp, err := http.Get(fmt.Sprintf("%s/api/v1/tasks/%s/mcp", ts.URL, taskID))
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("GET: expected 200, got %d", resp.StatusCode)
+	}
+
+	// DELETE stops the instance.
+	req, _ := http.NewRequest(http.MethodDelete, fmt.Sprintf("%s/api/v1/tasks/%s/mcp", ts.URL, taskID), nil)
+	delResp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("DELETE: %v", err)
+	}
+	delResp.Body.Close()
+	if delResp.StatusCode != http.StatusNoContent {
+		t.Fatalf("DELETE: expected 204, got %d", delResp.StatusCode)
+	}
+
+	// Instance no longer in manager.
+	if _, ok := lm.Get(taskID); ok {
+		t.Fatal("instance still in manager after DELETE")
+	}
+}
+
+func TestTaskMCPLifecycle_ToolCallEndToEnd(t *testing.T) {
+	ts, _ := setupTaskMCPServer(t)
+	wsRoot := t.TempDir()
+	taskID := "t-e2e-001"
+
+	// Start instance.
+	out := startInstanceReq(t, ts, taskID, "e2e", wsRoot)
+	port := int(out["port"].(float64))
+	token := out["token"].(string)
+
+	// Small delay for the loopback goroutine to be ready.
+	time.Sleep(20 * time.Millisecond)
+
+	// Connect MCP client to the per-task loopback.
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	client := mcp.NewClient(&mcp.Implementation{Name: "smoke-test"}, nil)
+	transport := &mcp.StreamableClientTransport{
+		Endpoint: fmt.Sprintf("http://127.0.0.1:%d/mcp", port),
+		HTTPClient: &http.Client{
+			Transport: &bearerTransport{token: token, base: http.DefaultTransport},
+		},
+		DisableStandaloneSSE: true,
+	}
+	sess, err := client.Connect(ctx, transport, nil)
+	if err != nil {
+		t.Fatalf("MCP connect: %v", err)
+	}
+	defer sess.Close()
+
+	// workspace_run_shell must be listed.
+	tools, err := sess.ListTools(ctx, nil)
+	if err != nil {
+		t.Fatalf("ListTools: %v", err)
+	}
+	if !containsTool(tools.Tools, "workspace_run_shell") {
+		t.Fatalf("workspace_run_shell not in tools list; got %v", toolNames(tools.Tools))
+	}
+
+	// Call workspace_run_shell — echo a known string.
+	// Arguments must be map[string]any (not json.RawMessage) — go-sdk marshals
+	// the any value to JSON; passing []byte would produce base64, not an object.
+	result, err := sess.CallTool(ctx, &mcp.CallToolParams{
+		Name:      "workspace_run_shell",
+		Arguments: map[string]any{"command": "echo e2e-ok"},
+	})
+	if err != nil {
+		t.Fatalf("CallTool workspace_run_shell: %v", err)
+	}
+	if result.IsError {
+		errText := ""
+		if len(result.Content) > 0 {
+			if tc, ok := result.Content[0].(*mcp.TextContent); ok {
+				errText = tc.Text
+			}
+		}
+		t.Fatalf("tool returned error: %s", errText)
+	}
+	text := result.Content[0].(*mcp.TextContent).Text
+	if !strings.Contains(text, "e2e-ok") {
+		t.Fatalf("expected stdout to contain 'e2e-ok', got %q", text)
+	}
+}
+
+func TestTaskMCPLifecycle_MissingSlugRejected(t *testing.T) {
+	ts, _ := setupTaskMCPServer(t)
+	body, _ := json.Marshal(map[string]any{
+		"ws_root":     t.TempDir(),
+		"skip_inject": true,
+	})
+	resp, err := http.Post(
+		fmt.Sprintf("%s/api/v1/tasks/t-bad/mcp", ts.URL),
+		"application/json",
+		bytes.NewReader(body),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("expected 400 for missing slug, got %d", resp.StatusCode)
+	}
+}


### PR DESCRIPTION
## Summary

- `workspace_run_shell` builtin MCP tool：`exec.Command` + pipe capture，30s timeout，`sh -c`，cwd 经 `SafeJoin` 校验，返回 `{stdout, stderr, exit_code}` JSON。不走 PTY（PTY 是 `/wt/shell` 交互式 terminal 专用）。
- 端到端集成测试：REST `POST /api/v1/tasks/{id}/mcp` → `MCPInstance` 启动 → HTTP transport MCP 客户端 → `workspace_run_shell` tool call → 验证输出。顺带导出 `RegisterTaskMCPAPI`，发现 go-sdk `CallToolParams.Arguments` 为 `any`（传 `json.RawMessage` 会被序列化为 base64）。
- polyforge lifecycle hookup：`.claude/settings.json` PostToolUse hooks 拦截 `pf2_task_start` / `pf2_task_pause` / `pf2_task_wrap`，调 `tether-mcp-start.sh` / `tether-mcp-stop.sh`，自动 spawn/kill per-task MCPInstance。

## Test Plan

- [x] `go test ./internal/mcp/builtin/...` — workspace_run_shell 4 项测试全通过
- [x] `go test ./internal/server/... -run TestTaskMCP` — 端到端集成测试全通过
- [x] `go test ./...` — 全套 21 个 package 无回归
- [x] GCP daemon 已替换新 binary 验证运行正常

---
_polyforge task: `t-01KRD1GYDZK5T1TW32RFAREEQV`_