### PR TITLE
fix(web): manifest.json → .webmanifest (auth exempt suffix)

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="theme-color" content="#0f0f0f" />
-    <link rel="manifest" href="/manifest.json" />
+    <link rel="manifest" href="/manifest.webmanifest" />
     <title>tether</title>
   </head>
   <body>

--- a/web/public/manifest.webmanifest
+++ b/web/public/manifest.webmanifest
@@ -1,0 +1,13 @@
+{
+  "name": "tether",
+  "short_name": "tether",
+  "description": "AI workspace daemon + browser UI",
+  "start_url": "/",
+  "display": "standalone",
+  "background_color": "#0f0f0f",
+  "theme_color": "#0f0f0f",
+  "icons": [
+    { "src": "/icons/icon-192.png", "sizes": "192x192", "type": "image/png" },
+    { "src": "/icons/icon-512.png", "sizes": "512x512", "type": "image/png" }
+  ]
+}


### PR DESCRIPTION
 后缀在 auth 中间件豁免列表里； 不在，导致 Chrome 收到 HTML redirect 后报 'Manifest: Syntax error'。重命名并更新 index.html 引用。