### PR TITLE
fix(mcp/host): generation-guard Manager against stale supervisor deregister

### DIFF
--- a/internal/mcp/host/manager.go
+++ b/internal/mcp/host/manager.go
@@ -16,6 +16,7 @@ type Manager struct {
 	mu      sync.RWMutex
 	conns   map[string]ServerConn
 	cancels map[string]context.CancelFunc
+	gen     map[string]uint64 // per-name generation counter; guards stale deregister/delete
 	reg     ToolRegistry
 	logger  HistoryLogger
 }
@@ -25,6 +26,7 @@ func NewManager(reg ToolRegistry, logger HistoryLogger) *Manager {
 	return &Manager{
 		conns:   make(map[string]ServerConn),
 		cancels: make(map[string]context.CancelFunc),
+		gen:     make(map[string]uint64),
 		reg:     reg,
 		logger:  logger,
 	}
@@ -90,9 +92,24 @@ func (m *Manager) startOne(ctx context.Context, cfg ServerConfig) error {
 	}
 
 	m.mu.Lock()
+	// Bump the generation BEFORE storing conn/cancel so this supervisor's
+	// deregister/delete become no-ops once a newer Start supersedes it.
+	m.gen[cfg.Name]++
+	g := m.gen[cfg.Name]
 	m.conns[cfg.Name] = conn
 	m.cancels[cfg.Name] = cancel
 	m.mu.Unlock()
+
+	// deregister only removes tools if this generation is still current;
+	// a stale supervisor's cleanup must not wipe a newer generation's tools.
+	deregister := func() {
+		m.mu.Lock()
+		current := m.gen[cfg.Name] == g
+		m.mu.Unlock()
+		if current {
+			m.reg.Deregister(cfg.Name)
+		}
+	}
 
 	// connectFn for supervisor retries: creates a new connection and updates m.conns.
 	connectFn := func() (ServerConn, []mcp.Tool, error) {
@@ -101,19 +118,26 @@ func (m *Manager) startOne(ctx context.Context, cfg ServerConfig) error {
 			return nil, nil, err
 		}
 		m.mu.Lock()
-		m.conns[cfg.Name] = c
+		if m.gen[cfg.Name] == g {
+			m.conns[cfg.Name] = c
+		}
 		m.mu.Unlock()
 		return c, t, nil
 	}
 
-	sup := NewSupervisor(cfg, m.reg, m.logger, conn, connectFn)
+	sup := NewSupervisor(cfg, m.reg, m.logger, conn, connectFn, deregister)
 	go func() {
 		sup.Run(supCtx)
 		// C2: clear stale conn when supervisor exits (retries exhausted or ctx cancelled).
+		// Only touch the maps if this generation is still current, so a fast
+		// Stop→Start for the same name is not clobbered by the old supervisor.
 		m.mu.Lock()
-		delete(m.conns, cfg.Name)
+		if m.gen[cfg.Name] == g {
+			delete(m.conns, cfg.Name)
+			delete(m.cancels, cfg.Name)
+		}
 		m.mu.Unlock()
-		m.reg.Deregister(cfg.Name)
+		deregister()
 	}()
 
 	return nil
@@ -126,6 +150,9 @@ func (m *Manager) Stop(name string) error {
 	conn, hasConn := m.conns[name]
 	delete(m.cancels, name)
 	delete(m.conns, name)
+	// Invalidate the stopped generation so the exiting supervisor's async
+	// deregister/delete cannot wipe a subsequent Start's tools/conn.
+	m.gen[name]++
 	m.mu.Unlock()
 
 	if hasCancel {

--- a/internal/mcp/host/manager_test.go
+++ b/internal/mcp/host/manager_test.go
@@ -1,0 +1,108 @@
+package host_test
+
+import (
+	"context"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+
+	"github.com/piaobeizu/tether/internal/mcp/host"
+	"github.com/piaobeizu/tether/internal/mcp/registry"
+)
+
+// stdioServerEnvMgr, when set to "1", makes TestStdioMCPServerHelperMgr act as a
+// real stdio MCP server (used as a spawnable child process by the manager tests).
+const stdioServerEnvMgr = "TETHER_TEST_MCP_STDIO_MGR"
+
+// TestStdioMCPServerHelperMgr is not a real test: when invoked via re-exec with
+// stdioServerEnvMgr=1 it serves a minimal MCP server over stdin/stdout so the
+// Manager's synchronous connect succeeds without a fragile fake binary.
+func TestStdioMCPServerHelperMgr(t *testing.T) {
+	if os.Getenv(stdioServerEnvMgr) != "1" {
+		t.Skip("helper process only")
+	}
+	srv := mcp.NewServer(&mcp.Implementation{Name: "test-stdio-mgr", Version: "v0.0.1"}, nil)
+	mcp.AddTool(srv, &mcp.Tool{Name: "noop", Description: "no-op"},
+		func(_ context.Context, _ *mcp.CallToolRequest, _ struct{}) (*mcp.CallToolResult, struct{}, error) {
+			return &mcp.CallToolResult{}, struct{}{}, nil
+		})
+	_ = srv.Run(context.Background(), &mcp.StdioTransport{})
+}
+
+// stdioCmd returns argv that re-execs the test binary as a stdio MCP server.
+func stdioCmd() []string {
+	return []string{os.Args[0], "-test.run=^TestStdioMCPServerHelperMgr$"}
+}
+
+// stdioEnv returns the env needed to activate the helper server.
+func stdioEnv() map[string]string {
+	return map[string]string{stdioServerEnvMgr: "1"}
+}
+
+// hasServerTool reports whether the registry has any tool for the given server.
+// Registry prefixes tools as "<name>_<tool>" (host.NamespacePrefix), so we match
+// on ServerName rather than an exact prefixed tool name.
+func hasServerTool(reg *registry.Registry, server string) bool {
+	for _, e := range reg.ListAll() {
+		if e.ServerName == server {
+			return true
+		}
+	}
+	return false
+}
+
+// TestManagerGenerationGuard_StopThenStartKeepsNewTools reproduces tether#6: a
+// fast Stop→Start for the same name must not lose the new generation's tools to
+// a stale supervisor's async cleanup.
+func TestManagerGenerationGuard_StopThenStartKeepsNewTools(t *testing.T) {
+	reg := registry.New()
+	mgr := host.NewManager(reg, host.NoopLogger())
+	defer mgr.StopAll()
+
+	ctx := context.Background()
+	cfg := &host.Config{
+		Servers: map[string]host.ServerConfig{
+			"ext": {Command: stdioCmd(), Env: stdioEnv()},
+		},
+	}
+
+	// Initial start: tools registered, conn live.
+	if err := mgr.Start(ctx, cfg); err != nil {
+		t.Fatalf("initial Start: %v", err)
+	}
+	if !hasServerTool(reg, "ext") {
+		t.Fatal("expected 'ext' tool registered after initial Start")
+	}
+	if _, ok := mgr.GetConn("ext"); !ok {
+		t.Fatal("expected live conn for 'ext' after initial Start")
+	}
+
+	// Stop deregisters synchronously. Its returned error is the conn.Close()
+	// result, which for a CommandContext-backed child is "signal: killed" once
+	// the supervisor context is cancelled — benign here, so we ignore it. What
+	// matters is that the tools were deregistered before Close.
+	_ = mgr.Stop("ext")
+	if hasServerTool(reg, "ext") {
+		t.Fatal("expected no 'ext' tool after Stop")
+	}
+
+	// Re-start (hibernate→wake): a new generation registers the tool again.
+	if err := mgr.Start(ctx, cfg); err != nil {
+		t.Fatalf("re-Start: %v", err)
+	}
+	if !hasServerTool(reg, "ext") {
+		t.Fatal("expected 'ext' tool registered after re-Start")
+	}
+
+	// Give any stale supervisor cleanup time to run; it must be a no-op.
+	time.Sleep(150 * time.Millisecond)
+
+	if !hasServerTool(reg, "ext") {
+		t.Fatal("stale supervisor cleanup wiped the new generation's 'ext' tool")
+	}
+	if _, ok := mgr.GetConn("ext"); !ok {
+		t.Fatal("stale supervisor cleanup wiped the new generation's 'ext' conn")
+	}
+}

--- a/internal/mcp/host/supervisor.go
+++ b/internal/mcp/host/supervisor.go
@@ -35,12 +35,15 @@ type Supervisor struct {
 	logger      HistoryLogger
 	initialConn ServerConn // already-established conn; Run starts with this
 	connectFn   ConnectFn  // called only for retries
+	deregister  func()     // generation-guarded deregister; supersedes raw reg.Deregister
 }
 
 // NewSupervisor creates a Supervisor. Call Run(ctx) to start it.
 // initialConn is the already-established connection; connectFn is called only for retries.
-func NewSupervisor(cfg ServerConfig, reg ToolRegistry, logger HistoryLogger, initialConn ServerConn, connectFn ConnectFn) *Supervisor {
-	return &Supervisor{cfg: cfg, reg: reg, logger: logger, initialConn: initialConn, connectFn: connectFn}
+// deregister removes this server's tools; the Manager guards it with a generation
+// counter so a stale supervisor's cleanup cannot wipe a newer generation's tools.
+func NewSupervisor(cfg ServerConfig, reg ToolRegistry, logger HistoryLogger, initialConn ServerConn, connectFn ConnectFn, deregister func()) *Supervisor {
+	return &Supervisor{cfg: cfg, reg: reg, logger: logger, initialConn: initialConn, connectFn: connectFn, deregister: deregister}
 }
 
 // Run blocks until the server is permanently stopped (ctx cancelled or retries exhausted).
@@ -56,14 +59,14 @@ func (s *Supervisor) Run(ctx context.Context) {
 		select {
 		case <-ctx.Done():
 			_ = conn.Close()
-			s.reg.Deregister(s.cfg.Name)
+			s.deregister()
 			return
 		default:
 		}
 
 		// Crash.
 		slog.Warn("mcp/supervisor: server crashed", "server", s.cfg.Name, "attempt", attempt, "err", waitErr)
-		s.reg.Deregister(s.cfg.Name)
+		s.deregister()
 		_ = conn.Close()
 
 		// Always backoff before reconnect (even after failed connectFn — fixes I2).
@@ -87,7 +90,7 @@ func (s *Supervisor) Run(ctx context.Context) {
 				// I6: collision on re-register — exit loudly rather than silently losing tools.
 				slog.Error("mcp/supervisor: re-register collision — server unrecoverable", "server", s.cfg.Name, "err", regErr)
 				_ = conn.Close()
-				s.reg.Deregister(s.cfg.Name)
+				s.deregister()
 				_ = s.logger.Append("mcp_server_unrecoverable", map[string]any{
 					"server": s.cfg.Name, "reason": regErr.Error(),
 				})
@@ -98,7 +101,7 @@ func (s *Supervisor) Run(ctx context.Context) {
 
 	// All retries exhausted — clean up.
 	_ = conn.Close()
-	s.reg.Deregister(s.cfg.Name)
+	s.deregister()
 	_ = s.logger.Append("mcp_server_crashed", map[string]any{
 		"server":        s.cfg.Name,
 		"attempt_count": maxRetries,

--- a/internal/mcp/host/supervisor_test.go
+++ b/internal/mcp/host/supervisor_test.go
@@ -17,7 +17,7 @@ import (
 
 // fakeConn is a ServerConn whose Wait() blocks until Close() is called.
 type fakeConn struct {
-	crashErr error      // nil → clean close; non-nil → crash
+	crashErr error // nil → clean close; non-nil → crash
 	closeCh  chan struct{}
 	listResp []mcp.Tool
 }
@@ -73,7 +73,7 @@ func TestSupervisorExhaustsRetries(t *testing.T) {
 	go initialConn.Close()
 
 	cfg := host.ServerConfig{Name: "test-srv"}
-	sup := host.NewSupervisor(cfg, reg, logger, initialConn, connectFn)
+	sup := host.NewSupervisor(cfg, reg, logger, initialConn, connectFn, func() { reg.Deregister(cfg.Name) })
 
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()
@@ -106,7 +106,7 @@ func TestSupervisorCleanShutdown(t *testing.T) {
 	initialConn := newFakeConn(nil)
 
 	cfg := host.ServerConfig{Name: "srv2"}
-	sup := host.NewSupervisor(cfg, reg, logger, initialConn, connectFn)
+	sup := host.NewSupervisor(cfg, reg, logger, initialConn, connectFn, func() { reg.Deregister(cfg.Name) })
 
 	ctx, cancel := context.WithCancel(context.Background())
 	done := make(chan struct{})
@@ -154,7 +154,7 @@ func TestSupervisorDeregistersBeforeRetry(t *testing.T) {
 	reg.Register(cfg, tools)
 	go initialConn.Close()
 
-	sup := host.NewSupervisor(cfg, reg, logger, initialConn, connectFn)
+	sup := host.NewSupervisor(cfg, reg, logger, initialConn, connectFn, func() { reg.Deregister(cfg.Name) })
 
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()
@@ -164,5 +164,66 @@ func TestSupervisorDeregistersBeforeRetry(t *testing.T) {
 		if e.ServerName == "srv3" {
 			t.Fatalf("registry still has tool from crashed server: %+v", e)
 		}
+	}
+}
+
+// TestSupervisorDeregisterHonorsGenerationGuard proves the supervisor routes its
+// deregister through the injected callback, and that a generation-guarded closure
+// makes a stale generation's clean-shutdown deregister a no-op — so a newer Start
+// that has re-registered the same name keeps its tools.
+func TestSupervisorDeregisterHonorsGenerationGuard(t *testing.T) {
+	reg := registry.New()
+	logger := &crashLogger{}
+
+	cfg := host.ServerConfig{Name: "srvG"}
+	tools := []mcp.Tool{{Name: "foo"}}
+	// Register the tool as a (newer) generation's Start would.
+	if err := reg.Register(cfg, tools); err != nil {
+		t.Fatalf("register: %v", err)
+	}
+
+	// genCur models the Manager's current generation; myGen is this supervisor's.
+	var genCur atomic.Int64
+	genCur.Store(1)
+	const myGen = 1
+	dereg := func() {
+		if genCur.Load() == myGen {
+			reg.Deregister("srvG")
+		}
+	}
+
+	// Clean-shutdown fakeConn (nil crashErr): Wait() unblocks on Close().
+	initialConn := newFakeConn(nil)
+	connectFn := func() (host.ServerConn, []mcp.Tool, error) {
+		return newFakeConn(nil), nil, nil
+	}
+	sup := host.NewSupervisor(cfg, reg, logger, initialConn, connectFn, dereg)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() { sup.Run(ctx); close(done) }()
+
+	// A newer generation supersedes this supervisor before it cleans up.
+	genCur.Store(2)
+
+	// Trigger the clean-shutdown deregister path.
+	cancel()
+	initialConn.Close()
+
+	select {
+	case <-done:
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("supervisor did not stop after context cancel")
+	}
+
+	// The stale-generation deregister must have no-op'd: the tool survives.
+	found := false
+	for _, e := range reg.ListAll() {
+		if e.ServerName == "srvG" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatal("stale-generation deregister wiped a newer generation's tool")
 	}
 }


### PR DESCRIPTION
## tether#6 — host.Manager async-deregister race

Follow-up to the PR #87 (v0.5) review. A server's supervisor goroutine deregisters its tools when it exits (ctx cancel on Stop/StopAll, or retries exhausted). On a fast **Stop→Start** for the same name — the v0.5 hibernate→wake cycle — a **stale generation's** async `Deregister`/map-`delete` could fire after a newer `Start` re-registered the name, wiping the new generation's tools/conn.

### Fix
Per-name **generation counter** in `Manager`:
- `startOne` bumps `gen[name]` (capturing `g`) before storing the conn; `Stop` bumps it too.
- The supervisor's deregister is now a Manager-supplied **generation-guarded closure** (`s.deregister()` replaces the 4 raw `reg.Deregister` calls in `supervisor.go`); it no-ops unless `gen[name] == g`.
- The cleanup goroutine's `delete(conns)`/`delete(cancels)` and `connectFn`'s conn write are likewise gen-guarded.

So a stale supervisor generation can no longer clobber a newer one.

### Tests
- `supervisor_test.go`: `TestSupervisorDeregisterHonorsGenerationGuard` — a stale-generation guarded closure no-ops on the supervisor's shutdown path.
- `manager_test.go` (new): `TestManagerGenerationGuard_StopThenStartKeepsNewTools` — real re-exec stdio MCP server, Start→Stop→Start, asserts the new generation's tool + conn survive.
- `go build`/`vet` clean; **`go test -race -count=1 ./internal/mcp/...` green** (host, instance, lifecycle).

🤖 Generated with [Claude Code](https://claude.com/claude-code)