### PR TITLE
fix(web): redirect to /auth when wt-ticket fetch returns 401

### DIFF
--- a/web/src/lib/wt.ts
+++ b/web/src/lib/wt.ts
@@ -150,9 +150,15 @@ export async function connectEventsOnly(
 // fetchWtTicket fetches a short-lived WT auth ticket from the daemon.
 // The browser has the session cookie; the Ticket bridges it to the WT
 // CONNECT request which Chrome does not attach cookies to.
+// Returns null on network error; redirects to /auth on 401/403.
 async function fetchWtTicket(): Promise<string | null> {
   try {
     const resp = await fetch('/api/v1/auth/wt-ticket', { method: 'POST' })
+    if (resp.status === 401 || resp.status === 403) {
+      // Session cookie missing or expired — send user to the login page.
+      window.location.href = '/auth'
+      return null
+    }
     if (!resp.ok) return null
     const body = await resp.json() as { ticket?: string }
     return typeof body.ticket === 'string' ? body.ticket : null


### PR DESCRIPTION
ticket fetch 失败时静默返回 null，导致用户停在 chat 页面却没有任何提示需要先登录。现在 401/403 时直接跳转 /auth。