### PR TITLE
docs(release): v0.5.0 — per-task MCP config + idle watchdog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,27 @@
 # Changelog
 
+## v0.5.0 — 2026-07-06 (PR #87)
+
+Per-task MCP server configuration and idle-instance resource management. Drop-in over
+v0.4.1; no breaking API changes.
+
+### Added
+- **Per-task external MCP servers via `.tether/task-config.json`**: a task declares its own
+  stdio MCP servers in `<workspace>/.tether/task-config.json` (`{ "version": 1, "servers": {…} }`);
+  they are merged with any inline `extra_servers` on the task-MCP REST API, request keys winning
+  on collision. A missing file is a no-op; a malformed file fails task start with a descriptive
+  error.
+- **Idle-instance watchdog**: `LifecycleManager` hibernates per-task MCP instances idle past a
+  threshold — child servers are stopped to reclaim resources while the loopback, in-process
+  builtins, and cold external tool defs stay advertised. The next external tool call lazily wakes
+  the instance (re-spawns children, repopulates routing) before dispatch. Configurable via
+  `TETHER_MCP_IDLE_TIMEOUT` (default `15m`; `0` or a negative value disables).
+
+### Fixed
+- Per-task child MCP servers are now scoped to an instance-level context (cancelled on `Stop`)
+  instead of the request context that triggered start/wake — they no longer die when that HTTP
+  request returns.
+
 ## v0.4.1 — 2026-05-28 (PR #71–#85)
 
 UI v2 + streaming + auth-hardening increment on the v0.4 line. No API or schema breaks;

--- a/docs/upgrade-path.md
+++ b/docs/upgrade-path.md
@@ -45,16 +45,22 @@ UI/streaming/auth increment on the v0.4 line — drop-in over v0.4.0, no API or 
 
 See [CHANGELOG](../CHANGELOG.md#v041--2026-05-28).
 
+### v0.4.1 → v0.5.0 (2026-07-06)
+
+Per-task MCP configuration + idle-instance resource management — drop-in over v0.4.1.
+
+- **Per-task external MCP server config**: tasks declare their own stdio servers in
+  `.tether/task-config.json`; merged with inline `extra_servers` (request wins).
+- **Idle-instance watchdog**: hibernates idle task instances (stops child servers, keeps the
+  loopback + builtins + cold tool defs) and lazily wakes them on the next external tool call.
+  Config via `TETHER_MCP_IDLE_TIMEOUT` (default 15m; `0`/negative disables).
+- **Fix**: per-task child servers scoped to instance lifetime, not the triggering request ctx.
+
+See [CHANGELOG](../CHANGELOG.md#v050--2026-07-06).
+
 ---
 
 ## Upcoming
-
-### v0.4 → v0.5 (planned)
-
-- **Per-task external MCP server config**: tasks declare their own servers in
-  `.tether/task-config.json`; `LifecycleManager` starts/stops them with the task.
-- **Watchdog GC for idle MCP instances**: idle instances stopped after a threshold;
-  revived on next tool call.
 
 ### v0.5 → v1.0 (roadmap)
 


### PR DESCRIPTION
## v0.5.0 release notes

Documents the v0.5 MCP features that landed on `main` via PR #87 (`5914077`). Docs-only.

- **CHANGELOG.md** — new `v0.5.0 — 2026-07-06` section: per-task `.tether/task-config.json` (merge with inline `extra_servers`), idle-instance watchdog (hibernate + lazy wake, `TETHER_MCP_IDLE_TIMEOUT`), and the child-server ctx-lifetime fix.
- **docs/upgrade-path.md** — moved the `v0.4 → v0.5` block from "Upcoming (planned)" into "Released versions" as `v0.4.1 → v0.5.0`.

After merge: annotated tag `v0.5.0` will be cut at the merge commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)