### PR TITLE
fix(web): F.2 stream-fix — WT ticket + tool_use streaming state

### DIFF
--- a/web/src/lib/store.ts
+++ b/web/src/lib/store.ts
@@ -46,13 +46,21 @@ export const useStore = create<AppState>((set) => ({
     switch (env.kind) {
       case 'message': {
         const p = env.payload
-        if (p && typeof p === 'object' && (p as Record<string, unknown>)['type'] === 'session_ready') {
-          set({ sessionId: (p as Record<string, unknown>)['sessionId'] as string })
+        if (p && typeof p === 'object') {
+          const pObj = p as Record<string, unknown>
+          if (pObj['type'] === 'session_ready') {
+            set({ sessionId: pObj['sessionId'] as string })
+            break
+          }
+          if (pObj['type'] === 'tool_use') {
+            // Claude is executing a tool — no chat bubble, but keep the
+            // streaming indicator on so the user sees activity.
+            set({ streaming: true })
+            break
+          }
+          // Unknown structured payload (future kinds) — ignore.
           break
         }
-        // Only stream text chunks to chat. Structured payloads (tool_use, tool_result)
-        // will be surfaced in the DAG/fenced-block pane (F.1). Coercing them to JSON
-        // strings here produces unreadable noise in the chat bubble.
         if (typeof p !== 'string') break
         set((s) => ({
           streaming: true,

--- a/web/src/lib/wt.ts
+++ b/web/src/lib/wt.ts
@@ -21,11 +21,11 @@ export class TetherWT {
   }
 
   async connect(): Promise<void> {
-    const certHash = await fetchCertHash()
+    const [certHash, ticket] = await Promise.all([fetchCertHash(), fetchWtTicket()])
     const wtOpts: WebTransportOptions = certHash
       ? { serverCertificateHashes: [{ algorithm: 'sha-256', value: hexToBuffer(certHash) }] }
       : {}
-    this.wt = new WebTransport(this.opts.url, wtOpts)
+    this.wt = new WebTransport(appendTicket(this.opts.url, ticket), wtOpts)
     await this.wt.ready
     this.readEvents()
     this.wt.closed.then((info) => {
@@ -98,11 +98,14 @@ export async function connectEventsOnly(
   onEnvelope: (env: Envelope) => void,
   onClose: () => void,
 ): Promise<WebTransport> {
-  const certHash = await fetchCertHash()
+  const [certHash, ticket] = await Promise.all([fetchCertHash(), fetchWtTicket()])
   const wtOpts: WebTransportOptions = certHash
     ? { serverCertificateHashes: [{ algorithm: 'sha-256', value: hexToBuffer(certHash) }] }
     : {}
-  const url = `https://${location.host}/wt/events?sid=${encodeURIComponent(sid)}`
+  const url = appendTicket(
+    `https://${location.host}/wt/events?sid=${encodeURIComponent(sid)}`,
+    ticket,
+  )
   const wt = new WebTransport(url, wtOpts)
   await wt.ready
 
@@ -142,6 +145,28 @@ export async function connectEventsOnly(
 
   wt.closed.then(fireClose).catch(fireClose)
   return wt
+}
+
+// fetchWtTicket fetches a short-lived WT auth ticket from the daemon.
+// The browser has the session cookie; the Ticket bridges it to the WT
+// CONNECT request which Chrome does not attach cookies to.
+async function fetchWtTicket(): Promise<string | null> {
+  try {
+    const resp = await fetch('/api/v1/auth/wt-ticket', { method: 'POST' })
+    if (!resp.ok) return null
+    const body = await resp.json() as { ticket?: string }
+    return typeof body.ticket === 'string' ? body.ticket : null
+  } catch {
+    return null
+  }
+}
+
+// appendTicket appends ?ticket=<t> (or &ticket=<t>) to url.
+// Returns url unchanged when ticket is null.
+function appendTicket(url: string, ticket: string | null): string {
+  if (!ticket) return url
+  const sep = url.includes('?') ? '&' : '?'
+  return `${url}${sep}ticket=${encodeURIComponent(ticket)}`
 }
 
 // fetchCertHash fetches /cert-hash from the current origin.

--- a/web/test/store.spec.ts
+++ b/web/test/store.spec.ts
@@ -34,10 +34,21 @@ describe('useStore.handleEnvelope', () => {
     expect(useStore.getState().messages).toHaveLength(0)
   })
 
-  it('tool_use object payload is NOT added to chat messages', () => {
+  it('tool_use object payload sets streaming=true but adds no chat message', () => {
     const env: Envelope = {
       kind: 'message',
       payload: { type: 'tool_use', id: 'toolu_01abc', name: 'Read', input: { file_path: '/tmp/x' } },
+    }
+    useStore.getState().handleEnvelope(env)
+    expect(useStore.getState().messages).toHaveLength(0)
+    // streaming stays on: Claude is mid-turn executing a tool.
+    expect(useStore.getState().streaming).toBe(true)
+  })
+
+  it('unknown structured payload is ignored without changing state', () => {
+    const env: Envelope = {
+      kind: 'message',
+      payload: { type: 'future_kind', data: 42 },
     }
     useStore.getState().handleEnvelope(env)
     expect(useStore.getState().messages).toHaveLength(0)


### PR DESCRIPTION
## 问题

1. **WT 连接 401**：browser-native WebTransport 的 CONNECT 请求不携带 Cookie，`/wt/chat` 和 `/wt/events` 的 ticket 验证拦截返回 401。
2. **tool_use 时 streaming 指示灭掉**：Claude 执行工具时 `streaming` 停留在 `false`（或从 `true` 被错误清掉），无活动指示。

## 改动

| 文件 | 改动 |
|---|---|
| `web/src/lib/wt.ts` | 新增 `fetchWtTicket()` + `appendTicket()`；`TetherWT.connect()` 和 `connectEventsOnly()` 并行 fetch cert hash + ticket，将 `?ticket=` 拼入 WT URL |
| `web/src/lib/store.ts` | `tool_use` payload 到来时设 `streaming: true`（Claude mid-turn 执行工具，活动指示应保持）；重构 object payload 分支逻辑更清晰 |
| `web/test/store.spec.ts` | 更新 tool_use 断言为 `streaming: true`；新增 unknown structured payload 测试 |

## 测试

```
✓ 15 passed | 2 skipped
tsc --noEmit 无报错
```