### PR TITLE
feat(mcp): v0.5 — per-task task-config.json + idle-instance watchdog

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ Checks: `cc-binary`, `data-dir`, `cert-state`, `port-bindable`, `cc-settings-hoo
 | `TETHER_NO_PERMISSION_HOOK` | `""` | Set to `1` to skip hook injection (auto-allows all tools) |
 | `TETHER_HOST` | `127.0.0.1` | Hostname for startup log URL |
 | `IS_SANDBOX` | auto-set if root | Injected into cc subprocess when running as root |
+| `TETHER_MCP_IDLE_TIMEOUT` | `15m` | Idle time before a per-task MCP instance is hibernated (child servers stopped, revived on next tool call). Set `0` to disable the watchdog. Accepts Go durations (e.g. `30m`). |
 
 ## CLI reference
 
@@ -51,6 +52,30 @@ tether server [--port PORT] [--cert-file F] [--key-file F] [--dev] [--dev-url UR
 tether doctor [--port PORT] [--verbose] [--json]
 tether version
 ```
+
+## Per-task MCP servers (v0.5)
+
+A task can declare its own MCP servers in `<workspace>/.tether/task-config.json`. `tether` starts
+them with the task and stops them on pause/wrap. File entries are merged with any `extra_servers`
+passed to the task-MCP REST API — request keys win on collision.
+
+```json
+{
+  "version": 1,
+  "servers": {
+    "playwright": {
+      "command": ["npx", "-y", "@modelcontextprotocol/server-playwright"],
+      "env": { "HEADLESS": "1" },
+      "prefix": "pw",
+      "inherit_env": ["PATH", "HOME"]
+    }
+  }
+}
+```
+
+Idle task instances are hibernated by a watchdog (see `TETHER_MCP_IDLE_TIMEOUT`): their child MCP
+servers are stopped to reclaim resources while the loopback and builtin tools keep serving, and the
+next tool call transparently revives them.
 
 ---
 

--- a/internal/mcp/instance/hibernate_internal_test.go
+++ b/internal/mcp/instance/hibernate_internal_test.go
@@ -1,0 +1,271 @@
+package instance
+
+// White-box tests for the v0.5 hibernate/wake mechanism (plan steps 4–5).
+// Internal package so we can assert on the unexported mgr/reg wiring, and use
+// an in-memory MCP client against the instance's own *mcp.Server to verify
+// cold-tool retention + lazy wake without HTTP/bearer plumbing.
+
+import (
+	"context"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+
+	"github.com/piaobeizu/tether/internal/mcp/host"
+	"github.com/piaobeizu/tether/internal/permission"
+)
+
+const stdioServerEnvInst = "TETHER_TEST_MCP_STDIO_INST"
+
+// TestStdioMCPServerHelperInstance is not a real test: re-exec'd with the env
+// set, it serves a minimal stdio MCP server exposing a single "noop" tool so
+// the instance's Manager can perform a real MCP connect.
+func TestStdioMCPServerHelperInstance(t *testing.T) {
+	if os.Getenv(stdioServerEnvInst) != "1" {
+		t.Skip("helper process only")
+	}
+	srv := mcp.NewServer(&mcp.Implementation{Name: "test-stdio-inst", Version: "v0.0.1"}, nil)
+	mcp.AddTool(srv, &mcp.Tool{Name: "noop", Description: "no-op"},
+		func(_ context.Context, _ *mcp.CallToolRequest, _ struct{}) (*mcp.CallToolResult, struct{}, error) {
+			return &mcp.CallToolResult{}, struct{}{}, nil
+		})
+	_ = srv.Run(context.Background(), &mcp.StdioTransport{})
+}
+
+func stdioCmdInst() []string {
+	return []string{os.Args[0], "-test.run=^TestStdioMCPServerHelperInstance$"}
+}
+func stdioEnvInst() map[string]string { return map[string]string{stdioServerEnvInst: "1"} }
+
+// startWithExtServer builds and starts an instance with one external stdio MCP
+// server registered under the given name/prefix.
+func startWithExtServer(t *testing.T, name, prefix string) *MCPInstance {
+	t.Helper()
+	inst, err := New(InstanceConfig{
+		TaskID:      "t-01HIBERNATE",
+		TaskSlug:    "hib-test",
+		WsRoot:      t.TempDir(),
+		PermManager: permission.New(),
+		SkipInject:  true,
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	servers := map[string]host.ServerConfig{
+		name: {Command: stdioCmdInst(), Env: stdioEnvInst(), Prefix: prefix},
+	}
+	if err := inst.Start(context.Background(), servers); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	return inst
+}
+
+func stopInst(inst *MCPInstance) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	_ = inst.Stop(ctx)
+}
+
+func TestHibernateWake_TogglesChildAndRegistry(t *testing.T) {
+	inst := startWithExtServer(t, "ext", "ext")
+	defer stopInst(inst)
+
+	// After Start: child connected + external tool in the registry.
+	if _, ok := inst.mgr.GetConn("ext"); !ok {
+		t.Fatal("expected child conn 'ext' after Start")
+	}
+	if len(inst.reg.ListAll()) == 0 {
+		t.Fatal("expected external tool registered after Start")
+	}
+	if inst.Dormant() {
+		t.Fatal("should not be dormant after Start")
+	}
+
+	// Hibernate: child stopped, registry drained, dormant flag set.
+	if err := inst.Hibernate(context.Background()); err != nil {
+		t.Fatalf("Hibernate: %v", err)
+	}
+	if !inst.Dormant() {
+		t.Fatal("expected Dormant() after Hibernate")
+	}
+	if _, ok := inst.mgr.GetConn("ext"); ok {
+		t.Fatal("child conn should be gone after Hibernate")
+	}
+	if len(inst.reg.ListAll()) != 0 {
+		t.Fatal("registry should be drained after Hibernate")
+	}
+
+	// Wake: child restarted, registry repopulated, awake.
+	if err := inst.Wake(context.Background()); err != nil {
+		t.Fatalf("Wake: %v", err)
+	}
+	if inst.Dormant() {
+		t.Fatal("should be awake after Wake")
+	}
+	if _, ok := inst.mgr.GetConn("ext"); !ok {
+		t.Fatal("child conn should be back after Wake")
+	}
+	if len(inst.reg.ListAll()) == 0 {
+		t.Fatal("external tool should be back in registry after Wake")
+	}
+}
+
+func TestColdToolRetentionAndLazyWake(t *testing.T) {
+	// The tool call below hits the gateway permission gate, which has no
+	// approver in this unit test; shorten its deadline so the (denied) call
+	// returns promptly instead of blocking for the default 60s.
+	origTimeout := permission.Timeout
+	permission.Timeout = 200 * time.Millisecond
+	defer func() { permission.Timeout = origTimeout }()
+
+	inst := startWithExtServer(t, "ext", "ext")
+	defer stopInst(inst)
+
+	// Connect an in-memory MCP client to the instance's own server.
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	clientT, serverT := mcp.NewInMemoryTransports()
+	go func() { _ = inst.Server().Run(ctx, serverT) }()
+
+	client := mcp.NewClient(&mcp.Implementation{Name: "test-client", Version: "v0"}, nil)
+	cs, err := client.Connect(ctx, clientT, nil)
+	if err != nil {
+		t.Fatalf("client connect: %v", err)
+	}
+	defer cs.Close()
+
+	hasExtNoop := func(when string) {
+		res, err := cs.ListTools(ctx, &mcp.ListToolsParams{})
+		if err != nil {
+			t.Fatalf("ListTools (%s): %v", when, err)
+		}
+		for _, tool := range res.Tools {
+			if tool.Name == "ext_noop" {
+				return
+			}
+		}
+		t.Fatalf("ext_noop not advertised %s", when)
+	}
+
+	// Advertised while running.
+	hasExtNoop("while running")
+
+	// Hibernate → tool defs retained on the server (client still sees it), dormant.
+	if err := inst.Hibernate(ctx); err != nil {
+		t.Fatalf("Hibernate: %v", err)
+	}
+	if !inst.Dormant() {
+		t.Fatal("expected dormant after Hibernate")
+	}
+	hasExtNoop("after Hibernate (cold retention)")
+
+	// Calling the cold external tool routes through the server's retained tool
+	// handler, which triggers lazy Wake *before* reaching the gateway. The call
+	// itself is permission-denied (no approver here) — that is orthogonal and
+	// covered by gateway tests; what this verifies is that reaching the handler
+	// woke the instance (child servers re-spawned, registry repopulated).
+	res, err := cs.CallTool(ctx, &mcp.CallToolParams{Name: "ext_noop", Arguments: map[string]any{}})
+	if err != nil {
+		t.Fatalf("CallTool ext_noop transport error: %v", err)
+	}
+	_ = res // result is permission-gated; not asserted here
+	if inst.Dormant() {
+		t.Fatal("instance should have woken after the external tool call reached the handler")
+	}
+}
+
+func TestHibernate_NoopWithoutExternalServers(t *testing.T) {
+	inst, err := New(InstanceConfig{
+		TaskID: "t-01NOEXT", TaskSlug: "noext", WsRoot: t.TempDir(),
+		PermManager: permission.New(), SkipInject: true,
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	if err := inst.Start(context.Background(), nil); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer stopInst(inst)
+
+	// No external servers → nothing to reclaim → Hibernate is a no-op.
+	if err := inst.Hibernate(context.Background()); err != nil {
+		t.Fatalf("Hibernate: %v", err)
+	}
+	if inst.Dormant() {
+		t.Fatal("builtin-only instance should not become dormant")
+	}
+}
+
+func TestHibernateWake_Idempotent(t *testing.T) {
+	inst := startWithExtServer(t, "ext", "ext")
+	defer stopInst(inst)
+
+	// Wake when already awake is a no-op.
+	if err := inst.Wake(context.Background()); err != nil {
+		t.Fatalf("Wake (awake) should be no-op: %v", err)
+	}
+	if inst.Dormant() {
+		t.Fatal("Wake on awake instance must not set dormant")
+	}
+
+	// Double Hibernate.
+	if err := inst.Hibernate(context.Background()); err != nil {
+		t.Fatalf("Hibernate 1: %v", err)
+	}
+	if err := inst.Hibernate(context.Background()); err != nil {
+		t.Fatalf("Hibernate 2 (idempotent): %v", err)
+	}
+	if !inst.Dormant() {
+		t.Fatal("expected dormant after Hibernate")
+	}
+
+	// Double Wake.
+	if err := inst.Wake(context.Background()); err != nil {
+		t.Fatalf("Wake 1: %v", err)
+	}
+	if err := inst.Wake(context.Background()); err != nil {
+		t.Fatalf("Wake 2 (idempotent): %v", err)
+	}
+	if inst.Dormant() {
+		t.Fatal("expected awake after Wake")
+	}
+}
+
+func TestWakeFailureRollsBackAndStaysDormant(t *testing.T) {
+	inst := startWithExtServer(t, "ext", "ext")
+	defer stopInst(inst)
+
+	if err := inst.Hibernate(context.Background()); err != nil {
+		t.Fatalf("Hibernate: %v", err)
+	}
+	if !inst.Dormant() {
+		t.Fatal("expected dormant after Hibernate")
+	}
+
+	// Simulate the external servers becoming unspawnable before wake: one good
+	// (re-exec) server plus one whose binary does not exist. Map order is
+	// non-deterministic, so whichever one starts first must be rolled back.
+	inst.mu.Lock()
+	inst.extraServers = map[string]host.ServerConfig{
+		"good": {Command: stdioCmdInst(), Env: stdioEnvInst(), Prefix: "good"},
+		"bad":  {Command: []string{"/nonexistent-tether-test-binary"}, Prefix: "bad"},
+	}
+	inst.mu.Unlock()
+
+	if err := inst.Wake(context.Background()); err == nil {
+		t.Fatal("expected Wake to fail when a child cannot spawn")
+	}
+	// Failed Wake must leave the instance dormant (retryable), not stuck awake.
+	if !inst.Dormant() {
+		t.Fatal("instance must stay dormant after a failed Wake")
+	}
+	// And it must not leak a partially-started child.
+	if _, ok := inst.mgr.GetConn("good"); ok {
+		t.Fatal("failed Wake leaked a partially-started 'good' child conn (no rollback)")
+	}
+	if _, ok := inst.mgr.GetConn("bad"); ok {
+		t.Fatal("'bad' child conn should not exist")
+	}
+}

--- a/internal/mcp/instance/instance.go
+++ b/internal/mcp/instance/instance.go
@@ -17,6 +17,7 @@ import (
 	"net"
 	"net/http"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
@@ -76,7 +77,26 @@ type MCPInstance struct {
 
 	skipInject bool
 	started    bool
+	// lastActive is updated on Start() and on each authorized loopback request.
+	lastActive time.Time
+	// extraServers records the stdio servers passed to Start().
+	extraServers map[string]mcphost.ServerConfig
+	// baseCtx scopes the child MCP server processes to the instance lifetime
+	// (cancelled in Stop) rather than to the request context that triggered a
+	// start/wake — so children survive the HTTP request that spawned them.
+	baseCtx    context.Context
+	baseCancel context.CancelFunc
 	mu         sync.Mutex
+
+	// dormant is true while the instance is hibernated: external child MCP
+	// servers are stopped to reclaim resources, but the loopback and builtin
+	// tools keep serving. The next external tool call triggers Wake.
+	dormant atomic.Bool
+	// suppressSrv, while true, makes the registry observer skip *mcp.Server
+	// tool add/remove so the advertised tool set stays stable across a
+	// hibernate/wake transition. Read via atomic, never under i.mu: the
+	// observer fires from mgr.Start/StopAll while Wake/Hibernate hold i.mu.
+	suppressSrv atomic.Bool
 }
 
 // New constructs (but does not start) an MCPInstance from cfg.
@@ -113,25 +133,36 @@ func New(cfg InstanceConfig) (*MCPInstance, error) {
 	}
 
 	gw := gateway.New(mgr, reg, cfg.PermManager, logger)
-	srv := buildServer(gw, bi, reg, cfg.TaskSlug)
 
-	lb, err := newLoopback(cfg.Port, srv, token)
-	if err != nil {
-		return nil, fmt.Errorf("mcp/instance: loopback init: %w", err)
-	}
-
-	return &MCPInstance{
+	// Construct the instance first (minus srv/loopback) so buildServer's
+	// observer and per-tool handlers can capture it for hibernate/wake wiring.
+	baseCtx, baseCancel := context.WithCancel(context.Background())
+	inst := &MCPInstance{
 		TaskID:     cfg.TaskID,
 		TaskSlug:   cfg.TaskSlug,
 		WsRoot:     cfg.WsRoot,
-		Port:       lb.port,
 		Token:      token,
 		mgr:        mgr,
 		reg:        reg,
-		srv:        srv,
-		loopback:   lb,
 		skipInject: cfg.SkipInject,
-	}, nil
+		baseCtx:    baseCtx,
+		baseCancel: baseCancel,
+	}
+
+	srv := buildServer(gw, bi, reg, cfg.TaskSlug, inst)
+	inst.srv = srv
+
+	lb, err := newLoopback(cfg.Port, srv, token)
+	if err != nil {
+		baseCancel()
+		return nil, fmt.Errorf("mcp/instance: loopback init: %w", err)
+	}
+	inst.Port = lb.port
+	inst.loopback = lb
+	// Wire loopback activity back to the instance so authorized requests
+	// keep the idle clock fresh.
+	lb.onActivity = inst.Touch
+	return inst, nil
 }
 
 // Start binds the loopback listener, starts any configured extra servers,
@@ -144,9 +175,15 @@ func (i *MCPInstance) Start(ctx context.Context, extraServers map[string]mcphost
 		return nil
 	}
 
+	i.extraServers = extraServers
+	i.lastActive = time.Now()
+
 	if len(extraServers) > 0 {
 		cfg := &mcphost.Config{Servers: extraServers}
-		if err := i.mgr.Start(ctx, cfg); err != nil {
+		// Use the instance-scoped context so child servers outlive the request
+		// that triggered Start; the passed ctx (often r.Context()) would kill
+		// them when the HTTP handler returns.
+		if err := i.mgr.Start(i.baseCtx, cfg); err != nil {
 			return fmt.Errorf("mcp/instance %s: start extra servers: %w", i.TaskSlug, err)
 		}
 	}
@@ -190,6 +227,9 @@ func (i *MCPInstance) Stop(ctx context.Context) error {
 		errs = append(errs, fmt.Errorf("loopback shutdown: %w", err))
 	}
 	i.mgr.StopAll()
+	if i.baseCancel != nil {
+		i.baseCancel()
+	}
 
 	if !i.skipInject {
 		name := "tether-" + i.TaskSlug
@@ -198,6 +238,8 @@ func (i *MCPInstance) Stop(ctx context.Context) error {
 		}
 	}
 
+	i.dormant.Store(false)
+	i.suppressSrv.Store(false)
 	i.started = false
 	slog.Info("mcp/instance: stopped",
 		"task_id", i.TaskID,
@@ -209,6 +251,97 @@ func (i *MCPInstance) Stop(ctx context.Context) error {
 	return nil
 }
 
+// Hibernate stops the instance's external child MCP servers to reclaim
+// resources while keeping the loopback listener and in-process builtin tools
+// serving. The advertised tool set is preserved (clients keep seeing the now
+// cold external tools); the next external tool call triggers Wake. It is a
+// no-op if the instance is not started, is already dormant, or has no external
+// servers to reclaim.
+func (i *MCPInstance) Hibernate(_ context.Context) error {
+	i.mu.Lock()
+	defer i.mu.Unlock()
+	if !i.started || i.dormant.Load() || len(i.extraServers) == 0 {
+		return nil
+	}
+	// Observer keeps srv tool defs through the teardown (Deregister → Removed).
+	i.suppressSrv.Store(true)
+	// Set dormant BEFORE teardown so a tool call arriving mid-StopAll takes the
+	// lazy-wake path (serialized on i.mu) instead of routing to a child that is
+	// being deregistered.
+	i.dormant.Store(true)
+	i.mgr.StopAll()
+	slog.Info("mcp/instance: hibernated", "task_id", i.TaskID, "task_slug", i.TaskSlug)
+	return nil
+}
+
+// Wake re-spawns the external child MCP servers of a hibernated instance and
+// restores the registry routing table. It is safe under concurrent calls
+// (later callers observe a no-op once awake) and a no-op if not dormant.
+func (i *MCPInstance) Wake(_ context.Context) error {
+	i.mu.Lock()
+	defer i.mu.Unlock()
+	if !i.dormant.Load() {
+		return nil
+	}
+	// suppressSrv is already true (set at Hibernate); keep it set through
+	// mgr.Start so the observer's Added events don't double-register tools the
+	// server still advertises. Clear it only once the servers are back.
+	if len(i.extraServers) > 0 {
+		cfg := &mcphost.Config{Servers: i.extraServers}
+		if err := i.mgr.Start(i.baseCtx, cfg); err != nil {
+			// Roll back any partially-started children so they don't leak. The
+			// instance stays dormant (suppressSrv still true → tools stay cold)
+			// and the next external tool call retries Wake cleanly.
+			i.mgr.StopAll()
+			return fmt.Errorf("mcp/instance %s: wake: %w", i.TaskSlug, err)
+		}
+	}
+	i.suppressSrv.Store(false)
+	i.dormant.Store(false)
+	slog.Info("mcp/instance: woke", "task_id", i.TaskID, "task_slug", i.TaskSlug)
+	return nil
+}
+
+// Dormant reports whether the instance is currently hibernated.
+func (i *MCPInstance) Dormant() bool { return i.dormant.Load() }
+
+// Touch records that the instance is active as of now.
+func (i *MCPInstance) Touch() {
+	i.mu.Lock()
+	defer i.mu.Unlock()
+	i.lastActive = time.Now()
+}
+
+// IdleFor returns how long the instance has been idle relative to now
+// (now.Sub(lastActive)).
+func (i *MCPInstance) IdleFor(now time.Time) time.Duration {
+	i.mu.Lock()
+	defer i.mu.Unlock()
+	return now.Sub(i.lastActive)
+}
+
+// LastActive returns the timestamp of the most recent activity.
+func (i *MCPInstance) LastActive() time.Time {
+	i.mu.Lock()
+	defer i.mu.Unlock()
+	return i.lastActive
+}
+
+// ExtraServers returns a snapshot of the stdio MCP servers that were passed to
+// Start(). The returned map is a shallow copy safe for the caller to read.
+func (i *MCPInstance) ExtraServers() map[string]mcphost.ServerConfig {
+	i.mu.Lock()
+	defer i.mu.Unlock()
+	if i.extraServers == nil {
+		return nil
+	}
+	out := make(map[string]mcphost.ServerConfig, len(i.extraServers))
+	for k, v := range i.extraServers {
+		out[k] = v
+	}
+	return out
+}
+
 // Server returns the underlying *mcp.Server so callers can mount it on
 // additional HTTP handlers (e.g. the HTTPS /mcp route).
 // Valid after New(); do not call AddTool/RemoveTool directly.
@@ -217,7 +350,7 @@ func (i *MCPInstance) Server() *mcp.Server { return i.srv }
 // buildServer constructs a *mcp.Server wired to the gateway and builtins.
 // This is an instance-scoped variant of server.BuildMCPServer; it lives here
 // to avoid an import cycle (server ← instance ← server).
-func buildServer(gw *gateway.Gateway, bi *builtin.Registry, reg *mcpreg.Registry, taskSlug string) *mcp.Server {
+func buildServer(gw *gateway.Gateway, bi *builtin.Registry, reg *mcpreg.Registry, taskSlug string, inst *MCPInstance) *mcp.Server {
 	srv := mcp.NewServer(
 		&mcp.Implementation{Name: "tether-" + taskSlug, Version: "v0.4.0"},
 		nil,
@@ -227,6 +360,15 @@ func buildServer(gw *gateway.Gateway, bi *builtin.Registry, reg *mcpreg.Registry
 		t := entry.Tool
 		t.Name = entry.PrefixedName
 		srv.AddTool(&t, func(ctx context.Context, req *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+			// Lazy wake: an external tool call on a hibernated instance
+			// re-spawns its child servers (repopulating the registry) before
+			// the call is routed. Builtin tools are registered directly on srv
+			// (not through addOne), so they never wake a dormant instance.
+			if inst.dormant.Load() {
+				if err := inst.Wake(ctx); err != nil {
+					return nil, fmt.Errorf("mcp/instance: wake before tool %q: %w", entry.PrefixedName, err)
+				}
+			}
 			return gw.CallTool(ctx, gateway.CallRequest{
 				ToolName:  entry.PrefixedName,
 				Arguments: req.Params.Arguments,
@@ -240,6 +382,13 @@ func buildServer(gw *gateway.Gateway, bi *builtin.Registry, reg *mcpreg.Registry
 	bi.RegisterInto(srv)
 
 	reg.AddObserver(func(e mcpreg.RegistryEvent) {
+		// During a hibernate/wake transition keep the advertised tool set
+		// stable: skip srv mutations while only the registry routing table and
+		// child processes are toggling. (Registry entries still change so
+		// gateway routing stays correct once awake.)
+		if inst.suppressSrv.Load() {
+			return
+		}
 		if len(e.Removed) > 0 {
 			names := make([]string, len(e.Removed))
 			for idx, t := range e.Removed {
@@ -263,6 +412,9 @@ type loopback struct {
 	port    int
 	token   string
 	handler http.Handler
+	// onActivity, if non-nil, is invoked after a request passes the bearer
+	// check and before it is forwarded to the handler.
+	onActivity func()
 }
 
 func newLoopback(port int, mcpSrv *mcp.Server, token string) (*loopback, error) {
@@ -294,6 +446,9 @@ func (l *loopback) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "unauthorized", http.StatusUnauthorized)
 		return
 	}
+	if l.onActivity != nil {
+		l.onActivity()
+	}
 	l.handler.ServeHTTP(w, r)
 }
 
@@ -318,5 +473,3 @@ func generateToken() (string, error) {
 	}
 	return hex.EncodeToString(b), nil
 }
-
-

--- a/internal/mcp/instance/instance_test.go
+++ b/internal/mcp/instance/instance_test.go
@@ -2,6 +2,9 @@ package instance_test
 
 import (
 	"context"
+	"fmt"
+	"net/http"
+	"strings"
 	"testing"
 	"time"
 
@@ -51,6 +54,150 @@ func TestNew_validation(t *testing.T) {
 			t.Fatal("expected error for nil PermManager")
 		}
 	})
+}
+
+func TestTouchAndIdleFor(t *testing.T) {
+	pm := newPermManager()
+
+	inst, err := instance.New(instance.InstanceConfig{
+		TaskID:      "t-01TOUCH",
+		TaskSlug:    "touch-test",
+		WsRoot:      t.TempDir(),
+		PermManager: pm,
+		SkipInject:  true,
+	})
+	if err != nil {
+		t.Fatalf("New() error: %v", err)
+	}
+
+	ctx := context.Background()
+	if err := inst.Start(ctx, nil); err != nil {
+		t.Fatalf("Start() error: %v", err)
+	}
+	defer func() {
+		stopCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+		defer cancel()
+		_ = inst.Stop(stopCtx)
+	}()
+
+	// Start() sets lastActive to ~now.
+	first := inst.LastActive()
+	if first.IsZero() {
+		t.Fatal("LastActive() should be non-zero after Start()")
+	}
+
+	// IdleFor computes now.Sub(lastActive).
+	now := first.Add(2 * time.Second)
+	if got := inst.IdleFor(now); got != 2*time.Second {
+		t.Fatalf("IdleFor() = %v, want 2s", got)
+	}
+
+	// Touch advances lastActive.
+	time.Sleep(2 * time.Millisecond)
+	inst.Touch()
+	second := inst.LastActive()
+	if !second.After(first) {
+		t.Fatalf("Touch() should advance lastActive: first=%v second=%v", first, second)
+	}
+}
+
+func TestAuthorizedRequestTouches(t *testing.T) {
+	pm := newPermManager()
+
+	inst, err := instance.New(instance.InstanceConfig{
+		TaskID:      "t-01REQTOUCH",
+		TaskSlug:    "req-touch-test",
+		WsRoot:      t.TempDir(),
+		PermManager: pm,
+		SkipInject:  true,
+	})
+	if err != nil {
+		t.Fatalf("New() error: %v", err)
+	}
+
+	ctx := context.Background()
+	if err := inst.Start(ctx, nil); err != nil {
+		t.Fatalf("Start() error: %v", err)
+	}
+	defer func() {
+		stopCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+		defer cancel()
+		_ = inst.Stop(stopCtx)
+	}()
+
+	before := inst.LastActive()
+	time.Sleep(2 * time.Millisecond)
+
+	url := fmt.Sprintf("http://127.0.0.1:%d/mcp", inst.Port)
+	body := `{"jsonrpc":"2.0","id":1,"method":"tools/list"}`
+	req, err := http.NewRequest(http.MethodPost, url, strings.NewReader(body))
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+inst.Token)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json, text/event-stream")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("do request: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode == http.StatusUnauthorized {
+		t.Fatalf("authorized request unexpectedly rejected: %d", resp.StatusCode)
+	}
+
+	after := inst.LastActive()
+	if !after.After(before) {
+		t.Fatalf("authorized request should advance lastActive: before=%v after=%v", before, after)
+	}
+}
+
+func TestUnauthorizedRequestDoesNotTouch(t *testing.T) {
+	pm := newPermManager()
+
+	inst, err := instance.New(instance.InstanceConfig{
+		TaskID:      "t-01NOAUTH",
+		TaskSlug:    "noauth-test",
+		WsRoot:      t.TempDir(),
+		PermManager: pm,
+		SkipInject:  true,
+	})
+	if err != nil {
+		t.Fatalf("New() error: %v", err)
+	}
+
+	ctx := context.Background()
+	if err := inst.Start(ctx, nil); err != nil {
+		t.Fatalf("Start() error: %v", err)
+	}
+	defer func() {
+		stopCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+		defer cancel()
+		_ = inst.Stop(stopCtx)
+	}()
+
+	before := inst.LastActive()
+	time.Sleep(2 * time.Millisecond)
+
+	url := fmt.Sprintf("http://127.0.0.1:%d/mcp", inst.Port)
+	req, err := http.NewRequest(http.MethodPost, url, strings.NewReader(`{}`))
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+	// No / bad Authorization header.
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("do request: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusUnauthorized {
+		t.Fatalf("expected 401, got %d", resp.StatusCode)
+	}
+
+	after := inst.LastActive()
+	if !after.Equal(before) {
+		t.Fatalf("unauthorized request should NOT advance lastActive: before=%v after=%v", before, after)
+	}
 }
 
 func TestStartStop(t *testing.T) {

--- a/internal/mcp/lifecycle/manager.go
+++ b/internal/mcp/lifecycle/manager.go
@@ -33,17 +33,89 @@ type TaskConfig struct {
 	SkipInject bool
 }
 
+// Config tunes the LifecycleManager. The zero value disables the idle watchdog.
+type Config struct {
+	// IdleThreshold is how long an instance may go without a tool call before
+	// the watchdog hibernates it. <= 0 disables the watchdog entirely.
+	IdleThreshold time.Duration
+	// TickInterval is the watchdog scan period. If <= 0 it defaults to
+	// IdleThreshold, capped at one minute.
+	TickInterval time.Duration
+}
+
+// Option configures a LifecycleManager at construction.
+type Option func(*Config)
+
+// WithIdleWatchdog enables the idle-instance watchdog: instances idle for
+// longer than threshold are hibernated (child servers stopped, revived on the
+// next tool call). threshold <= 0 leaves the watchdog disabled; tick <= 0
+// selects a sensible default (min(threshold, 1m)).
+func WithIdleWatchdog(threshold, tick time.Duration) Option {
+	return func(c *Config) {
+		c.IdleThreshold = threshold
+		c.TickInterval = tick
+	}
+}
+
 // LifecycleManager maintains a map of active per-task MCPInstances and ensures
-// at most one instance per task is running at any time.
+// at most one instance per task is running at any time. When configured with an
+// idle watchdog it also hibernates instances that have gone quiet.
 type LifecycleManager struct {
 	mu        sync.RWMutex
 	instances map[string]*instance.MCPInstance // keyed by TaskID
+
+	cfg          Config
+	watchdogStop chan struct{}
+	watchdogDone chan struct{}
+	stopOnce     sync.Once
 }
 
-// New creates an empty LifecycleManager.
-func New() *LifecycleManager {
-	return &LifecycleManager{
+// New creates a LifecycleManager. With no options the idle watchdog is off
+// (backward-compatible); pass WithIdleWatchdog to enable it.
+func New(opts ...Option) *LifecycleManager {
+	m := &LifecycleManager{
 		instances: make(map[string]*instance.MCPInstance),
+	}
+	for _, o := range opts {
+		o(&m.cfg)
+	}
+	if m.cfg.IdleThreshold > 0 {
+		if m.cfg.TickInterval <= 0 {
+			m.cfg.TickInterval = m.cfg.IdleThreshold
+			if m.cfg.TickInterval > time.Minute {
+				m.cfg.TickInterval = time.Minute
+			}
+		}
+		m.watchdogStop = make(chan struct{})
+		m.watchdogDone = make(chan struct{})
+		go m.runWatchdog()
+	}
+	return m
+}
+
+// runWatchdog periodically hibernates instances idle longer than the configured
+// threshold. It exits when watchdogStop is closed.
+func (m *LifecycleManager) runWatchdog() {
+	defer close(m.watchdogDone)
+	ticker := time.NewTicker(m.cfg.TickInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-m.watchdogStop:
+			return
+		case <-ticker.C:
+			m.sweepIdle(time.Now())
+		}
+	}
+}
+
+// sweepIdle hibernates every active instance idle past the threshold. Hibernate
+// is a no-op for instances already dormant or without external servers.
+func (m *LifecycleManager) sweepIdle(now time.Time) {
+	for _, inst := range m.Active() {
+		if inst.IdleFor(now) > m.cfg.IdleThreshold {
+			_ = inst.Hibernate(context.Background())
+		}
 	}
 }
 
@@ -60,6 +132,25 @@ func (m *LifecycleManager) StartTask(ctx context.Context, cfg TaskConfig) (*inst
 	}
 	if cfg.PermManager == nil {
 		return nil, fmt.Errorf("lifecycle: PermManager is required")
+	}
+
+	// Load per-task MCP servers from <WsRoot>/.tether/task-config.json.
+	// A missing file yields no servers; a malformed file aborts start.
+	fileServers, err := LoadTaskConfig(cfg.WsRoot)
+	if err != nil {
+		return nil, fmt.Errorf("lifecycle: load task-config for %s: %w", cfg.TaskSlug, err)
+	}
+	// Merge: file servers first, then request ExtraServers overlaid so request
+	// keys win on collision.
+	var mergedServers map[string]host.ServerConfig
+	if len(fileServers) > 0 || len(cfg.ExtraServers) > 0 {
+		mergedServers = make(map[string]host.ServerConfig, len(fileServers)+len(cfg.ExtraServers))
+		for k, v := range fileServers {
+			mergedServers[k] = v
+		}
+		for k, v := range cfg.ExtraServers {
+			mergedServers[k] = v
+		}
 	}
 
 	// Stop any existing instance for this task first (idempotent restart).
@@ -88,7 +179,7 @@ func (m *LifecycleManager) StartTask(ctx context.Context, cfg TaskConfig) (*inst
 		return nil, fmt.Errorf("lifecycle: new instance for %s: %w", cfg.TaskSlug, err)
 	}
 
-	if err := inst.Start(ctx, cfg.ExtraServers); err != nil {
+	if err := inst.Start(ctx, mergedServers); err != nil {
 		return nil, fmt.Errorf("lifecycle: start instance for %s: %w", cfg.TaskSlug, err)
 	}
 
@@ -134,9 +225,14 @@ func (m *LifecycleManager) Active() []*instance.MCPInstance {
 	return out
 }
 
-// StopAll shuts down all running instances.  Intended for daemon shutdown.
-// Best-effort: errors are logged but not aggregated.
+// StopAll stops the idle watchdog (if running) and shuts down all instances.
+// Intended for daemon shutdown. Best-effort: per-instance errors are ignored.
 func (m *LifecycleManager) StopAll(ctx context.Context) {
+	if m.watchdogStop != nil {
+		m.stopOnce.Do(func() { close(m.watchdogStop) })
+		<-m.watchdogDone
+	}
+
 	m.mu.Lock()
 	ids := make([]string, 0, len(m.instances))
 	for id := range m.instances {
@@ -148,4 +244,3 @@ func (m *LifecycleManager) StopAll(ctx context.Context) {
 		_ = m.StopTask(ctx, id)
 	}
 }
-

--- a/internal/mcp/lifecycle/manager_test.go
+++ b/internal/mcp/lifecycle/manager_test.go
@@ -2,12 +2,48 @@ package lifecycle_test
 
 import (
 	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+
+	"github.com/piaobeizu/tether/internal/mcp/host"
 	"github.com/piaobeizu/tether/internal/mcp/lifecycle"
 	"github.com/piaobeizu/tether/internal/permission"
 )
+
+// stdioServerEnv, when set to "1", makes TestStdioMCPServerHelper act as a real
+// stdio MCP server (used as a spawnable child process by the merge tests).
+const stdioServerEnv = "TETHER_TEST_MCP_STDIO"
+
+// TestStdioMCPServerHelper is not a real test: when invoked via re-exec with
+// stdioServerEnv=1 it serves a minimal MCP server over stdin/stdout so that the
+// LifecycleManager's synchronous connect succeeds without a fragile fake binary.
+func TestStdioMCPServerHelper(t *testing.T) {
+	if os.Getenv(stdioServerEnv) != "1" {
+		t.Skip("helper process only")
+	}
+	srv := mcp.NewServer(&mcp.Implementation{Name: "test-stdio", Version: "v0.0.1"}, nil)
+	mcp.AddTool(srv, &mcp.Tool{Name: "noop", Description: "no-op"},
+		func(_ context.Context, _ *mcp.CallToolRequest, _ struct{}) (*mcp.CallToolResult, struct{}, error) {
+			return &mcp.CallToolResult{}, struct{}{}, nil
+		})
+	_ = srv.Run(context.Background(), &mcp.StdioTransport{})
+}
+
+// stdioServerCommand returns argv that re-execs the test binary as a stdio MCP
+// server via TestStdioMCPServerHelper.
+func stdioServerCommand() []string {
+	return []string{os.Args[0], "-test.run=^TestStdioMCPServerHelper$"}
+}
+
+// stdioServerEnvMap returns the env needed to activate the helper server.
+func stdioServerEnvMap() map[string]string {
+	return map[string]string{stdioServerEnv: "1"}
+}
 
 func newPermManager() *permission.Manager {
 	return permission.New()
@@ -62,6 +98,185 @@ func TestStartStopTask(t *testing.T) {
 	}
 }
 
+// writeManagerTaskConfig writes task-config.json under <dir>/.tether.
+func writeManagerTaskConfig(t *testing.T, dir, body string) {
+	t.Helper()
+	td := filepath.Join(dir, ".tether")
+	if err := os.MkdirAll(td, 0o755); err != nil {
+		t.Fatalf("mkdir .tether: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(td, "task-config.json"), []byte(body), 0o644); err != nil {
+		t.Fatalf("write task-config.json: %v", err)
+	}
+}
+
+func TestStartTask_FileServersReachInstance(t *testing.T) {
+	pm := newPermManager()
+	lm := lifecycle.New()
+	ctx := context.Background()
+
+	ws := t.TempDir()
+	cmdJSON, err := json.Marshal(stdioServerCommand())
+	if err != nil {
+		t.Fatalf("marshal command: %v", err)
+	}
+	envJSON, err := json.Marshal(stdioServerEnvMap())
+	if err != nil {
+		t.Fatalf("marshal env: %v", err)
+	}
+	writeManagerTaskConfig(t, ws, `{
+		"version": 1,
+		"servers": {
+			"file-srv": {"command": `+string(cmdJSON)+`, "env": `+string(envJSON)+`, "prefix": "fs"}
+		}
+	}`)
+
+	cfg := lifecycle.TaskConfig{
+		TaskID:      "t-01FILESRV",
+		TaskSlug:    "file-srv-test",
+		WsRoot:      ws,
+		PermManager: pm,
+		SkipInject:  true,
+	}
+	inst, err := lm.StartTask(ctx, cfg)
+	if err != nil {
+		t.Fatalf("StartTask() error: %v", err)
+	}
+	defer func() {
+		stopCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+		defer cancel()
+		_ = lm.StopTask(stopCtx, cfg.TaskID)
+	}()
+
+	es := inst.ExtraServers()
+	sc, ok := es["file-srv"]
+	if !ok {
+		t.Fatalf("file server not passed to instance: %v", es)
+	}
+	if sc.Prefix != "fs" {
+		t.Fatalf("prefix not threaded: %q", sc.Prefix)
+	}
+}
+
+func TestStartTask_RequestOverridesFile(t *testing.T) {
+	pm := newPermManager()
+	lm := lifecycle.New()
+	ctx := context.Background()
+
+	// Use the re-exec stdio MCP helper so StartTask's synchronous connect
+	// succeeds; the point of this test is the merge, not child-process behavior.
+	ws := t.TempDir()
+	cmdJSON, err := json.Marshal(stdioServerCommand())
+	if err != nil {
+		t.Fatalf("marshal command: %v", err)
+	}
+	envJSON, err := json.Marshal(stdioServerEnvMap())
+	if err != nil {
+		t.Fatalf("marshal env: %v", err)
+	}
+	writeManagerTaskConfig(t, ws, `{
+		"version": 1,
+		"servers": {
+			"shared": {"command": `+string(cmdJSON)+`, "env": `+string(envJSON)+`, "prefix": "fromfile"},
+			"only-file": {"command": `+string(cmdJSON)+`, "env": `+string(envJSON)+`}
+		}
+	}`)
+
+	cfg := lifecycle.TaskConfig{
+		TaskID:      "t-01OVERRIDE",
+		TaskSlug:    "override-test",
+		WsRoot:      ws,
+		PermManager: pm,
+		SkipInject:  true,
+		ExtraServers: map[string]host.ServerConfig{
+			"shared":   {Command: stdioServerCommand(), Env: stdioServerEnvMap(), Prefix: "fromreq"},
+			"only-req": {Command: stdioServerCommand(), Env: stdioServerEnvMap()},
+		},
+	}
+	inst, err := lm.StartTask(ctx, cfg)
+	if err != nil {
+		t.Fatalf("StartTask() error: %v", err)
+	}
+	defer func() {
+		stopCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+		defer cancel()
+		_ = lm.StopTask(stopCtx, cfg.TaskID)
+	}()
+
+	es := inst.ExtraServers()
+	if len(es) != 3 {
+		t.Fatalf("expected 3 merged servers, got %d: %v", len(es), es)
+	}
+	// Request key wins on collision.
+	if es["shared"].Prefix != "fromreq" {
+		t.Fatalf("request should override file for 'shared': %q", es["shared"].Prefix)
+	}
+	if _, ok := es["only-file"]; !ok {
+		t.Fatalf("file-only server 'only-file' missing: %v", es)
+	}
+	if _, ok := es["only-req"]; !ok {
+		t.Fatalf("request-only server 'only-req' missing: %v", es)
+	}
+}
+
+func TestStartTask_NoFileRequestOnlyUnchanged(t *testing.T) {
+	pm := newPermManager()
+	lm := lifecycle.New()
+	ctx := context.Background()
+
+	cfg := lifecycle.TaskConfig{
+		TaskID:      "t-01NOFILE",
+		TaskSlug:    "nofile-test",
+		WsRoot:      t.TempDir(), // no .tether/task-config.json
+		PermManager: pm,
+		SkipInject:  true,
+		ExtraServers: map[string]host.ServerConfig{
+			"req": {Command: stdioServerCommand(), Env: stdioServerEnvMap()},
+		},
+	}
+	inst, err := lm.StartTask(ctx, cfg)
+	if err != nil {
+		t.Fatalf("StartTask() error: %v", err)
+	}
+	defer func() {
+		stopCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+		defer cancel()
+		_ = lm.StopTask(stopCtx, cfg.TaskID)
+	}()
+
+	es := inst.ExtraServers()
+	if len(es) != 1 {
+		t.Fatalf("expected only the request server, got %d: %v", len(es), es)
+	}
+	if _, ok := es["req"]; !ok {
+		t.Fatalf("request server 'req' missing: %v", es)
+	}
+}
+
+func TestStartTask_MalformedFileErrors(t *testing.T) {
+	pm := newPermManager()
+	lm := lifecycle.New()
+	ctx := context.Background()
+
+	ws := t.TempDir()
+	writeManagerTaskConfig(t, ws, `{"version": 1, "servers": {`) // malformed
+
+	cfg := lifecycle.TaskConfig{
+		TaskID:      "t-01BADFILE",
+		TaskSlug:    "badfile-test",
+		WsRoot:      ws,
+		PermManager: pm,
+		SkipInject:  true,
+	}
+	_, err := lm.StartTask(ctx, cfg)
+	if err == nil {
+		t.Fatal("StartTask() should error on malformed task-config")
+	}
+	if _, ok := lm.Get(cfg.TaskID); ok {
+		t.Fatal("no instance should be registered when task-config load fails")
+	}
+}
+
 func TestStopNonExistent(t *testing.T) {
 	lm := lifecycle.New()
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
@@ -108,4 +323,105 @@ func TestStopAll(t *testing.T) {
 	if ok {
 		t.Fatal("Get(cfg2) should return false after StopAll")
 	}
+}
+
+// waitCond polls cond up to within, failing the test if it never becomes true.
+func waitCond(t *testing.T, within time.Duration, cond func() bool) {
+	t.Helper()
+	deadline := time.Now().Add(within)
+	for time.Now().Before(deadline) {
+		if cond() {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("condition not met within %v", within)
+}
+
+// extConfig returns a TaskConfig with one external stdio MCP server.
+func extConfig(t *testing.T, pm *permission.Manager, taskID, slug string) lifecycle.TaskConfig {
+	t.Helper()
+	cfg := baseConfig(t, pm, taskID, slug)
+	cfg.ExtraServers = map[string]host.ServerConfig{
+		"ext": {Command: stdioServerCommand(), Env: stdioServerEnvMap(), Prefix: "ext"},
+	}
+	return cfg
+}
+
+func TestWatchdogHibernatesIdle(t *testing.T) {
+	pm := newPermManager()
+	lm := lifecycle.New(lifecycle.WithIdleWatchdog(60*time.Millisecond, 20*time.Millisecond))
+	ctx := context.Background()
+	defer func() {
+		c, cancel := context.WithTimeout(ctx, 5*time.Second)
+		defer cancel()
+		lm.StopAll(c)
+	}()
+
+	inst, err := lm.StartTask(ctx, extConfig(t, pm, "t-01WDIDLE", "wd-idle"))
+	if err != nil {
+		t.Fatalf("StartTask: %v", err)
+	}
+	if inst.Dormant() {
+		t.Fatal("should not be dormant immediately after start")
+	}
+	// The instance is idle; the watchdog should hibernate it past the threshold.
+	waitCond(t, 3*time.Second, inst.Dormant)
+}
+
+func TestWatchdogSkipsRecentlyActive(t *testing.T) {
+	pm := newPermManager()
+	lm := lifecycle.New(lifecycle.WithIdleWatchdog(5*time.Second, 20*time.Millisecond))
+	ctx := context.Background()
+	defer func() {
+		c, cancel := context.WithTimeout(ctx, 5*time.Second)
+		defer cancel()
+		lm.StopAll(c)
+	}()
+
+	inst, err := lm.StartTask(ctx, extConfig(t, pm, "t-01WDACTIVE", "wd-active"))
+	if err != nil {
+		t.Fatalf("StartTask: %v", err)
+	}
+	// Many watchdog ticks pass but we are well within the 5s threshold.
+	time.Sleep(300 * time.Millisecond)
+	if inst.Dormant() {
+		t.Fatal("recently-active instance must not be hibernated")
+	}
+}
+
+func TestWatchdogDisabled(t *testing.T) {
+	pm := newPermManager()
+	ctx := context.Background()
+	cases := map[string]*lifecycle.LifecycleManager{
+		"default_off":    lifecycle.New(),
+		"threshold_zero": lifecycle.New(lifecycle.WithIdleWatchdog(0, 10*time.Millisecond)),
+	}
+	for name, lm := range cases {
+		t.Run(name, func(t *testing.T) {
+			defer func() {
+				c, cancel := context.WithTimeout(ctx, 5*time.Second)
+				defer cancel()
+				lm.StopAll(c)
+			}()
+			inst, err := lm.StartTask(ctx, extConfig(t, pm, "t-01WDOFF"+name, "wd-off-"+name))
+			if err != nil {
+				t.Fatalf("StartTask: %v", err)
+			}
+			time.Sleep(200 * time.Millisecond)
+			if inst.Dormant() {
+				t.Fatal("watchdog disabled: instance must not hibernate")
+			}
+		})
+	}
+}
+
+func TestStopAllStopsWatchdogIdempotent(t *testing.T) {
+	lm := lifecycle.New(lifecycle.WithIdleWatchdog(50*time.Millisecond, 20*time.Millisecond))
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	// First StopAll must stop the watchdog goroutine without hanging.
+	lm.StopAll(ctx)
+	// Second StopAll must be a no-op (no double-close panic, no hang).
+	lm.StopAll(ctx)
 }

--- a/internal/mcp/lifecycle/taskconfig.go
+++ b/internal/mcp/lifecycle/taskconfig.go
@@ -1,0 +1,71 @@
+package lifecycle
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+
+	"github.com/piaobeizu/tether/internal/mcp/host"
+)
+
+// taskConfigFile is the DTO for <wsRoot>/.tether/task-config.json.
+// It exists to bind snake_case JSON keys that host.ServerConfig (which has no
+// json tags) cannot decode directly.
+type taskConfigFile struct {
+	Version int                        `json:"version"`
+	Servers map[string]serverConfigDTO `json:"servers"`
+}
+
+// serverConfigDTO mirrors host.ServerConfig with explicit json tags.
+type serverConfigDTO struct {
+	Command    []string          `json:"command"`
+	Env        map[string]string `json:"env"`
+	Prefix     string            `json:"prefix"`
+	InheritEnv []string          `json:"inherit_env"`
+}
+
+// LoadTaskConfig reads <wsRoot>/.tether/task-config.json and returns the
+// configured extra MCP servers keyed by server name.
+//
+// A missing file is not an error: it returns (nil, nil). It returns a
+// descriptive error on malformed JSON, an unsupported version, or any server
+// with an empty command.
+func LoadTaskConfig(wsRoot string) (map[string]host.ServerConfig, error) {
+	path := filepath.Join(wsRoot, ".tether", "task-config.json")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("task-config: read %s: %w", path, err)
+	}
+
+	var file taskConfigFile
+	if err := json.Unmarshal(data, &file); err != nil {
+		return nil, fmt.Errorf("task-config: parse %s: %w", path, err)
+	}
+	if file.Version != 1 {
+		return nil, fmt.Errorf("task-config: unsupported version %d (want 1)", file.Version)
+	}
+
+	if len(file.Servers) == 0 {
+		return nil, nil
+	}
+
+	out := make(map[string]host.ServerConfig, len(file.Servers))
+	for name, dto := range file.Servers {
+		if len(dto.Command) == 0 {
+			return nil, fmt.Errorf("task-config: server %q has empty command", name)
+		}
+		out[name] = host.ServerConfig{
+			Command:    dto.Command,
+			Env:        dto.Env,
+			Prefix:     dto.Prefix,
+			InheritEnv: dto.InheritEnv,
+		}
+	}
+	return out, nil
+}

--- a/internal/mcp/lifecycle/taskconfig_test.go
+++ b/internal/mcp/lifecycle/taskconfig_test.go
@@ -1,0 +1,119 @@
+package lifecycle_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/piaobeizu/tether/internal/mcp/lifecycle"
+)
+
+// writeTaskConfig writes the given JSON body to <dir>/.tether/task-config.json.
+func writeTaskConfig(t *testing.T, dir, body string) {
+	t.Helper()
+	td := filepath.Join(dir, ".tether")
+	if err := os.MkdirAll(td, 0o755); err != nil {
+		t.Fatalf("mkdir .tether: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(td, "task-config.json"), []byte(body), 0o644); err != nil {
+		t.Fatalf("write task-config.json: %v", err)
+	}
+}
+
+func TestLoadTaskConfig_MissingFile(t *testing.T) {
+	dir := t.TempDir()
+	got, err := lifecycle.LoadTaskConfig(dir)
+	if err != nil {
+		t.Fatalf("missing file should not error, got: %v", err)
+	}
+	if got != nil {
+		t.Fatalf("missing file should return nil map, got: %v", got)
+	}
+}
+
+func TestLoadTaskConfig_ValidSingle(t *testing.T) {
+	dir := t.TempDir()
+	writeTaskConfig(t, dir, `{
+		"version": 1,
+		"servers": {
+			"foo": {
+				"command": ["foo-bin", "--flag"],
+				"env": {"K": "V"},
+				"prefix": "fx",
+				"inherit_env": ["GOPATH", "HOME"]
+			}
+		}
+	}`)
+
+	got, err := lifecycle.LoadTaskConfig(dir)
+	if err != nil {
+		t.Fatalf("valid config error: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("expected 1 server, got %d", len(got))
+	}
+	sc, ok := got["foo"]
+	if !ok {
+		t.Fatalf("expected server 'foo', got %v", got)
+	}
+	if len(sc.Command) != 2 || sc.Command[0] != "foo-bin" || sc.Command[1] != "--flag" {
+		t.Fatalf("command not mapped: %v", sc.Command)
+	}
+	if sc.Env["K"] != "V" {
+		t.Fatalf("env not mapped: %v", sc.Env)
+	}
+	if sc.Prefix != "fx" {
+		t.Fatalf("prefix not mapped: %q", sc.Prefix)
+	}
+	if len(sc.InheritEnv) != 2 || sc.InheritEnv[0] != "GOPATH" || sc.InheritEnv[1] != "HOME" {
+		t.Fatalf("inherit_env not mapped: %v", sc.InheritEnv)
+	}
+}
+
+func TestLoadTaskConfig_ValidMulti(t *testing.T) {
+	dir := t.TempDir()
+	writeTaskConfig(t, dir, `{
+		"version": 1,
+		"servers": {
+			"a": {"command": ["a-bin"]},
+			"b": {"command": ["b-bin", "arg"]}
+		}
+	}`)
+
+	got, err := lifecycle.LoadTaskConfig(dir)
+	if err != nil {
+		t.Fatalf("valid multi config error: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("expected 2 servers, got %d", len(got))
+	}
+	if _, ok := got["a"]; !ok {
+		t.Fatalf("missing server 'a': %v", got)
+	}
+	if _, ok := got["b"]; !ok {
+		t.Fatalf("missing server 'b': %v", got)
+	}
+}
+
+func TestLoadTaskConfig_Errors(t *testing.T) {
+	cases := []struct {
+		name string
+		body string
+	}{
+		{"malformed JSON", `{"version": 1, "servers": {`},
+		{"version 0", `{"version": 0, "servers": {"a": {"command": ["a-bin"]}}}`},
+		{"version 2", `{"version": 2, "servers": {"a": {"command": ["a-bin"]}}}`},
+		{"empty command", `{"version": 1, "servers": {"a": {"command": []}}}`},
+		{"missing command", `{"version": 1, "servers": {"a": {"env": {"K": "V"}}}}`},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			writeTaskConfig(t, dir, tc.body)
+			_, err := lifecycle.LoadTaskConfig(dir)
+			if err == nil {
+				t.Fatalf("expected error for %s", tc.name)
+			}
+		})
+	}
+}

--- a/internal/server/lifecycle.go
+++ b/internal/server/lifecycle.go
@@ -191,9 +191,24 @@ func Run(cfg *Config) error {
 		}
 	}
 
-	// Step 3c: per-task MCP lifecycle manager (v0.4).
+	// Step 3c: per-task MCP lifecycle manager (v0.4) + idle watchdog (v0.5).
+	// The watchdog hibernates task instances idle past TETHER_MCP_IDLE_TIMEOUT
+	// (default 15m; set "0" to disable); a hibernated instance is revived on its
+	// next tool call.
 	if cfg.MCPLifecycle == nil {
-		cfg.MCPLifecycle = mcplifecycle.New()
+		idleTimeout := 15 * time.Minute
+		if v := os.Getenv("TETHER_MCP_IDLE_TIMEOUT"); v != "" {
+			switch d, err := time.ParseDuration(v); {
+			case err != nil:
+				slog.Warn("invalid TETHER_MCP_IDLE_TIMEOUT; using default", "value", v, "default", idleTimeout)
+			case d < 0:
+				slog.Warn("negative TETHER_MCP_IDLE_TIMEOUT disables the idle watchdog", "value", v)
+				idleTimeout = d // <= 0 disables the watchdog in WithIdleWatchdog
+			default:
+				idleTimeout = d
+			}
+		}
+		cfg.MCPLifecycle = mcplifecycle.New(mcplifecycle.WithIdleWatchdog(idleTimeout, 0))
 	}
 
 	// Step 4: load or generate cert.


### PR DESCRIPTION
## tether v0.5 MCP features

Implements the two planned v0.5 items (spec `mem_jjx9AsCv`, plan `mem_PsupoGEh`).

### F1 — Per-task external MCP server config
Tasks declare MCP servers in `<workspace>/.tether/task-config.json`; they're **merged** with any inline `extra_servers` on the task-MCP REST API (request keys win on collision). Missing file = no-op; malformed file (bad JSON / `version != 1` / empty command) aborts start with a descriptive error.

### F2 — Idle-instance watchdog (hibernate + lazy wake)
`LifecycleManager` runs a watchdog that **hibernates** task MCP instances idle past a threshold: child servers are stopped to reclaim resources while the loopback, in-process builtins, and **cold external tool defs** stay advertised. The next external tool call **lazily wakes** the instance (re-spawns children, repopulates routing) before dispatch; builtin calls never wake. Config via `TETHER_MCP_IDLE_TIMEOUT` (default `15m`; `0`/negative disables).

### Incidental fix
Per-task child MCP servers were scoped to the **request context** that started them (they'd die when that HTTP request returned). Now scoped to an instance-level `baseCtx` cancelled on `Stop`.

### Tests
Unit + white-box: an in-memory MCP client proves cold-tool retention (tool stays listed after hibernate) and lazy wake; watchdog hibernate/skip-active/disabled/StopAll; **wake-failure rollback** (no child leak, stays retryably dormant); task-config loader + merge. `go build`/`vet`/full `./internal/...` tests green, gofmt clean, **race-clean**.

### Review notes / known follow-ups (not blocking)
- **host.Manager async deregister vs. fast hibernate→wake**: the supervisor goroutine's async `reg.Deregister` on ctx-cancel can, under a rare millisecond-scale hibernate→wake race, strip a just-woken tool from the server until the next registry churn. Pre-existing host behavior, newly exposed; self-heals. Tracking a follow-up to harden `host.Manager` with generation/epoch tracking.
- **Activity = any authorized MCP request** (incl. `tools/list`), by design; a client that polls keeps an instance warm.
- `v0.5.0` tag will be cut as a separate release step (mirrors v0.4.1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)