### PR TITLE
fix(auth): close isExempt suffix auth bypass (tether#16)

### DIFF
--- a/internal/auth/middleware.go
+++ b/internal/auth/middleware.go
@@ -167,20 +167,38 @@ func (s *State) isExempt(r *http.Request) bool {
 		p == "/api/v1/auth/verify",
 		p == "/api/v1/auth/logout",
 		p == "/cert-hash",
-		// WebTransport CONNECT uses a new QUIC connection that may not carry
-		// SameSite=Strict cookies. Auth is checked inside the handler instead.
-		strings.HasPrefix(p, "/wt/"),
 		p == "/cert-hash-spki",
 		p == "/mcp",
 		strings.HasPrefix(p, "/mcp/"),
+		// WebTransport CONNECT uses a new QUIC connection that may not carry
+		// SameSite=Strict cookies. Auth is checked inside the handler instead.
 		strings.HasPrefix(p, "/wt/"),
 		p == "/oauth/authorize",
 		p == "/oauth/token",
-		p == "/.well-known/oauth-authorization-server",
+		p == "/.well-known/oauth-authorization-server":
+		return true
+	// Static-asset suffixes (.js/.css/fonts/favicon/manifest) are exempt from
+	// the cookie check ONLY outside protected namespaces. The SPA and all its
+	// assets are served by the catch-all "/" handler (embed.FS) — never under
+	// /api, /wt, or /mcp. Gating on the suffix alone let a client-controlled
+	// trailing path segment (e.g. /api/v1/work/items/x.js) masquerade as a
+	// static asset and bypass cookie auth, reaching a handler that calls aihub
+	// with the daemon's server-side key (tether#16).
+	case !isProtectedNamespace(p) &&
 		hasSuffix(p, ".js", ".css", ".ico", ".png", ".svg", ".woff2", ".woff", ".ttf", ".webmanifest"):
 		return true
 	}
 	return false
+}
+
+// isProtectedNamespace reports whether p lives under a namespace that must
+// always be authenticated (cookie in the middleware, or a ticket/session
+// inside the handler for /wt and /mcp). Static-asset suffix exemption must
+// never apply to these, since their trailing path segments are client-controlled.
+func isProtectedNamespace(p string) bool {
+	return strings.HasPrefix(p, "/api/") ||
+		strings.HasPrefix(p, "/wt/") ||
+		p == "/mcp" || strings.HasPrefix(p, "/mcp/")
 }
 
 // IsExemptForTest exposes isExempt for whitebox testing.

--- a/internal/auth/middleware_test.go
+++ b/internal/auth/middleware_test.go
@@ -177,3 +177,68 @@ func TestIsExempt_OAuthAndWellKnownExact(t *testing.T) {
 		}
 	}
 }
+
+// TestIsExempt_StaticSuffixOnlyOutsideProtected pins tether#16: the static-asset
+// suffix exemption must apply to SPA assets served at root, but NEVER to a
+// client-controlled trailing segment under a protected namespace (/api, /wt, /mcp).
+func TestIsExempt_StaticSuffixOnlyOutsideProtected(t *testing.T) {
+	s := auth.NewState("tok", []byte("0123456789abcdef0123456789abcdef"))
+
+	// Genuine static assets served by the catch-all "/" handler.
+	exempt := []string{
+		"/assets/index-abc123.js",
+		"/assets/index-abc123.css",
+		"/favicon.ico",
+		"/logo.svg",
+		"/apple-touch-icon.png",
+		"/fonts/Inter.woff2",
+		"/manifest.webmanifest",
+	}
+	// Client-controlled trailing segments under protected namespaces that
+	// happen to end in an asset suffix — must NOT slip past the cookie check.
+	notExempt := []string{
+		"/api/v1/work/items/x.js",
+		"/api/v1/work/items/evil.css",
+		"/api/v1/sessions/foo.png",
+		"/api/v1/skills/bar.svg",
+		"/api/v1/work/projects.js",
+		// Lock the OTHER protected sub-namespaces too, so the guard is proven
+		// to cover the whole privileged surface, not just /api/v1/work.
+		"/api/v1/permission/x.svg",
+		"/api/v1/tasks/foo.css",
+		"/api/v1/mcp/tokens/x.png",
+	}
+
+	for _, p := range exempt {
+		req := httptest.NewRequest("GET", p, nil)
+		if !s.IsExemptForTest(req) {
+			t.Errorf("static asset %q should be exempt", p)
+		}
+	}
+	for _, p := range notExempt {
+		req := httptest.NewRequest("GET", p, nil)
+		if s.IsExemptForTest(req) {
+			t.Errorf("protected path %q must NOT be exempt via suffix", p)
+		}
+	}
+}
+
+// TestMiddleware_APISuffixLookAlikeNotExempt is the end-to-end guard for tether#16:
+// an unauthenticated /api path whose trailing segment ends in ".js" must get 401
+// and must never reach the inner handler.
+func TestMiddleware_APISuffixLookAlikeNotExempt(t *testing.T) {
+	s := auth.NewState("tok", []byte("0123456789abcdef0123456789abcdef"))
+	innerCalled := false
+	h := s.Middleware(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
+		innerCalled = true
+	}))
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/v1/work/items/x.js", nil)
+	h.ServeHTTP(rr, req)
+	if rr.Code != http.StatusUnauthorized {
+		t.Fatalf("unauth GET /api/v1/work/items/x.js: expected 401, got %d", rr.Code)
+	}
+	if innerCalled {
+		t.Fatal("inner handler must NOT be reached for a .js-suffixed /api path without a cookie")
+	}
+}


### PR DESCRIPTION
## What

`auth.isExempt` exempted **any** path ending in `.js/.css/.ico/.png/.svg/.woff2/.woff/.ttf/.webmanifest` from the `tether_session` cookie check via a global suffix match. Since REST paths like `/api/v1/work/items/{id}` carry a **client-controlled trailing segment**, a request to `/api/v1/work/items/x.js` matched the `.js` suffix, skipped auth, and reached the work-proxy handler — which calls aihub with the daemon's **server-side API key**.

## Fix

Gate the static-asset suffix case behind `!isProtectedNamespace(p)` (`/api/`, `/wt/`, `/mcp`). The SPA and all its assets are served at **root** by the catch-all `mux.Handle("/")` handler (go:embed) — never under a protected prefix — so root assets stay exempt while API/WT/MCP paths always require auth. Also dropped a duplicate `/wt/` switch case.

> Note: the wi originally proposed "anchor on `/static/` prefix", but there is **no `/static/` mount** — assets live at root. The negative-guard shape is more robust (won't over-block `/favicon.ico`-style root assets) and closes the same hole.

## Tests

- Whitebox `IsExemptForTest`: positive (`/assets/*.js`, `/favicon.ico`, `/manifest.webmanifest`, fonts) + negative (suffix-lookalikes under `/api/work`, `/permission`, `/tasks`, `/mcp/tokens`, `/sessions`, `/skills`).
- End-to-end `TestMiddleware_APISuffixLookAlikeNotExempt`: unauth `GET /api/v1/work/items/x.js` → **401**, inner handler never reached.
- `GOWORK=off go build` + `go test -race` + `go vet` all green.

## Verification

- **Opus adversarial review: ACCEPT** — no data-exposure bypass (`../`/`//`/`%2e` vectors are harmless `301→401` because Go's `ServeMux` canonicalizes the path *before* dispatch and the middleware keys off the same `r.URL.Path`); no over-block of legit SPA assets.
- **Live-verified on a real daemon** (`:8799`): exploit paths → `401 {"error":"unauthorized"}`; `/api/v1/work/queue` → `401`; `/assets/index-*.js` + `/manifest.webmanifest` → `200`; `/favicon.ico` → `404` (static handler, not an auth redirect → exemption intact).

## Deferred hardening (separate wi)

Opus flagged two **non-blocking** items: (1) flip the denylist to a `/assets`-prefix **allowlist** so it fails-closed on any future privileged prefix; (2) add canonicalization/traversal e2e tests through the real `buildMux` with a stub aihub client. Will track as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)