### PR TITLE
docs(release): v0.4.1 — UI v2 + streaming + auth hardening

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,35 @@
 # Changelog
 
+## v0.4.1 — 2026-05-28 (PR #71–#85)
+
+UI v2 + streaming + auth-hardening increment on the v0.4 line. No API or schema breaks;
+drop-in over v0.4.0.
+
+### Added
+- **v2 UI**: three-tab layout (chat / shell / events), settings pane, and desktop chrome —
+  titlebar + statusbar + chat bubbles + workspace tree (#80, #81).
+- **Token-level streaming**: cc + opencode now stream at token granularity with per-session
+  history restore (#82, #84); IME composition fix for CJK input (#82).
+
+### Fixed
+- **WebTransport auth ticket**: Chrome's WT CONNECT does not carry the auth Cookie, so the
+  server issues a short-lived ticket exchanged on the WT handshake (#74, #75); redirect to
+  `/auth` when the wt-ticket returns 401 (#78).
+- **Stream indicator** (F.3): blinking cursor + input disabled while a turn streams (#76);
+  `tool_use` stream-state fix (F.2) (#75).
+- **Static assets**: `manifest.json` → `.webmanifest` (auth-exempt suffix) (#77); register the
+  `.webmanifest` MIME type and serve a real 404 for missing static paths instead of the SPA
+  fallback (#85).
+- **Session liveness**: accept a stale `?sid=` after a server restart via an `IsLive` check
+  rather than hard-rejecting (#83).
+- **Token paste**: trim whitespace before verifying a pasted access token (#79).
+
+### Docs
+- K.8 troubleshooting expanded — K.8.1 VPN/TUN details + K.8.6 `serverCertificateHashes` vs
+  CA cert (#71).
+- K.9 performance baseline — in-process benchmarks + E2E measurement script (#72).
+- v1.0 release-gate docs — CHANGELOG + upgrade-path + known-limitations + release-gate (#73).
+
 ## v0.4.0 — 2026-05-12 (PR #68, #69, #70)
 
 ### Added

--- a/docs/upgrade-path.md
+++ b/docs/upgrade-path.md
@@ -30,6 +30,21 @@ Initial release. See [CHANGELOG](../CHANGELOG.md#v010--2026-05-09).
 - Design token system + dark-mode body override.
 - WebTransport + SPA routing fixes.
 
+### v0.4.0 → v0.4.1 (2026-05-28)
+
+UI/streaming/auth increment on the v0.4 line — drop-in over v0.4.0, no API or schema breaks.
+
+- **v2 UI**: three-tab layout, settings pane, desktop chrome (titlebar/statusbar/chat
+  bubbles/workspace tree).
+- **Token-level streaming**: cc + opencode token-granularity streaming + per-session history.
+- **WebTransport auth ticket**: Chrome WT CONNECT carries no Cookie → short-lived ticket
+  exchanged on handshake; `/auth` redirect on 401.
+- **Static assets**: `.webmanifest` rename + MIME registration; real 404 for missing static
+  paths (no SPA fallback).
+- **Docs**: K.8 troubleshooting + K.9 benchmarks + v1.0 release-gate docs.
+
+See [CHANGELOG](../CHANGELOG.md#v041--2026-05-28).
+
 ---
 
 ## Upcoming


### PR DESCRIPTION
## v0.4.1 release notes

Documents the 16 commits (PR #71–#85) that landed on `main` beyond the `v0.4.0` tag (`4ded192`). Docs-only change — no code touched.

### CHANGELOG.md
New `v0.4.1 — 2026-05-28` section:
- **Added**: v2 UI (three-tab + desktop chrome) (#80/#81); token-level streaming for cc + opencode + session history (#82/#84).
- **Fixed**: WebTransport auth ticket (#74/#75/#78); stream indicator F.2/F.3 (#75/#76); `.webmanifest` rename + MIME + real 404 (#77/#85); stale `?sid=` liveness (#83); token paste trim (#79).
- **Docs**: K.8 troubleshooting (#71); K.9 benchmarks (#72); v1.0 release-gate docs (#73).

### docs/upgrade-path.md
Adds the `v0.4.0 → v0.4.1` released entry.

After merge: tag `v0.4.1` will be cut on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)