### PR TITLE
fix(web): F.3 stream-indicator — blinking cursor + input disabled while streaming

### DIFF
--- a/web/src/index.css
+++ b/web/src/index.css
@@ -136,3 +136,18 @@ html, body, #root {
   flex-shrink: 0;
 }
 .pane-body { flex: 1; overflow: auto; padding: 12px; }
+
+/* ── Streaming cursor ─────────────────────────────────── */
+@keyframes tether-blink {
+  0%, 100% { opacity: 1; }
+  50%       { opacity: 0; }
+}
+.tether-cursor {
+  display: inline-block;
+  width: 2px;
+  height: 1em;
+  background: currentColor;
+  vertical-align: text-bottom;
+  margin-left: 1px;
+  animation: tether-blink 1s step-start infinite;
+}

--- a/web/src/panes/chat/index.tsx
+++ b/web/src/panes/chat/index.tsx
@@ -190,9 +190,9 @@ export default function ChatPane() {
             </div>
           ))}
           {streaming && (
-            <div style={{ color: '#555', fontSize: 13, padding: '2px 0' }}>
-              <span>assistant: </span>
-              <span style={{ letterSpacing: 2 }}>…</span>
+            <div style={{ color: 'var(--ink-tertiary)', fontSize: 13, padding: '2px 0' }}>
+              <span style={{ color: 'var(--ink-secondary)' }}>assistant: </span>
+              <span className="tether-cursor" aria-label="Claude is responding" />
             </div>
           )}
         </div>
@@ -216,12 +216,12 @@ export default function ChatPane() {
             </select>
           )}
           <input
-            disabled={connState !== 'connected'}
-            style={{ flex: 1, background: 'var(--bg-surface)', border: '1px solid var(--line)', borderRadius: 4, padding: '6px 10px', color: connState === 'connected' ? 'var(--ink-primary)' : 'var(--ink-disabled)', outline: 'none' }}
+            disabled={connState !== 'connected' || streaming}
+            style={{ flex: 1, background: 'var(--bg-surface)', border: '1px solid var(--line)', borderRadius: 4, padding: '6px 10px', color: (connState === 'connected' && !streaming) ? 'var(--ink-primary)' : 'var(--ink-disabled)', outline: 'none' }}
             value={input}
             onChange={(e) => setInput(e.target.value)}
             onKeyDown={(e) => e.key === 'Enter' && !e.shiftKey && void sendMessage()}
-            placeholder={connState === 'connected' ? 'Message…' : connState === 'connecting' ? 'Connecting…' : 'Not connected'}
+            placeholder={connState !== 'connected' ? (connState === 'connecting' ? 'Connecting…' : 'Not connected') : streaming ? 'Claude is thinking…' : 'Message…'}
           />
           <button
             disabled={connState !== 'connected'}


### PR DESCRIPTION
## 改动

| 文件 | 内容 |
|---|---|
| `web/src/index.css` | `@keyframes tether-blink` + `.tether-cursor`（2px 竖条，1s step 闪烁） |
| `web/src/panes/chat/index.tsx` | 静态 `…` 替换为动画 `.tether-cursor`；streaming 时 input disabled + placeholder 改为 'Claude is thinking…' |

## 效果

- streaming=true → 光标闪烁，用户看到 Claude 正在输出
- streaming=true → 输入框禁用 + placeholder 提示，防止重复发送
- streaming=false → 输入框恢复，光标消失

## 测试

15 passed | 2 skipped，tsc clean