### PR TITLE
fix(agent): make opencode Interrupt() actually stop generation

### DIFF
--- a/internal/agent/opencode_provider.go
+++ b/internal/agent/opencode_provider.go
@@ -28,72 +28,115 @@ func NewOpenCodeProvider() *OpenCodeProvider { return &OpenCodeProvider{} }
 func (p *OpenCodeProvider) Name() string { return "opencode" }
 
 func (p *OpenCodeProvider) Spawn(ctx context.Context, cfg SpawnConfig) (Session, error) {
+	workdir := cfg.Workdir
+	if workdir == "" {
+		workdir, _ = os.Getwd()
+	}
+
+	sess := &opencodeSession{
+		workdir:   workdir,
+		env:       cfg.Env,
+		spawnCtx:  ctx,
+		events:    make(chan Event, 64),
+		sidCh:     make(chan struct{}),
+		resumeSID: cfg.ResumeSessionID,
+	}
+
+	if err := sess.startServe(ctx); err != nil {
+		return nil, err
+	}
+
+	// When the session context ends, release any SessionID() waiters and close
+	// the event stream. Each per-serve sseLoop deliberately does NOT own these
+	// (a hibernated/relaunched serve must not tear down the session's event
+	// stream), so this single session-scoped goroutine covers the ctx-cancel
+	// teardown paths that don't go through Close().
+	go func() {
+		<-ctx.Done()
+		sess.unblockSID()
+		sess.closeEvents()
+	}()
+
+	return sess, nil
+}
+
+// startServe launches (or relaunches) the `opencode serve` child on a fresh
+// port and starts a per-incarnation SSE loop bound to it. Called once by Spawn
+// and again by SendPrompt after Interrupt() hibernated the serve. Each call
+// installs a fresh serveExitDone channel and sseCancel so the previous
+// incarnation's goroutines are fully superseded.
+func (s *opencodeSession) startServe(ctx context.Context) error {
 	// Pick a random free TCP port for the opencode server.
 	ln, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {
-		return nil, fmt.Errorf("opencode: find free port: %w", err)
+		return fmt.Errorf("opencode: find free port: %w", err)
 	}
 	port := ln.Addr().(*net.TCPAddr).Port
 	ln.Close()
 
 	baseURL := fmt.Sprintf("http://127.0.0.1:%d", port)
 
-	workdir := cfg.Workdir
-	if workdir == "" {
-		workdir, _ = os.Getwd()
-	}
-
 	serve := exec.CommandContext(ctx, "opencode", "serve", "--port", fmt.Sprint(port))
-	serve.Dir = workdir
-	serve.Env = buildEnv(cfg.Env)
+	serve.Dir = s.workdir
+	serve.Env = buildEnv(s.env)
 	serve.Stderr = os.Stderr
 	if err := serve.Start(); err != nil {
-		return nil, fmt.Errorf("opencode serve: %w", err)
+		return fmt.Errorf("opencode serve: %w", err)
 	}
 
-	sess := &opencodeSession{
-		baseURL:       baseURL,
-		serve:         serve,
-		workdir:       workdir,
-		events:        make(chan Event, 64),
-		sidCh:         make(chan struct{}),
-		serveExitDone: make(chan struct{}),
-		resumeSID:     cfg.ResumeSessionID,
-	}
-	// Single goroutine owns serve.Wait(); waitReady checks done non-blocking,
-	// Close() reads done blocking. Catches the TOCTOU port-grab window
-	// between net.Listen() and opencode binding — if the port was stolen,
-	// opencode exits ~immediately and we get a clear error instead of
-	// "timeout after 10s".
+	// One goroutine owns serve.Wait() for this incarnation; waitReady checks
+	// exitDone non-blocking, Close()/Interrupt() read it blocking. Catches the
+	// TOCTOU port-grab window between net.Listen() and opencode binding — if the
+	// port was stolen, opencode exits ~immediately and we surface a clear error.
+	exitDone := make(chan struct{})
 	go func() {
-		err := serve.Wait()
-		sess.serveExitErr = err
-		close(sess.serveExitDone)
+		werr := serve.Wait()
+		s.mu.Lock()
+		s.serveExitErr = werr
+		s.mu.Unlock()
+		close(exitDone)
 	}()
 
-	if err := sess.waitReady(ctx, 10*time.Second); err != nil {
+	s.mu.Lock()
+	s.baseURL = baseURL
+	s.serve = serve
+	s.serveExitDone = exitDone
+	s.mu.Unlock()
+
+	if err := s.waitReady(ctx, baseURL, exitDone, 10*time.Second); err != nil {
 		_ = serve.Process.Kill()
-		<-sess.serveExitDone
-		return nil, fmt.Errorf("opencode serve not ready: %w", err)
+		<-exitDone
+		return fmt.Errorf("opencode serve not ready: %w", err)
 	}
 
-	go sess.sseLoop(ctx)
-	return sess, nil
+	// Per-serve SSE loop. Its own cancel lets Interrupt()/Close() stop just this
+	// incarnation without spinning on a dead port after the serve is killed; the
+	// next relaunch starts a fresh loop bound to the new port.
+	sseCtx, sseCancel := context.WithCancel(ctx)
+	s.mu.Lock()
+	s.sseCancel = sseCancel
+	s.mu.Unlock()
+	go s.sseLoop(sseCtx, baseURL)
+
+	return nil
 }
 
 // waitReady polls /global/health until the serve subprocess is responsive,
 // the deadline elapses, or the subprocess exits early.
-func (s *opencodeSession) waitReady(ctx context.Context, timeout time.Duration) error {
+func (s *opencodeSession) waitReady(ctx context.Context, baseURL string, exitDone chan struct{}, timeout time.Duration) error {
 	deadline := time.Now().Add(timeout)
-	url := s.baseURL + "/global/health"
+	url := baseURL + "/global/health"
 	client := &http.Client{Timeout: 500 * time.Millisecond}
 	for time.Now().Before(deadline) {
 		if ctx.Err() != nil {
 			return ctx.Err()
 		}
 		select {
-		case <-s.serveExitDone:
-			return fmt.Errorf("opencode serve exited during startup (port grab? missing binary?): %w", s.serveExitErr)
+		case <-exitDone:
+			s.mu.Lock()
+			werr := s.serveExitErr
+			s.mu.Unlock()
+			return fmt.Errorf("opencode serve exited during startup (port grab? missing binary?): %w", werr)
 		default:
 		}
 		resp, err := client.Get(url)
@@ -110,26 +153,48 @@ func (s *opencodeSession) waitReady(ctx context.Context, timeout time.Duration) 
 }
 
 type opencodeSession struct {
-	baseURL  string
-	serve    *exec.Cmd
+	// workdir/env/spawnCtx are captured at Spawn and reused to relaunch the
+	// serve after Interrupt(): opencode persists session state to disk, so a
+	// fresh serve resumes the same conversation via `--session <sid>`.
 	workdir  string
+	env      []string
+	spawnCtx context.Context
+
 	busy     atomic.Bool
 	events   chan Event
 	eventsMu sync.RWMutex // guards closed
 	closed   bool
-	mu       sync.RWMutex
-	sid      string
-	sidCh    chan struct{}
-	sidOnce  sync.Once
-	// Set once by the serve-monitor goroutine right before serveExitDone
-	// closes; safe to read after <-serveExitDone without a lock.
+
+	// lifeMu serializes serve-lifecycle transitions — the SendPrompt() resume
+	// swap, Interrupt(), and Close() — against each other. SendPrompt runs on
+	// the chat-stream goroutine while Interrupt runs on the control-channel
+	// goroutine (registry.InterruptSession), so without this the read-dormant →
+	// startServe → clear-dormant sequence could interleave with Interrupt's
+	// kill → set-dormant and clobber state / orphan a fresh serve. Held across
+	// the (blocking) kill+wait and relaunch; never held with s.mu.
+	lifeMu sync.Mutex
+
+	// mu guards every field below: the serve incarnation (baseURL/serve/
+	// serveExitErr/serveExitDone/sseCancel) is replaced across
+	// Interrupt()+SendPrompt() restarts, and dormant/curRunCancel/sid are
+	// touched from both the caller and the run goroutine.
+	mu            sync.RWMutex
+	sid           string
+	baseURL       string
+	serve         *exec.Cmd
 	serveExitErr  error
 	serveExitDone chan struct{}
-	resumeSID     string
+	sseCancel     context.CancelFunc
+	dormant       bool
+	curRunCancel  context.CancelFunc
+
+	sidCh     chan struct{}
+	sidOnce   sync.Once
+	resumeSID string
 }
 
 // emit safely sends ev to s.events; drops if the channel has been closed by
-// sseLoop's defer, preventing the closed-channel send panic.
+// closeEvents, preventing the closed-channel send panic.
 func (s *opencodeSession) emit(ev Event) {
 	s.eventsMu.RLock()
 	defer s.eventsMu.RUnlock()
@@ -178,15 +243,52 @@ func (s *opencodeSession) SendPrompt(ctx context.Context, text string) error {
 		return nil
 	}
 
+	// If a prior Interrupt() hibernated the serve, bring it back before running.
+	// opencode persisted the session to disk, so `--session <sid>` (appended
+	// below) resumes the same conversation on the fresh serve. lifeMu makes the
+	// read-dormant → startServe → clear-dormant swap atomic against a concurrent
+	// Interrupt()/Close() (see lifeMu doc).
+	s.lifeMu.Lock()
+	s.mu.RLock()
+	dormant := s.dormant
+	s.mu.RUnlock()
+	if dormant {
+		if err := s.startServe(s.spawnCtx); err != nil {
+			s.lifeMu.Unlock()
+			s.busy.Store(false)
+			s.emit(Event{Kind: EventError, Err: fmt.Errorf("opencode resume serve: %w", err)})
+			return nil
+		}
+		s.mu.Lock()
+		s.dormant = false
+		s.mu.Unlock()
+	}
+	s.lifeMu.Unlock()
+
+	// Derive a cancelable ctx for this run so Interrupt() can stop the client
+	// cleanly: cancellation suppresses the run's exit error (see below) and the
+	// goroutine still emits EventResult to close the turn.
+	runCtx, runCancel := context.WithCancel(ctx)
+	s.mu.Lock()
+	s.curRunCancel = runCancel
+	s.mu.Unlock()
+
 	go func() {
 		defer s.busy.Store(false)
 		// Always release SessionID() waiters when this goroutine exits — if
 		// opencode crashed before emitting session.created, sidCh would
 		// otherwise stay open forever.
 		defer s.unblockSID()
+		defer func() {
+			s.mu.Lock()
+			s.curRunCancel = nil
+			s.mu.Unlock()
+			runCancel()
+		}()
 
-		args := []string{"run", "--attach", s.baseURL, "--format", "json"}
 		s.mu.RLock()
+		baseURL := s.baseURL
+		args := []string{"run", "--attach", baseURL, "--format", "json"}
 		if s.sid != "" {
 			args = append(args, "--session", s.sid)
 		} else if s.resumeSID != "" {
@@ -195,7 +297,7 @@ func (s *opencodeSession) SendPrompt(ctx context.Context, text string) error {
 		s.mu.RUnlock()
 		args = append(args, text)
 
-		cmd := exec.CommandContext(ctx, "opencode", args...)
+		cmd := exec.CommandContext(runCtx, "opencode", args...)
 		cmd.Dir = s.workdir
 		cmd.Env = buildEnv(nil)
 		cmd.Stderr = os.Stderr
@@ -233,42 +335,113 @@ func (s *opencodeSession) SendPrompt(ctx context.Context, text string) error {
 		if err := sc.Err(); err != nil {
 			s.emit(Event{Kind: EventError, Err: fmt.Errorf("opencode run: stdout scan: %w", err)})
 		}
-		if err := cmd.Wait(); err != nil && ctx.Err() == nil {
+		// A non-zero exit that is the result of an Interrupt() (runCtx cancelled)
+		// or session teardown (ctx cancelled) is expected — don't surface it.
+		if err := cmd.Wait(); err != nil && ctx.Err() == nil && runCtx.Err() == nil {
 			s.emit(Event{Kind: EventError, Err: fmt.Errorf("opencode run exited: %w", err)})
 		}
-		// Emit EventResult after opencode run exits — more reliable than
-		// session.idle SSE (which can fire spuriously before text is done).
+		// Emit EventResult after opencode run exits (or is interrupted) — closes
+		// the turn for the consumer. More reliable than the session.idle SSE
+		// (which can fire spuriously before text is done).
 		s.emit(Event{Kind: EventResult, Text: "stop"})
 	}()
 	return nil
 }
 
-// Interrupt is a documented no-op for opencode (tether#8 T9 targets cc's
-// stream-json control_request interrupt only — see ccSession.Interrupt in
-// claude_provider.go). opencode's `serve` HTTP backend has no equivalent
-// interrupt call wired here, so a DAG-card pause click against an opencode
-// session currently does nothing observable. This asymmetry is intentional
-// scope for T9, not an oversight — extending pause to opencode is future
-// work, not tracked as a wi here.
-func (s *opencodeSession) Interrupt() error { return nil }
-
-func (s *opencodeSession) Close() error {
-	if s.serve.Process != nil {
-		_ = s.serve.Process.Kill()
+// Interrupt stops the in-flight turn for an opencode session. Unlike cc — which
+// writes a stream-json control_request on a long-lived stdin (see
+// ccSession.Interrupt) — opencode's generation is owned by the persistent
+// `opencode serve` process and streamed over SSE independently of the
+// short-lived `opencode run` client. Killing the run subprocess therefore does
+// NOT stop generation: the serve keeps producing tokens and the SSE stream
+// keeps flowing (verified empirically, tether#11 — killing the run process,
+// even its whole process group, left the serve generating). The only effective
+// interrupt is to kill the serve, which owns the work.
+//
+// The session stays resumable: opencode persists session state to disk, so the
+// next SendPrompt relaunches a fresh serve (the dormant path in SendPrompt) and
+// continues the same conversation via `--session <sid>`.
+func (s *opencodeSession) Interrupt() error {
+	// Nothing running -> nothing to interrupt (avoid needlessly hibernating an
+	// idle serve).
+	if !s.busy.Load() {
+		return nil
 	}
-	<-s.serveExitDone
-	return s.serveExitErr
+
+	// Serialize against a concurrent SendPrompt-resume / Close (see lifeMu doc).
+	s.lifeMu.Lock()
+	defer s.lifeMu.Unlock()
+
+	s.mu.Lock()
+	runCancel := s.curRunCancel
+	sseCancel := s.sseCancel
+	serve := s.serve
+	exitDone := s.serveExitDone
+	s.dormant = true
+	s.mu.Unlock()
+
+	// 1. Cancel the in-flight `opencode run` client so its goroutine winds down
+	//    without surfacing a spurious exit error and emits EventResult.
+	if runCancel != nil {
+		runCancel()
+	}
+	// 2. Stop this serve's SSE loop so it doesn't spin reconnecting to a port
+	//    that is about to die; SendPrompt starts a fresh loop on relaunch.
+	if sseCancel != nil {
+		sseCancel()
+	}
+	// 3. Kill the serve — it owns generation, so this actually stops it.
+	if serve != nil && serve.Process != nil {
+		_ = serve.Process.Kill()
+		if exitDone != nil {
+			<-exitDone
+		}
+	}
+	return nil
 }
 
-func (s *opencodeSession) sseLoop(ctx context.Context) {
-	defer s.closeEvents()
-	// Also unblock SessionID() waiters on shutdown — sseLoop is the goroutine
-	// that publishes the real sid via session.created; without this fallback,
-	// a waiter on s.sidCh would hang forever if the loop exits before sid.
-	defer s.unblockSID()
+func (s *opencodeSession) Close() error {
+	s.lifeMu.Lock()
+	defer s.lifeMu.Unlock()
 
+	s.mu.Lock()
+	runCancel := s.curRunCancel
+	sseCancel := s.sseCancel
+	serve := s.serve
+	exitDone := s.serveExitDone
+	s.mu.Unlock()
+
+	// Cancel any in-flight `opencode run` client too: killing the serve alone
+	// may not make an attached run client exit, which would block its goroutine
+	// on cmd.Wait() forever (goroutine leak + busy stuck true).
+	if runCancel != nil {
+		runCancel()
+	}
+	if sseCancel != nil {
+		sseCancel()
+	}
+	if serve != nil && serve.Process != nil {
+		_ = serve.Process.Kill()
+	}
+	if exitDone != nil {
+		<-exitDone
+	}
+	s.closeEvents()
+
+	s.mu.RLock()
+	err := s.serveExitErr
+	s.mu.RUnlock()
+	return err
+}
+
+// sseLoop consumes the serve's SSE /global/event stream for one serve
+// incarnation, bound to baseURL and stopped via ctx (see startServe). It does
+// NOT close the session's event stream on exit — the session outlives any
+// single serve incarnation (Interrupt() kills one, SendPrompt relaunches
+// another); closeEvents is owned by Close() / the Spawn ctx-done goroutine.
+func (s *opencodeSession) sseLoop(ctx context.Context, baseURL string) {
 	client := &http.Client{}
-	url := s.baseURL + "/global/event"
+	url := baseURL + "/global/event"
 
 	for {
 		if ctx.Err() != nil {
@@ -365,7 +538,9 @@ func (s *opencodeSession) readSSE(ctx context.Context, r io.Reader, emit func(Ev
 
 		case "session.error":
 			var props struct {
-				Error struct{ Message string `json:"message"` } `json:"error"`
+				Error struct {
+					Message string `json:"message"`
+				} `json:"error"`
 			}
 			if err := json.Unmarshal(wrapper.Payload.Properties, &props); err == nil {
 				if props.Error.Message != "" {

--- a/internal/agent/opencode_provider_test.go
+++ b/internal/agent/opencode_provider_test.go
@@ -1,0 +1,228 @@
+package agent
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+// newTestOCSession builds a bare opencodeSession suitable for exercising the
+// pure parsing/lifecycle helpers without spawning any real subprocess.
+func newTestOCSession() *opencodeSession {
+	return &opencodeSession{
+		events: make(chan Event, 64),
+		sidCh:  make(chan struct{}),
+	}
+}
+
+// TestOpenCodeReadSSE_TextDelta verifies a message.part.delta text frame yields
+// a token-level EventText and publishes the session id.
+func TestOpenCodeReadSSE_TextDelta(t *testing.T) {
+	s := newTestOCSession()
+	body := strings.Join([]string{
+		`data: {"payload":{"type":"message.part.delta","properties":{"sessionID":"ses_1","field":"text","delta":"Hel"}}}`,
+		`data: {"payload":{"type":"message.part.delta","properties":{"sessionID":"ses_1","field":"text","delta":"lo"}}}`,
+		// non-text field must be ignored
+		`data: {"payload":{"type":"message.part.delta","properties":{"sessionID":"ses_1","field":"reasoning","delta":"x"}}}`,
+		"",
+	}, "\n")
+
+	var got []Event
+	s.readSSE(context.Background(), strings.NewReader(body), func(ev Event) { got = append(got, ev) })
+
+	if len(got) != 2 {
+		t.Fatalf("expected 2 text events, got %d: %+v", len(got), got)
+	}
+	for _, ev := range got {
+		if ev.Kind != EventText {
+			t.Errorf("Kind = %q, want %q", ev.Kind, EventText)
+		}
+	}
+	if got[0].Text != "Hel" || got[1].Text != "lo" {
+		t.Errorf("deltas = %q,%q; want Hel,lo", got[0].Text, got[1].Text)
+	}
+	if s.SessionID() != "ses_1" {
+		t.Errorf("SessionID = %q, want ses_1", s.SessionID())
+	}
+}
+
+// TestOpenCodeReadSSE_CreatedAndError covers session.created -> EventInit and
+// session.error -> EventError.
+func TestOpenCodeReadSSE_CreatedAndError(t *testing.T) {
+	s := newTestOCSession()
+	body := strings.Join([]string{
+		`data: {"payload":{"type":"session.created","properties":{"sessionID":"ses_9"}}}`,
+		`data: {"payload":{"type":"session.error","properties":{"error":{"message":"boom"}}}}`,
+		// unrecognized type is ignored
+		`data: {"payload":{"type":"session.idle","properties":{}}}`,
+		// non-SSE line ignored
+		`: keep-alive`,
+		"",
+	}, "\n")
+
+	var got []Event
+	s.readSSE(context.Background(), strings.NewReader(body), func(ev Event) { got = append(got, ev) })
+
+	if len(got) != 2 {
+		t.Fatalf("expected 2 events (init+error), got %d: %+v", len(got), got)
+	}
+	if got[0].Kind != EventInit || got[0].SessionID != "ses_9" {
+		t.Errorf("event0 = %+v, want EventInit/ses_9", got[0])
+	}
+	if got[1].Kind != EventError || got[1].Err == nil || got[1].Err.Error() != "boom" {
+		t.Errorf("event1 = %+v, want EventError/boom", got[1])
+	}
+}
+
+// TestOpenCodeInterrupt_IdleNoOp — Interrupt() on a session with no in-flight
+// prompt must be a no-op (must not touch the nil serve / panic).
+func TestOpenCodeInterrupt_IdleNoOp(t *testing.T) {
+	s := newTestOCSession() // busy == false, serve == nil
+	if err := s.Interrupt(); err != nil {
+		t.Fatalf("idle Interrupt() = %v, want nil", err)
+	}
+	s.mu.RLock()
+	dormant := s.dormant
+	s.mu.RUnlock()
+	if dormant {
+		t.Error("idle Interrupt() must not hibernate the serve (dormant=true)")
+	}
+}
+
+// TestOpenCodeCloseEvents_Idempotent — closeEvents must be safe to call twice.
+func TestOpenCodeCloseEvents_Idempotent(t *testing.T) {
+	s := newTestOCSession()
+	s.closeEvents()
+	s.closeEvents() // must not panic on double close
+	if !s.closed {
+		t.Error("closed flag not set")
+	}
+	// emit after close is dropped, not a panic.
+	s.emit(Event{Kind: EventText, Text: "late"})
+}
+
+// TestOpenCodeInterrupt_Integration exercises the real spawn -> prompt ->
+// interrupt -> resume flow against an installed `opencode` binary. It is gated
+// behind TETHER_OPENCODE_IT (and skipped if opencode is absent) because it
+// spawns real subprocesses and makes a model call. Run locally with:
+//
+//	TETHER_OPENCODE_IT=1 GOWORK=off go test ./internal/agent/ -run Integration -v
+//
+// The model is pinned to a free opencode model via an opencode.json written
+// into the run workdir; override with TETHER_OPENCODE_MODEL.
+func TestOpenCodeInterrupt_Integration(t *testing.T) {
+	if os.Getenv("TETHER_OPENCODE_IT") == "" {
+		t.Skip("set TETHER_OPENCODE_IT=1 to run the opencode integration test")
+	}
+	if _, err := exec.LookPath("opencode"); err != nil {
+		t.Skip("opencode binary not found in PATH")
+	}
+	model := os.Getenv("TETHER_OPENCODE_MODEL")
+	if model == "" {
+		model = "opencode/deepseek-v4-flash-free"
+	}
+
+	// Pin the model via a project config in the workdir so we don't burn paid
+	// credits (the provider doesn't pass --model; opencode reads cwd config).
+	work := t.TempDir()
+	cfg := `{"$schema":"https://opencode.ai/config.json","model":"` + model + `"}`
+	if err := os.WriteFile(filepath.Join(work, "opencode.json"), []byte(cfg), 0o644); err != nil {
+		t.Fatalf("write opencode.json: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
+	defer cancel()
+
+	sess, err := NewOpenCodeProvider().Spawn(ctx, SpawnConfig{Workdir: work})
+	if err != nil {
+		t.Fatalf("spawn: %v", err)
+	}
+	defer sess.Close()
+	oc := sess.(*opencodeSession)
+
+	var counter chanCounter
+	go func() {
+		for ev := range sess.Events() {
+			if ev.Kind == EventText {
+				counter.incr()
+			}
+		}
+	}()
+
+	// First prompt: a long generation, so it's still running when we interrupt.
+	const longPrompt = "Write an extremely long, exhaustive 1500-word essay on the full history of computing. Use many paragraphs and be thorough."
+	if err := sess.SendPrompt(ctx, longPrompt); err != nil {
+		t.Fatalf("send: %v", err)
+	}
+	if !waitFor(30*time.Second, func() bool { return counter.get() > 2 }) {
+		t.Fatalf("no token deltas flowed within 30s (n=%d) — check model/creds", counter.get())
+	}
+
+	// Interrupt: must hibernate (kill) the serve and stop the delta flow.
+	if err := sess.Interrupt(); err != nil {
+		t.Fatalf("interrupt: %v", err)
+	}
+	oc.mu.RLock()
+	dormant, exitDone := oc.dormant, oc.serveExitDone
+	oc.mu.RUnlock()
+	if !dormant {
+		t.Error("after Interrupt() dormant should be true")
+	}
+	select { // Interrupt waits on exitDone before returning, so it's closed.
+	case <-exitDone:
+	default:
+		t.Error("serve exitDone not closed after Interrupt()")
+	}
+	// Let any in-flight SSE settle, then confirm the flow has actually stopped
+	// (this is the whole point: killing the serve stops generation).
+	time.Sleep(4 * time.Second)
+	afterGrace := counter.get()
+	time.Sleep(3 * time.Second)
+	if delta := counter.get() - afterGrace; delta > 0 {
+		t.Errorf("deltas kept flowing after interrupt+grace (+%d) — serve not stopped", delta)
+	}
+
+	// Resume: a fresh prompt must relaunch the serve and produce output again.
+	resumeBase := counter.get()
+	if err := sess.SendPrompt(ctx, "Reply with the single word: resumed."); err != nil {
+		t.Fatalf("resume send: %v", err)
+	}
+	if !waitFor(40*time.Second, func() bool { return counter.get() > resumeBase }) {
+		t.Fatalf("resume produced no new output within 40s (serve relaunch failed)")
+	}
+	oc.mu.RLock()
+	stillDormant := oc.dormant
+	oc.mu.RUnlock()
+	if stillDormant {
+		t.Error("after resume SendPrompt dormant should be cleared")
+	}
+}
+
+// chanCounter is a tiny concurrency-safe counter for the integration test.
+type chanCounter struct {
+	mu sync.Mutex
+	n  int
+}
+
+func (c *chanCounter) incr() { c.mu.Lock(); c.n++; c.mu.Unlock() }
+func (c *chanCounter) get() int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.n
+}
+
+func waitFor(d time.Duration, cond func() bool) bool {
+	deadline := time.Now().Add(d)
+	for time.Now().Before(deadline) {
+		if cond() {
+			return true
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	return cond()
+}


### PR DESCRIPTION
## tether#11

`opencodeSession.Interrupt()` was a no-op, so pausing an opencode-backed session (DAG pause / control-frame interrupt) did nothing observable.

### Why the documented design doesn't work
tether-doc (D-17a, v02-design) specified "kill the active subprocess" for opencode. That's **ineffective** for the `opencode run --attach <serve>` architecture this provider uses: generation is owned by the persistent `opencode serve` process and streamed over SSE (`/global/event`) **independently of the short-lived `opencode run` client**.

**Verified empirically** (opencode v1.3.13, free model): killing the `run` process — and even its entire process group — left the serve generating; the SSE stream kept delivering tokens for seconds after the client died. opencode v1.3.13's OpenAPI (`/doc`) also exposes **no** server-side abort endpoint, and `opencode run` has no interrupt flag.

### The fix — kill the serve, relaunch on resume
The serve owns the work, so killing it is the only thing that actually stops generation. opencode persists sessions to disk, so the session stays resumable:

- **`Interrupt()`**: cancel the in-flight run → cancel the serve's SSE loop → kill the serve (stops generation) → mark session dormant. No-op when idle.
- **`SendPrompt()`**: if dormant, relaunch a fresh `opencode serve` on a new port and continue the same conversation via `--session <sid>`.
- **Per-serve `sseLoop(ctx, baseURL)`** with its own cancel; it no longer closes the session event stream (a relaunched serve must not tear the session down) — `closeEvents` is owned by `Close()` + a session-ctx-done goroutine.
- **`lifeMu`** serializes the SendPrompt-resume swap / Interrupt / Close, since SendPrompt (chat-stream goroutine) and Interrupt (control-channel goroutine) run concurrently — without it a race could clobber dormant state or orphan a serve.
- **`Close()`** also cancels the in-flight run so its goroutine can't hang on `cmd.Wait()`.

### Tests (opencode had none before)
`internal/agent/opencode_provider_test.go`: readSSE parsing, idle-Interrupt no-op, closeEvents idempotency, and an **env-gated real-opencode integration test** (`TETHER_OPENCODE_IT=1`) that spawns a session, sends a long prompt, interrupts, asserts the token flow **stops**, then resumes and asserts new output.

### Verification
- `GOWORK=off go build ./...` / `go vet` — clean
- `go test -race ./internal/agent/` — green
- Real-opencode integration test — **PASS** (interrupt stops generation, resume works)
- Two-round opus concurrency review — **APPROVE** (round 1 caught 3 real races in the serve-restart lifecycle; fixed via `lifeMu` + Close cancelling the run; round 2 confirmed resolved, no deadlock)

### Known follow-up (not in scope)
`emit`'s non-blocking send can drop events under burst; a dropped terminal `EventResult` would leave a turn un-closed. Pre-existing (shared with the cc provider); worth a separate ticket to make terminal-event delivery reliable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)