### PR TITLE
fix(session): evict ended sessions from registry map (tether#12)

### DIFF
--- a/internal/session/registry.go
+++ b/internal/session/registry.go
@@ -168,10 +168,12 @@ func (r *Registry) GetOrSpawn(ctx context.Context, sid, providerName string) (ag
 
 // evict removes e from the sessions map after its session has terminated —
 // called from fanOut's defer, i.e. once the agent's Events() channel has
-// closed. Both providers close Events() when their subprocess exits, and
-// serveChat binds that subprocess to the client-connection context
-// (exec.CommandContext with wtsess.Context()); so a client disconnect cancels
-// the context, kills the subprocess, closes Events(), and lands here too.
+// closed. serveChat binds the agent subprocess to the client-connection
+// context (exec.CommandContext with wtsess.Context()), and both providers
+// close Events() when that context is cancelled — cc via readLoop's
+// `defer close(events)` after the SIGKILL'd subprocess EOFs, opencode via its
+// ctx-done goroutine (closeEvents). So a client disconnect (ctx cancel) closes
+// Events() and lands here, the same path as a session that ends on its own.
 // That single trigger covers BOTH "session ended" and "client disconnected",
 // which is why no idle timer or grace period is needed — the connection
 // context already bounds the subprocess lifetime (tether#12).

--- a/internal/session/registry.go
+++ b/internal/session/registry.go
@@ -32,6 +32,12 @@ type Entry struct {
 	subsMu        sync.RWMutex
 	ownerClientID string
 	fenceParser   *FenceParser // D-19 fenced-block extraction (tether#8 T6); one per session
+	// evicted is set true by Registry.evict once this session's fanOut loop
+	// has returned (session ended / client disconnected). Guarded by
+	// Registry.mu (NOT subsMu). It exists so the re-key goroutine in
+	// GetOrSpawnEntry, if it wins the race and runs AFTER eviction, refuses to
+	// re-insert this dead entry under its real sid (tether#12).
+	evicted bool
 }
 
 // Session returns the underlying agent.Session.
@@ -137,7 +143,10 @@ func (r *Registry) GetOrSpawnEntry(ctx context.Context, sid, providerName string
 		sid := sess.SessionID()
 		r.mu.Lock()
 		delete(r.sessions, tempKey)
-		if sid != "" {
+		// Skip the re-key if the session already ended and fanOut evicted the
+		// entry while we were parked in SessionID() (tether#12). Without this
+		// guard a fast session teardown could be resurrected here and leak.
+		if sid != "" && !e.evicted {
 			r.sessions[sid] = e
 		}
 		r.mu.Unlock()
@@ -155,6 +164,41 @@ func (r *Registry) GetOrSpawn(ctx context.Context, sid, providerName string) (ag
 		return nil, err
 	}
 	return e.sess, nil
+}
+
+// evict removes e from the sessions map after its session has terminated —
+// called from fanOut's defer, i.e. once the agent's Events() channel has
+// closed. Both providers close Events() when their subprocess exits, and
+// serveChat binds that subprocess to the client-connection context
+// (exec.CommandContext with wtsess.Context()); so a client disconnect cancels
+// the context, kills the subprocess, closes Events(), and lands here too.
+// That single trigger covers BOTH "session ended" and "client disconnected",
+// which is why no idle timer or grace period is needed — the connection
+// context already bounds the subprocess lifetime (tether#12).
+//
+// Eviction is by value: it deletes whatever key maps to e, catching the entry
+// whether it is keyed under its real sid or still under the pending-%p
+// placeholder from GetOrSpawnEntry. The placeholder case matters — a session
+// that dies before emitting system/init parks the re-key goroutine forever in
+// ccSession.SessionID() (sidReady never closes), so this by-value scan is the
+// only path that reclaims that map slot. Setting e.evicted first makes a
+// late-waking re-key goroutine refuse to re-insert the entry (see
+// GetOrSpawnEntry). Deleting during range is safe per the Go spec, and this
+// runs once per session lifetime — not on a hot path.
+//
+// r.locks is deliberately NOT cleaned here: the per-sid SessionLock is shared
+// with shell sessions (handleWTShell calls GetLock for the same sid), so its
+// lifetime is not bound to this chat Entry — reclaiming it safely needs a
+// cross-surface refcount, tracked as a separate follow-up.
+func (r *Registry) evict(e *Entry) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	e.evicted = true
+	for k, v := range r.sessions {
+		if v == e {
+			delete(r.sessions, k)
+		}
+	}
 }
 
 // RecordUserMessage persists a user-sent message to session history.
@@ -365,6 +409,12 @@ func truncStr(s string, n int) string {
 // (dropped, or the turn was interrupted): without it a stale open fence
 // from the previous turn would swallow the next turn's text forever.
 func (r *Registry) fanOut(e *Entry) {
+	// When the range below returns, the agent's Events() channel has closed —
+	// the session has ended (subprocess exited, or the client disconnected and
+	// cancelled the Spawn context that bounds the subprocess). Evict the entry
+	// so long-running daemons don't leak dead sessions in r.sessions (tether#12).
+	defer r.evict(e)
+
 	var sid string
 
 	emitSegments := func(segs []Segment) {

--- a/internal/session/registry_integration_test.go
+++ b/internal/session/registry_integration_test.go
@@ -1,0 +1,60 @@
+package session
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"testing"
+	"time"
+
+	"github.com/piaobeizu/tether/internal/agent"
+)
+
+// TestRegistry_EvictionOnContextCancel_Integration confirms the load-bearing
+// tether#12 chain end-to-end against a REAL opencode process: the ctx passed
+// to GetOrSpawnEntry bounds the agent subprocess (serveChat passes
+// wtsess.Context()), so cancelling it — the daemon's "client disconnected"
+// signal — closes the session's Events() channel, exits fanOut, and evicts the
+// entry. The unit tests close Events() by hand; only a real provider exercises
+// the ctx-cancel → closeEvents link that everything downstream depends on.
+//
+// No prompt is sent: spawning starts `opencode serve` and registers a pending
+// entry, which is all we need to prove that a ctx cancel tears the entry back
+// down. Gated behind TETHER_OPENCODE_IT and skipped when opencode is absent,
+// mirroring the agent-package opencode integration test:
+//
+//	TETHER_OPENCODE_IT=1 GOWORK=off go test ./internal/session/ -run Integration -v
+func TestRegistry_EvictionOnContextCancel_Integration(t *testing.T) {
+	if os.Getenv("TETHER_OPENCODE_IT") == "" {
+		t.Skip("set TETHER_OPENCODE_IT=1 to run the opencode integration test")
+	}
+	if _, err := exec.LookPath("opencode"); err != nil {
+		t.Skip("opencode binary not found in PATH")
+	}
+
+	reg := NewRegistry(agent.NewOpenCodeProvider())
+
+	ctx, cancel := context.WithCancel(context.Background())
+	if _, err := reg.GetOrSpawnEntry(ctx, "", "opencode"); err != nil {
+		cancel()
+		t.Fatalf("GetOrSpawnEntry: %v", err)
+	}
+
+	// Spawn registers the entry synchronously under its pending key; confirm
+	// it is present before we tear it down.
+	waitForCount(t, reg, 1)
+
+	// Mimic the client disconnecting: cancel the connection context. This must
+	// cascade through the real opencode session (closeEvents → fanOut exit →
+	// evict). Poll with a generous bound to absorb real process teardown.
+	cancel()
+
+	deadline := time.Now().Add(10 * time.Second)
+	for time.Now().Before(deadline) {
+		if regLen(reg) == 0 {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("registry still holds %d entries 10s after ctx cancel, want 0", regLen(reg))
+}

--- a/internal/session/registry_test.go
+++ b/internal/session/registry_test.go
@@ -21,13 +21,24 @@ import (
 type fakeSession struct {
 	sid    string
 	events chan agent.Event
+	// sidReady, when non-nil, gates SessionID() until it is closed — mimics
+	// ccSession.SessionID() blocking on system/init, used by the tether#12
+	// eviction-race test to end a session while the re-key goroutine is still
+	// parked in SessionID(). Nil (the default) returns the sid immediately,
+	// preserving every other test's behavior.
+	sidReady chan struct{}
 
 	mu             sync.Mutex
 	prompts        []string
 	interruptCalls int
 }
 
-func (f *fakeSession) SessionID() string { return f.sid }
+func (f *fakeSession) SessionID() string {
+	if f.sidReady != nil {
+		<-f.sidReady
+	}
+	return f.sid
+}
 func (f *fakeSession) SendPrompt(_ context.Context, text string) error {
 	f.mu.Lock()
 	defer f.mu.Unlock()
@@ -498,5 +509,105 @@ func TestRegistry_InterruptSession_UnknownSession(t *testing.T) {
 	reg := NewRegistry()
 	if err := reg.InterruptSession("does-not-exist"); err == nil {
 		t.Fatal("InterruptSession: want error for unknown session, got nil")
+	}
+}
+
+// regLen returns how many entries the registry currently holds, read under
+// its lock. Same-package white-box access used by the tether#12 eviction
+// tests to assert the map is actually reclaimed — not just that one sid
+// lookup misses.
+func regLen(reg *Registry) int {
+	reg.mu.RLock()
+	defer reg.mu.RUnlock()
+	return len(reg.sessions)
+}
+
+// waitForEvicted polls until sid is no longer registered — i.e. fanOut ran
+// its eviction defer after Events() closed. Bounded so a genuine failure
+// (entry never evicted) fails fast instead of hanging.
+func waitForEvicted(t *testing.T, reg *Registry, sid string) {
+	t.Helper()
+	deadline := time.Now().Add(500 * time.Millisecond)
+	for time.Now().Before(deadline) {
+		if !reg.IsLive(sid) {
+			return
+		}
+		time.Sleep(time.Millisecond)
+	}
+	t.Fatalf("session %q never evicted after its Events() channel closed", sid)
+}
+
+// waitForCount polls until the registry holds exactly n entries. Bounded.
+func waitForCount(t *testing.T, reg *Registry, n int) {
+	t.Helper()
+	deadline := time.Now().Add(500 * time.Millisecond)
+	for time.Now().Before(deadline) {
+		if regLen(reg) == n {
+			return
+		}
+		time.Sleep(time.Millisecond)
+	}
+	t.Fatalf("registry never reached %d entries; has %d", n, regLen(reg))
+}
+
+// TestRegistry_EvictsEntryOnSessionEnd — (tether#12) once a session's agent
+// Events() channel closes (subprocess exited, or the client disconnected and
+// cancelled the ctx that bounds the subprocess), fanOut returns and must
+// remove the entry from the registry. Before this fix a long-running daemon
+// leaked one map entry — plus its subscriber set and fence parser — for every
+// session ever opened.
+func TestRegistry_EvictsEntryOnSessionEnd(t *testing.T) {
+	fs := &fakeSession{sid: "sid-evict", events: make(chan agent.Event, 8)}
+	reg := NewRegistry(&fakeProvider{sess: fs})
+
+	if _, err := reg.GetOrSpawnEntry(context.Background(), "", "fake"); err != nil {
+		t.Fatalf("GetOrSpawnEntry: %v", err)
+	}
+	// Drive system/init so the entry is re-keyed under its real sid.
+	fs.events <- agent.Event{Kind: agent.EventInit, SessionID: "sid-evict"}
+	waitForRegistered(t, reg, "sid-evict")
+
+	// Session ends: closing Events() unblocks fanOut's range and runs its
+	// eviction defer.
+	close(fs.events)
+
+	waitForEvicted(t, reg, "sid-evict")
+	if n := regLen(reg); n != 0 {
+		t.Fatalf("registry holds %d entries after session end, want 0", n)
+	}
+}
+
+// TestRegistry_EvictedEntryNotResurrectedByRekey — (tether#12) guards the race
+// between fanOut's eviction and GetOrSpawnEntry's re-key goroutine. The
+// session ends BEFORE its sid is published (SessionID() is gated on sidReady),
+// so fanOut evicts the pending-keyed entry while the re-key goroutine is still
+// parked in SessionID(). When SessionID() is then released with a real sid,
+// the re-key goroutine must observe e.evicted and refuse to re-insert the dead
+// entry — otherwise it resurrects the very leak this task fixes.
+func TestRegistry_EvictedEntryNotResurrectedByRekey(t *testing.T) {
+	ready := make(chan struct{})
+	fs := &fakeSession{sid: "sid-race", events: make(chan agent.Event, 4), sidReady: ready}
+	reg := NewRegistry(&fakeProvider{sess: fs})
+
+	if _, err := reg.GetOrSpawnEntry(context.Background(), "", "fake"); err != nil {
+		t.Fatalf("GetOrSpawnEntry: %v", err)
+	}
+
+	// End the session before init: fanOut evicts the pending entry while the
+	// re-key goroutine is blocked in SessionID() (ready not yet closed).
+	close(fs.events)
+	waitForCount(t, reg, 0)
+
+	// Release the re-key goroutine with a real sid; it must NOT re-insert.
+	close(ready)
+	deadline := time.Now().Add(200 * time.Millisecond)
+	for time.Now().Before(deadline) {
+		if reg.IsLive("sid-race") {
+			t.Fatal("evicted entry was resurrected by the re-key goroutine")
+		}
+		time.Sleep(time.Millisecond)
+	}
+	if n := regLen(reg); n != 0 {
+		t.Fatalf("registry holds %d entries, want 0 (re-key must not resurrect)", n)
 	}
 }


### PR DESCRIPTION
## Problem

`Registry.fanOut` loops on the session's `Events()` channel; when the loop exits (session ended), it returned but **never removed the entry from `r.sessions`**. A long-running daemon therefore leaked one map entry — plus its subscriber set and fence parser — for every session ever opened. `tether#8`-follow-up.

## Why eviction-on-fanOut-exit is sufficient (no TTL/grace needed)

Both providers bind their subprocess to the `Spawn` ctx via `exec.CommandContext`, and `serveChat` passes `wtsess.Context()`. So a **client disconnect cancels the ctx → kills the subprocess → closes `Events()` → exits `fanOut`** — the exact same path as a self-terminating session. Evicting in `fanOut`'s `defer` covers *both* "session ended" and "client disconnected". The wi's open question (evict after EventResult? on disconnect? TTL/grace?) resolves to: **the connection ctx already bounds the subprocess lifetime**, so no idle timer or reaper is required.

## Change (`internal/session/registry.go`)

- `fanOut` gains `defer r.evict(e)`.
- `evict` deletes **by value**, catching both the real-sid key and the `pending-%p` placeholder. The placeholder case matters: a session that dies before `system/init` parks its re-key goroutine forever in `ccSession.SessionID()`, so the by-value scan is the only path that reclaims that map slot.
- `Entry.evicted` (guarded by `Registry.mu`) stops the `GetOrSpawnEntry` re-key goroutine from resurrecting a just-evicted entry if it wakes after eviction.
- **`r.locks` intentionally left untouched**: the per-sid `SessionLock` is shared with shell sessions (`handleWTShell` calls `GetLock` for the same sid), so its lifetime isn't bound to the chat `Entry`. Reclaiming it safely needs a cross-surface refcount — noted as a separate follow-up.

## Non-goal

Per the wi: fanparser / fan-out logic itself is untouched — this only adds lifecycle eviction.

## Test plan

- `go build ./...` ✓ · `go vet ./internal/session/` ✓ · `go test -race ./internal/session/` ✓
- **New unit tests**: `TestRegistry_EvictsEntryOnSessionEnd` (normal end) and `TestRegistry_EvictedEntryNotResurrectedByRekey` (fanOut-evict vs. re-key goroutine race, using a `sidReady`-gated fake). Both `-race`-clean.
- **Negative test**: removing `defer r.evict(e)` makes both new tests fail (`never evicted` / count stuck at 1) — confirming they bind the fix.
- **Live-verify (real process)**: new env-gated `TestRegistry_EvictionOnContextCancel_Integration` spawns a real `opencode` session through the `Registry`, cancels the ctx (= client disconnect), and asserts the entry is evicted — PASS in ~2.9s. Confirms the load-bearing `ctx-cancel → closeEvents → fanOut-exit → evict` chain that the unit tests only stub.

🤖 Generated with [Claude Code](https://claude.com/claude-code)