### PR TITLE
fix(server): register .webmanifest MIME type and serve real 404 for static asset paths

### DIFF
--- a/internal/server/static.go
+++ b/internal/server/static.go
@@ -2,12 +2,22 @@ package server
 
 import (
 	"io/fs"
+	"mime"
 	"net/http"
 	"net/http/httputil"
 	"net/url"
+	"path"
+	"strings"
 
 	"github.com/piaobeizu/tether/web"
 )
+
+func init() {
+	// Go's built-in mime database doesn't map .webmanifest. Without this,
+	// http.FileServer falls back to sniffing JSON as text/plain, which makes
+	// Lighthouse and strict PWA validators reject the manifest.
+	_ = mime.AddExtensionType(".webmanifest", "application/manifest+json")
+}
 
 // noCacheWriter injects Cache-Control: no-cache at WriteHeader time so the
 // header survives even when http.FileServer/ServeContent resets headers internally.
@@ -81,12 +91,28 @@ func newStaticHandler(devFrontendURL string) http.Handler {
 		}
 		spy := &spy404{ResponseWriter: w}
 		fileServer.ServeHTTP(spy, r)
-		if spy.code == http.StatusNotFound {
-			// Unknown path (client-side route): serve index.html.
-			for k := range w.Header() {
-				delete(w.Header(), k)
-			}
-			serveIndex(w)
+		if spy.code != http.StatusNotFound {
+			return
 		}
+		// Clear headers poisoned by the 404 probe (e.g. Content-Type: text/plain).
+		// http.FileServer only sets Content-Type when it's absent, so we must
+		// clear it before writing our own response.
+		for k := range w.Header() {
+			delete(w.Header(), k)
+		}
+		// Static-asset-like paths (favicon.ico, foo.png, etc.) must return a
+		// real 404 rather than the SPA shell — otherwise browsers happily
+		// "render" index.html as a favicon and tools like Lighthouse complain.
+		if isStaticAssetPath(r.URL.Path) {
+			http.Error(w, "404 page not found", http.StatusNotFound)
+			return
+		}
+		serveIndex(w)
 	})
+}
+
+// isStaticAssetPath reports whether p looks like a request for a static file
+// (final path segment contains a dot) rather than an SPA route.
+func isStaticAssetPath(p string) bool {
+	return strings.Contains(path.Base(p), ".")
 }

--- a/internal/server/static_test.go
+++ b/internal/server/static_test.go
@@ -1,0 +1,96 @@
+package server
+
+import (
+	"mime"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestWebmanifestMIMERegistered(t *testing.T) {
+	got := mime.TypeByExtension(".webmanifest")
+	if !strings.HasPrefix(got, "application/manifest+json") {
+		t.Fatalf(".webmanifest MIME = %q, want application/manifest+json", got)
+	}
+}
+
+func TestStaticHandler(t *testing.T) {
+	h := newStaticHandler("")
+
+	cases := []struct {
+		name        string
+		path        string
+		wantCode    int
+		wantCTPart  string
+		wantBodyHas string
+	}{
+		{
+			name:        "root serves SPA index",
+			path:        "/",
+			wantCode:    http.StatusOK,
+			wantCTPart:  "text/html",
+			wantBodyHas: "<!DOCTYPE html>",
+		},
+		{
+			name:        "unknown page route falls back to SPA",
+			path:        "/some/spa/route",
+			wantCode:    http.StatusOK,
+			wantCTPart:  "text/html",
+			wantBodyHas: "<!DOCTYPE html>",
+		},
+		{
+			name:       "missing favicon returns 404 (not SPA HTML)",
+			path:       "/favicon.ico",
+			wantCode:   http.StatusNotFound,
+			wantCTPart: "text/plain",
+		},
+		{
+			name:       "missing asset returns 404",
+			path:       "/assets/does-not-exist.js",
+			wantCode:   http.StatusNotFound,
+			wantCTPart: "text/plain",
+		},
+		{
+			name:       "manifest.webmanifest served as application/manifest+json",
+			path:       "/manifest.webmanifest",
+			wantCode:   http.StatusOK,
+			wantCTPart: "application/manifest+json",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, tc.path, nil)
+			rec := httptest.NewRecorder()
+			h.ServeHTTP(rec, req)
+			if rec.Code != tc.wantCode {
+				t.Fatalf("code = %d, want %d (body=%q)", rec.Code, tc.wantCode, rec.Body.String())
+			}
+			if ct := rec.Header().Get("Content-Type"); !strings.Contains(ct, tc.wantCTPart) {
+				t.Fatalf("Content-Type = %q, want substring %q", ct, tc.wantCTPart)
+			}
+			if tc.wantBodyHas != "" && !strings.Contains(rec.Body.String(), tc.wantBodyHas) {
+				t.Fatalf("body missing %q; got %q", tc.wantBodyHas, rec.Body.String())
+			}
+		})
+	}
+}
+
+func TestIsStaticAssetPath(t *testing.T) {
+	cases := map[string]bool{
+		"/favicon.ico":          true,
+		"/icons/icon-192.png":   true,
+		"/manifest.webmanifest": true,
+		"/assets/index.js":      true,
+		"/":                     false,
+		"/auth":                 false,
+		"/some/spa/route":       false,
+		"/dotted.dir/page":      false,
+	}
+	for p, want := range cases {
+		if got := isStaticAssetPath(p); got != want {
+			t.Errorf("isStaticAssetPath(%q) = %v, want %v", p, got, want)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- Register `.webmanifest` MIME type via `mime.AddExtensionType` so Go's `http.FileServer` serves it as `application/manifest+json` instead of falling back to `text/plain` (fixes Lighthouse / strict PWA validators)
- Fix the SPA fallback handler: paths whose last segment contains a dot (static asset paths) now return a real 404 instead of being swallowed by the SPA shell
- Extract `isStaticAssetPath` helper with table-driven unit tests

## Test plan

- [x] `TestWebmanifestMIMERegistered` — `.webmanifest` MIME type registered correctly
- [x] `TestStaticHandler` — root and SPA routes return `index.html`; missing favicon/asset return 404
- [x] `TestIsStaticAssetPath` — helper correctly classifies dot-bearing vs. SPA paths (including `/dotted.dir/page` edge case)

🤖 Generated with [Claude Code](https://claude.com/claude-code)