### PR TITLE
fix(web): trim token on auth verify

### DIFF
--- a/web/src/AuthPage.tsx
+++ b/web/src/AuthPage.tsx
@@ -17,7 +17,7 @@ export default function AuthPage() {
       const res = await fetch('/api/v1/auth/verify', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ token, clientId }),
+        body: JSON.stringify({ token: token.trim(), clientId }),
       })
       if (res.ok) {
         const params = new URLSearchParams(window.location.search)


### PR DESCRIPTION
token.trim() before sending to /api/v1/auth/verify，防止粘贴时带尾部空格导致 Invalid token。