### PR TITLE
docs: v1.0 release checklist — CHANGELOG + upgrade-path + known-limitations + release-gate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## v0.4.0 — 2026-05-12
+## v0.4.0 — 2026-05-12 (PR #68, #69, #70)
 
 ### Added
 - **Per-task MCP lifecycle**: `MCPInstance` + `LifecycleManager` — spawn/stop external MCP

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,27 @@
 # Changelog
 
-## v0.3.4 — tether doctor MCP health (unreleased)
+## v0.4.0 — 2026-05-12
+
+### Added
+- **Per-task MCP lifecycle**: `MCPInstance` + `LifecycleManager` — spawn/stop external MCP
+  servers on task start/pause; REST API `POST/DELETE /api/v1/mcp/lifecycle/{task_id}`.
+- **`workspace_run_shell` builtin tool**: exec + pipe (no PTY), 4 MiB output cap,
+  `Setpgid` process-group kill, `timeout_secs` parameter.
+- **End-to-end smoke test**: REST POST → MCPInstance → HTTP MCP → tool call
+  (`waitForPort` replaces flaky `sleep`).
+- **Polyforge lifecycle hooks**: `.claude/settings.json` PostToolUse intercepts
+  `pf2_task_start/pause/wrap` → curl tether REST, bridging workspace events into
+  tether's MCP lifecycle.
+- **Design token system**: CSS custom properties in `tokens.css`; dark-mode body
+  background override (`[data-theme="dark"] body { background: #0F0E0C }`).
+- **WebTransport + SPA routing fixes**: Alt-Svc rewrite, `/wt/*` path conflicts resolved.
+
+### Notes
+- `workspace_run_shell` is exec+pipe only; PTY is `/wt/shell` (interactive terminal).
+- `CallToolParams.Arguments` in go-sdk is `any`; pass `map[string]any`, not
+  `json.RawMessage`, to avoid base64-encoding in tests.
+
+## v0.3.4 — 2026-05-12 (PR #69)
 
 ### Added
 - Three new `tether doctor` checks for MCP subsystem health:
@@ -17,7 +38,7 @@
   `~/.claude/settings.json`; hooks check now reads the correct file so it no
   longer always reports "hook not found" on a correctly configured system
 
-## v0.3.3 — OAuth 2.1 PKCE (unreleased)
+## v0.3.3 — 2026-05-11/12 (PR #68)
 
 ### Added
 - `internal/auth/oauth/` — OAuth 2.1 Authorization Code + PKCE (S256) flow
@@ -38,7 +59,7 @@
 ### Changed
 - `auth.State.isExempt` — exact-path exemptions for `/oauth/authorize`, `/oauth/token`, `/.well-known/oauth-authorization-server`
 
-## v0.3.2 (unreleased)
+## v0.3.2 — 2026-05-11 (PR #67)
 
 ### Added
 - HTTPS `/mcp` endpoint on the main port for external MCP clients (Cursor, Goose).
@@ -74,14 +95,14 @@
   cookie middleware and `WithOriginGuard` CSRF posture (rejects POST/DELETE with
   mismatched `Origin` header).
 
-## v0.3.1 (merged 2026-05-11)
+## v0.3.1 — 2026-05-11 (PR #66)
 
 ### Added
 - MCP loopback endpoint at `127.0.0.1:8899/mcp` for CC subprocess integration.
 - Builtin workspace tools (`workspace_read_file`, `workspace_list_files`, etc.).
 - CC settings injection into `~/.claude/settings.json` on daemon startup.
 
-## v0.3.0 (unreleased)
+## v0.3.0 — 2026-05-10 (PR #64/#65)
 
 ### Changed
 - Permission API: canonical paths are now `/api/v1/permission/request` and `/api/v1/permission/{id}/decide`. Old paths `/api/v1/agent/permission/*` are kept as aliases through v0.3.x and will be removed in v0.4.
@@ -89,7 +110,7 @@
 - `internal/agent/permhook/` renamed to `internal/permission/cchook/` (import path change; binary behavior unchanged).
 - `/mcp` and `/api/v1/mcp/*` reserved — return 501 until MCP host is implemented later in v0.3.
 
-## v0.2.0 (unreleased)
+## v0.2.0 — 2026-05-10 (PR #63)
 
 ### Added
 - Auth: static token gate (`--token` flag, auto-generated at `~/.tether/access-token`); JWT cookie (`HttpOnly; Secure; SameSite=Strict; Path=/`; 90-day sliding expiry); `/auth` page in SPA

--- a/docs/known-limitations.md
+++ b/docs/known-limitations.md
@@ -1,46 +1,63 @@
-# Known Limitations — tether v0.1
+# Known Limitations — tether v0.4
 
 ## Security
 
 **No end-to-end encryption (D-12 deferred to v1.0+)**
-TLS terminates at the tether daemon. The threat model is equivalent to cloudcli: traffic between the browser and daemon is TLS-protected, but the daemon itself has plaintext access. WebCrypto E2E (D-12) is a v1.0+ item.
+TLS terminates at the tether daemon. Traffic between the browser and daemon is
+TLS-protected, but the daemon itself has plaintext access. WebCrypto E2E (D-12)
+is a v1.0+ item.
 
-**Self-signed certificate**
-v0.1 does not integrate with Let's Encrypt or any CA. The daemon generates a 14-day ECDSA P-256 self-signed cert that auto-rotates. Browser access requires a `--ignore-certificate-errors` flag or a per-origin override. See [README K.8.3](../README.md#k83--self-signed-cert-chrome-refuses-to-load-the-page).
+~~**Self-signed certificate**~~
+*(Resolved in v0.1.1 / v0.2.0)* — Let's Encrypt ACME is available via
+`--acme-domain` / `--acme-email`. For LAN/self-signed dev setups see
+[README K.8.3](../README.md#k83--self-signed-cert-chrome-refuses-to-load-the-page).
 
 ## Connectivity
 
-**No TCP fallback for WebTransport (Risk #2)**
-HTTP/3 over UDP is the only transport. VPNs and corporate firewalls that block UDP will cause chat/shell channels to fail even if the page loads. No WebSocket fallback in v0.1. See [README K.8.1](../README.md#k81--vpn--corporate-firewall-breaks-the-shell-and-chat-channels).
+**No TCP fallback for WebTransport**
+HTTP/3 over UDP is the only transport. VPNs and corporate firewalls that block
+UDP will cause chat/shell channels to fail even if the page loads. See
+[README K.8.1](../README.md#k81--vpn--corporate-firewall-breaks-the-shell-and-chat-channels).
 
 **Browser support: Chrome/Edge 97+ only**
-Firefox and Safari do not support the WebTransport API. See [README K.8.2](../README.md#k82--browser-version-requirements).
+Firefox and Safari do not support the WebTransport API. See
+[README K.8.2](../README.md#k82--browser-version-requirements).
 
 ## Multi-user / Multi-device
 
-**Single-user, single-machine only**
-No authentication (D-16 deferred), no pairing (D-13 deferred). The daemon binds to `127.0.0.1` by default. LAN/remote access requires `TETHER_HOST` and Chrome cert-bypass flags.
+~~**Single-user, single-machine only (no auth)**~~
+*(Partially resolved)* — v0.2.0 added JWT token gate; v0.3.2 added manual API
+tokens for external MCP clients; v0.3.3 added OAuth 2.1 PKCE. Full multi-user
+session isolation (D-04 `LockUser="default"`) is still v1.0+.
 
-**No pair/attach commands**
-`tether attach` and `tether pair` are stubs. Multi-device pairing is v1.0+.
+**No QR-pairing (`tether pair`)**
+`tether pair` is deferred to v1.0 (D-13).
 
 ## Agent providers
 
-**Claude Code only**
-opencode, Cursor, and Gemini providers are stubbed (`Spawn()` returns "not yet implemented"). Multi-provider support is v0.2+.
+~~**Claude Code only**~~
+*(Partially resolved)* — opencode provider added in v0.2.0. External MCP
+clients (Cursor, Goose) can connect via OAuth PKCE (v0.3.3) or manual Bearer
+tokens (v0.3.2). Gemini provider is still v1.0+.
 
 ## UI / PWA
 
 **No offline support**
-The PWA manifest is minimal. Service worker and offline caching are v0.1.1 follow-ups.
+The PWA manifest is minimal. Service worker and offline caching are v0.5+.
 
 **No partial-message streaming**
-`--include-partial-messages` is not enabled. The chat pane renders complete assistant turns only.
+`--include-partial-messages` is not enabled. The chat pane renders complete
+assistant turns only. Deferred to v0.5+.
 
 ## Permission hook
 
 **`bypassPermissions` mode skips the hook**
-When `claude` is started in `--permission-mode bypassPermissions`, cc does not fire PreToolUse hooks. tether's permission UI is never shown — tool calls auto-approve. This is the intended UX for fully autonomous mode.
+When `claude` is started in `--permission-mode bypassPermissions`, cc does not
+fire PreToolUse hooks. tether's permission UI is never shown — tool calls
+auto-approve. This is the intended UX for fully autonomous mode.
 
 **Hook requires Go toolchain at runtime (fallback path)**
-The permission hook binary is pre-compiled in release tarballs. For `go install` users, the hook is compiled from embedded source on first daemon start, which requires `go` on PATH. If `go` is absent, the hook compilation is skipped and a warning is logged.
+The permission hook binary is pre-compiled in release tarballs. For `go install`
+users the hook is compiled from embedded source on first daemon start, which
+requires `go` on PATH. If `go` is absent, the hook compilation is skipped and a
+warning is logged.

--- a/docs/release-gate.md
+++ b/docs/release-gate.md
@@ -1,0 +1,59 @@
+# tether v1.0 Release Gate
+
+> Last updated 2026-05-13. K-criteria = the spec §10.K ship gate.
+
+## K-criteria status
+
+| # | Criterion | Status | Notes |
+|---|---|---|---|
+| K.1 | Single binary, `go install` | ✅ | v0.1.0+ |
+| K.2 | HTTP/3 + WebTransport single-port mux | ✅ | v0.1.0+ |
+| K.3 | Chat channel (`/wt/chat`) stream-json | ✅ | v0.1.0+ |
+| K.4 | Shell channel (`/wt/shell`) PTY | ✅ | v0.1.0+ |
+| K.5 | Permission UI (PreToolUse hook) | ✅ | v0.1.0+ |
+| K.6 | `tether doctor` preflight | ✅ | v0.1.0+; MCP checks added v0.3.4 |
+| K.7 | CI pipeline (codegen drift, build, test) | ✅ | v0.1.0+ |
+| K.8 | Troubleshooting docs (VPN, cert, browser) | ✅ | README K.8.1–K.8.6; PR #71 (2026-05-13) |
+| K.9 | Performance baseline | ✅ | In-process benchmarks + E2E script; PR #72 (2026-05-13) |
+| K.10 | Dogfood ≥1 week | — | **Explicitly waived** (2026-05-13) |
+
+**All K-criteria met or waived.** This codebase is at the v0.4.0 ship-gate baseline.
+
+---
+
+## What ships at v0.4 ("v1.0 baseline")
+
+- Single-port HTTP/3 + TCP server with ECDSA P-256 cert (self-signed or ACME).
+- Chat + Shell + Events WebTransport channels.
+- Permission UI (PreToolUse hook gate).
+- Auth: JWT cookie + OAuth 2.1 PKCE + manual API tokens.
+- MCP Host Core: host/registry/gateway/loopback; builtin workspace tools.
+- Per-task MCP lifecycle (`MCPInstance` + `LifecycleManager`).
+- `tether doctor` with MCP health checks.
+- Troubleshooting docs (K.8.1–K.8.6).
+- Performance benchmarks (K.9).
+
+---
+
+## Explicitly deferred to v1.0+
+
+These were known at project start; they do not block the current ship gate.
+
+| Feature | Spec ref | Target |
+|---|---|---|
+| WebCrypto E2E encryption | D-12 | v1.0+ |
+| Multi-user session isolation | D-04 | v1.0+ |
+| `tether pair` QR pairing | D-13 | v1.0+ |
+| Gemini provider | D-17a §5.3 | v1.0+ |
+| Mobile PWA (offline + push) | — | v1.0+ |
+| TCP / WebSocket fallback | — | v0.5+ (if QUIC adoption lags) |
+| PWA offline + partial-message streaming | — | v0.5+ |
+
+---
+
+## Next milestone: v0.5
+
+See [upgrade-path.md](./upgrade-path.md#v04--v05-planned).
+
+- Per-task external MCP server config
+- Watchdog GC for idle MCP instances

--- a/docs/release-gate.md
+++ b/docs/release-gate.md
@@ -21,7 +21,7 @@
 
 ---
 
-## What ships at v0.4 ("v1.0 baseline")
+## What's in v0.4.0 (current ship-gate)
 
 - Single-port HTTP/3 + TCP server with ECDSA P-256 cert (self-signed or ACME).
 - Chat + Shell + Events WebTransport channels.

--- a/docs/upgrade-path.md
+++ b/docs/upgrade-path.md
@@ -1,21 +1,54 @@
 # Upgrade Path
 
-## v0.1 → v0.1.1 (planned)
+## Released versions
 
-- ~~Let's Encrypt integration~~ — shipped: `--acme-domain <domain> --acme-email <email>` (HTTP-01, port 80 required; certmagic auto-renews).
-- PWA offline support: service worker + cache strategy.
-- Partial-message streaming: `--include-partial-messages` mode for lower-latency chat.
+### v0.1.0 (2026-05-09)
 
-## v0.1 → v0.2 (planned)
+Initial release. See [CHANGELOG](../CHANGELOG.md#v010--2026-05-09).
 
+### v0.1 → v0.2.0 (2026-05-10)
+
+- ~~Let's Encrypt integration~~ — shipped: `--acme-domain` / `--acme-email` (HTTP-01).
 - **opencode provider**: D-17a §5.1 — stream-json compatible, requires opencode ≥0.4.
-- Basic authentication: JWT (D-16 simplified), token-per-device.
-- `tether attach <sid>`: attach to an already-running session from a second device.
+- **Basic authentication**: JWT token gate, auto-generated `~/.tether/access-token`.
+- **Multi-tab attach**: `/wt/events` read-only fan-out.
+- ~~PWA offline support~~ — deferred to v0.5+.
+- ~~Partial-message streaming~~ — deferred to v0.5+.
 
-## v0.2 → v1.0 (roadmap)
+### v0.2 → v0.3.x (2026-05-10–05-12)
 
-- **WebCrypto E2E (D-12)**: ECDH key exchange, encrypted payloads. Daemon becomes a relay, not a decryption point.
+- v0.3.0 — MCP Host Core (host/registry/gateway) + permission API generalization.
+- v0.3.1 — MCP loopback (`127.0.0.1:8899/mcp`), builtin workspace tools, CC settings inject.
+- v0.3.2 — HTTPS `/mcp` + manual API tokens; dynamic tool list refresh.
+- v0.3.3 — OAuth 2.1 PKCE flow; IP rate-limiter on Bearer failures.
+- v0.3.4 — `tether doctor` MCP health checks.
+
+### v0.3 → v0.4.0 (2026-05-12)
+
+- Per-task MCP lifecycle (`MCPInstance` + `LifecycleManager` + REST API).
+- `workspace_run_shell` builtin tool (exec+pipe, 4 MiB cap, `Setpgid`).
+- Design token system + dark-mode body override.
+- WebTransport + SPA routing fixes.
+
+---
+
+## Upcoming
+
+### v0.4 → v0.5 (planned)
+
+- **Per-task external MCP server config**: tasks declare their own servers in
+  `.tether/task-config.json`; `LifecycleManager` starts/stops them with the task.
+- **Watchdog GC for idle MCP instances**: idle instances stopped after a threshold;
+  revived on next tool call.
+
+### v0.5 → v1.0 (roadmap)
+
+Features explicitly deferred from v0.x — see [release-gate.md](./release-gate.md)
+for current ship-gate status.
+
+- **WebCrypto E2E (D-12)**: ECDH key exchange; daemon becomes a relay.
 - **Multi-user**: per-user session isolation, audit log.
 - **`tether pair`**: QR-code-based device pairing (D-13).
-- **Gemini / Cursor providers**: D-17a §5.2–5.3.
+- **Gemini provider**: D-17a §5.3. Cursor already works via OAuth PKCE (v0.3.3).
 - **Mobile PWA**: full offline + push notifications.
+- **CI hardening**: cross-platform build matrix, coverage gate.


### PR DESCRIPTION
## Summary

- **CHANGELOG.md**: marked v0.2.0–v0.3.4 with actual release dates and PR numbers; added v0.4.0 section covering per-task MCP lifecycle, `workspace_run_shell`, design tokens, and polyforge hooks
- **docs/upgrade-path.md**: restructured into "Released" vs "Upcoming" sections; struck out completed items; added v0.5 and v1.0 roadmap entries linking to `release-gate.md`
- **docs/known-limitations.md**: struck through resolved limitations (Let's Encrypt, auth, multi-provider); updated for v0.4 state
- **docs/release-gate.md** (new): K.1–K.9 ✅, K.10 waived table; "what ships at v0.4", deferred-to-v1.0+ list, next milestone pointer

## Test plan

- [ ] All doc links resolve (README K.8.x anchors, upgrade-path ↔ release-gate cross-refs)
- [ ] No version numbers contradict git log

---
_polyforge task: `t-01KRFBWRER6NVQ5SJRY3J9AKY8`_