### PR TITLE
fix: allow stale ?sid= after server restart

### DIFF
--- a/internal/server/wt_chat.go
+++ b/internal/server/wt_chat.go
@@ -51,8 +51,10 @@ func serveChat(r *http.Request, wtsess *webtransport.Session, reg *session.Regis
 	providerName := r.URL.Query().Get("provider")
 
 	// If resuming an existing session, verify ownership before spawning.
-	// Note: ccSID == realSID for resumed sessions (registry is keyed by the same ID).
-	if ccSID != "" && clientID != "" && !reg.IsOwner(ccSID, clientID) {
+	// Only reject if the session EXISTS and is owned by a different client.
+	// If the session doesn't exist (e.g. server restart), silently ignore the
+	// stale sid and fall through to spawn a fresh session below.
+	if ccSID != "" && clientID != "" && reg.IsLive(ccSID) && !reg.IsOwner(ccSID, clientID) {
 		sendEnvelope(wtsess, wire.Envelope{Kind: wire.KindError, Payload: "session owned by another client; use /wt/events to attach read-only"})
 		return
 	}

--- a/internal/session/registry.go
+++ b/internal/session/registry.go
@@ -183,6 +183,14 @@ func (r *Registry) SetOwner(ccSID, clientID string) bool {
 	return true
 }
 
+// IsLive returns true if the session exists and is actively tracked.
+func (r *Registry) IsLive(ccSID string) bool {
+	r.mu.RLock()
+	_, ok := r.sessions[ccSID]
+	r.mu.RUnlock()
+	return ok
+}
+
 // IsOwner returns true if clientID is the recorded owner of ccSID.
 func (r *Registry) IsOwner(ccSID, clientID string) bool {
 	r.mu.RLock()


### PR DESCRIPTION
After server restart, sessions map is empty. Client reconnects with localStorage ?sid= → IsOwner returns false → 'session owned by another client' error → daemon unreachable.

Fix: only reject if the session IS LIVE and owned by a different client. Stale sid after restart is silently ignored and a new session is spawned.