### PR TITLE
fix(agent): reliably deliver terminal events under backpressure (tether#14)

### DIFF
--- a/internal/agent/claude_provider.go
+++ b/internal/agent/claude_provider.go
@@ -63,6 +63,7 @@ func (p *ClaudeCodeProvider) Spawn(ctx context.Context, cfg SpawnConfig) (Sessio
 
 	sess := &ccSession{
 		cmd:       cmd,
+		ctx:       ctx,
 		stdin:     stdin,
 		enc:       enc,
 		events:    make(chan Event, 64),
@@ -85,6 +86,7 @@ func buildEnv(extra []string) []string {
 // ccSession is a live ClaudeCode stream-json session.
 type ccSession struct {
 	cmd      *exec.Cmd
+	ctx      context.Context // Spawn ctx; escape for the blocking terminal-event send
 	stdin    interface{ Close() error }
 	enc      *json.Encoder
 	events   chan Event
@@ -161,6 +163,28 @@ func (s *ccSession) Close() error {
 	return s.cmd.Wait()
 }
 
+// emit sends ev to s.events. Terminal events (isTerminal) block until delivered
+// so a full buffer can't drop them — a lost EventResult/EventError leaves the
+// consumer's turn open forever (tether#14). fanOut drains Events() until close,
+// so the send always makes progress; s.ctx is the escape when the session is
+// torn down (client disconnect cancels ctx, which also kills the subprocess).
+// readLoop is the sole sender and closes s.events only after it returns, so
+// there is no concurrent send/close here. Non-terminal events (token deltas
+// etc.) keep the non-blocking backpressure drop.
+func (s *ccSession) emit(ev Event) {
+	if isTerminal(ev.Kind) {
+		select {
+		case s.events <- ev:
+		case <-s.ctx.Done():
+		}
+		return
+	}
+	select {
+	case s.events <- ev:
+	default:
+	}
+}
+
 // readLoop consumes stream-json lines from cc stdout and emits Events.
 func (s *ccSession) readLoop(scanner *bufio.Scanner) {
 	scanner.Buffer(make([]byte, 1<<20), 100<<20)
@@ -171,10 +195,7 @@ func (s *ccSession) readLoop(scanner *bufio.Scanner) {
 		if ev == nil {
 			continue
 		}
-		select {
-		case s.events <- *ev:
-		default:
-		}
+		s.emit(*ev)
 	}
 }
 

--- a/internal/agent/emit_test.go
+++ b/internal/agent/emit_test.go
@@ -1,0 +1,174 @@
+package agent
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+// TestIsTerminal pins which event kinds must be delivered reliably (tether#14).
+func TestIsTerminal(t *testing.T) {
+	terminal := []EventKind{EventResult, EventError}
+	best := []EventKind{EventInit, EventText, EventToolUse, EventRateLimit}
+	for _, k := range terminal {
+		if !isTerminal(k) {
+			t.Errorf("%q should be terminal (must-deliver)", k)
+		}
+	}
+	for _, k := range best {
+		if isTerminal(k) {
+			t.Errorf("%q should be best-effort (droppable), not terminal", k)
+		}
+	}
+}
+
+// waitReturned reports whether close(done) happened within d.
+func waitReturned(done <-chan struct{}, d time.Duration) bool {
+	select {
+	case <-done:
+		return true
+	case <-time.After(d):
+		return false
+	}
+}
+
+// --- opencode emit -----------------------------------------------------------
+
+func TestOpencodeEmit_TerminalBlocksThenDelivers(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	s := &opencodeSession{spawnCtx: ctx, events: make(chan Event, 1)}
+
+	// Fill the single-slot buffer.
+	s.emit(Event{Kind: EventText, Text: "fill"})
+
+	// A non-terminal emit on a full buffer must DROP (return immediately).
+	dropped := make(chan struct{})
+	go func() { s.emit(Event{Kind: EventText, Text: "drop"}); close(dropped) }()
+	if !waitReturned(dropped, time.Second) {
+		t.Fatal("non-terminal emit blocked on a full buffer; must drop")
+	}
+
+	// A terminal emit on a full buffer must BLOCK (not drop).
+	term := make(chan struct{})
+	go func() { s.emit(Event{Kind: EventResult, Text: "stop"}); close(term) }()
+	if waitReturned(term, 50*time.Millisecond) {
+		t.Fatal("terminal emit returned while buffer full; must block until delivered")
+	}
+
+	// Drain one slot → the blocked terminal send now proceeds.
+	if got := <-s.events; got.Text != "fill" {
+		t.Fatalf("first buffered event = %q, want \"fill\" (the dropped one must be gone)", got.Text)
+	}
+	if !waitReturned(term, time.Second) {
+		t.Fatal("terminal emit did not complete after draining a slot")
+	}
+	if got := <-s.events; got.Kind != EventResult {
+		t.Fatalf("delivered event kind = %q, want EventResult", got.Kind)
+	}
+}
+
+func TestOpencodeEmit_TerminalUnblocksOnCtxCancel(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	s := &opencodeSession{spawnCtx: ctx, events: make(chan Event, 1)}
+	s.emit(Event{Kind: EventText}) // fill
+
+	term := make(chan struct{})
+	go func() { s.emit(Event{Kind: EventError}); close(term) }()
+	if waitReturned(term, 50*time.Millisecond) {
+		t.Fatal("terminal emit returned before ctx cancel with a full buffer")
+	}
+	cancel() // session torn down; no consumer will ever drain
+	if !waitReturned(term, time.Second) {
+		t.Fatal("terminal emit did not unblock on ctx cancel (goroutine leak)")
+	}
+}
+
+// TestOpencodeEmit_CloseEventsRaceWithBlockedTerminal pins the deadlock-freedom
+// claim: a terminal emit blocked mid-send holds eventsMu.RLock while closeEvents
+// contends for the write Lock. Safety relies on the consumer draining until the
+// channel closes (as fanOut does), so here a drainer mirrors fanOut. Whichever
+// wins the race — closeEvents sets closed first (terminal dropped) or the send
+// lands first (terminal drained) — must not deadlock.
+func TestOpencodeEmit_CloseEventsRaceWithBlockedTerminal(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	s := &opencodeSession{spawnCtx: ctx, events: make(chan Event, 1)}
+	s.emit(Event{Kind: EventText}) // fill the single slot
+
+	drained := make(chan struct{})
+	go func() {
+		for range s.events { //nolint:revive // draining like fanOut
+		}
+		close(drained)
+	}()
+
+	go s.emit(Event{Kind: EventResult, Text: "stop"})
+	time.Sleep(20 * time.Millisecond) // best-effort: let the terminal emit park
+	s.closeEvents()
+
+	if !waitReturned(drained, 2*time.Second) {
+		t.Fatal("deadlock: closeEvents vs blocked terminal emit never resolved")
+	}
+}
+
+func TestOpencodeEmit_ClosedIsNoop(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	s := &opencodeSession{spawnCtx: ctx, events: make(chan Event, 1)}
+	s.closeEvents()
+	// Must not panic on send-to-closed and must return promptly.
+	done := make(chan struct{})
+	go func() { s.emit(Event{Kind: EventResult}); close(done) }()
+	if !waitReturned(done, time.Second) {
+		t.Fatal("emit after closeEvents blocked; must be a no-op")
+	}
+}
+
+// --- cc emit -----------------------------------------------------------------
+
+func TestCCEmit_TerminalBlocksThenDelivers(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	s := &ccSession{ctx: ctx, events: make(chan Event, 1), sidReady: make(chan struct{})}
+
+	s.emit(Event{Kind: EventText, Text: "fill"})
+
+	dropped := make(chan struct{})
+	go func() { s.emit(Event{Kind: EventText, Text: "drop"}); close(dropped) }()
+	if !waitReturned(dropped, time.Second) {
+		t.Fatal("non-terminal emit blocked on a full buffer; must drop")
+	}
+
+	term := make(chan struct{})
+	go func() { s.emit(Event{Kind: EventResult, Text: "stop"}); close(term) }()
+	if waitReturned(term, 50*time.Millisecond) {
+		t.Fatal("terminal emit returned while buffer full; must block until delivered")
+	}
+
+	if got := <-s.events; got.Text != "fill" {
+		t.Fatalf("first buffered event = %q, want \"fill\"", got.Text)
+	}
+	if !waitReturned(term, time.Second) {
+		t.Fatal("terminal emit did not complete after draining a slot")
+	}
+	if got := <-s.events; got.Kind != EventResult {
+		t.Fatalf("delivered event kind = %q, want EventResult", got.Kind)
+	}
+}
+
+func TestCCEmit_TerminalUnblocksOnCtxCancel(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	s := &ccSession{ctx: ctx, events: make(chan Event, 1), sidReady: make(chan struct{})}
+	s.emit(Event{Kind: EventText}) // fill
+
+	term := make(chan struct{})
+	go func() { s.emit(Event{Kind: EventResult}); close(term) }()
+	if waitReturned(term, 50*time.Millisecond) {
+		t.Fatal("terminal emit returned before ctx cancel with a full buffer")
+	}
+	cancel()
+	if !waitReturned(term, time.Second) {
+		t.Fatal("terminal emit did not unblock on ctx cancel (goroutine leak)")
+	}
+}

--- a/internal/agent/event.go
+++ b/internal/agent/event.go
@@ -25,6 +25,18 @@ type Event struct {
 	Err       error // EventError
 }
 
+// isTerminal reports whether k is a turn-closing event that MUST be delivered
+// reliably — never dropped under backpressure. Losing one leaves the consumer's
+// turn open forever: the frontend clears its "thinking…" indicator on both the
+// result and error envelopes (tether#14), and some opencode error paths return
+// before emitting any EventResult, so the error is the only turn-closer. All
+// other kinds (EventText token deltas, tool_use, init, rate_limit) stay
+// best-effort and may be dropped when the buffer is full — intentional
+// backpressure for high-frequency output.
+func isTerminal(k EventKind) bool {
+	return k == EventResult || k == EventError
+}
+
 // ToolUseEvent carries a tool_use content block extracted from an assistant event.
 // NOTE: tool_use is a CONTENT BLOCK inside assistant.message.content[], NOT a
 // top-level stream event (D-05a §3, Risk #4). chat_translate.go extracts these.

--- a/internal/agent/opencode_provider.go
+++ b/internal/agent/opencode_provider.go
@@ -195,10 +195,26 @@ type opencodeSession struct {
 
 // emit safely sends ev to s.events; drops if the channel has been closed by
 // closeEvents, preventing the closed-channel send panic.
+//
+// Terminal events (isTerminal) block until delivered instead of being dropped:
+// a lost EventResult/EventError leaves the consumer's turn open forever
+// (tether#14). This is safe against a permanent hang because fanOut drains
+// Events() unconditionally until close, so the send always makes progress; the
+// spawnCtx guard is the escape when the session is torn down mid-send (the
+// same ctx the Spawn teardown goroutine uses to call closeEvents, so on cancel
+// this returns and releases eventsMu before closeEvents needs the write lock —
+// no deadlock). Non-terminal events keep the non-blocking backpressure drop.
 func (s *opencodeSession) emit(ev Event) {
 	s.eventsMu.RLock()
 	defer s.eventsMu.RUnlock()
 	if s.closed {
+		return
+	}
+	if isTerminal(ev.Kind) {
+		select {
+		case s.events <- ev:
+		case <-s.spawnCtx.Done():
+		}
 		return
 	}
 	select {

--- a/internal/agent/opencode_provider_test.go
+++ b/internal/agent/opencode_provider_test.go
@@ -15,8 +15,9 @@ import (
 // pure parsing/lifecycle helpers without spawning any real subprocess.
 func newTestOCSession() *opencodeSession {
 	return &opencodeSession{
-		events: make(chan Event, 64),
-		sidCh:  make(chan struct{}),
+		spawnCtx: context.Background(), // emit's terminal branch selects on this; nil would panic
+		events:   make(chan Event, 64),
+		sidCh:    make(chan struct{}),
 	}
 }
 


### PR DESCRIPTION
## What

Both agent providers emit events to a 64-slot buffered channel with a **non-blocking** send (`select { case events <- ev: default: }`). Dropping high-frequency `EventText` token deltas under backpressure is intentional. But dropping a **terminal** event is a bug: the frontend clears its "thinking…" spinner only on the result/error envelope (`store.ts`), so a lost `EventResult` (or `EventError`) leaves the turn open **forever**. Some opencode error paths `return` before ever emitting `EventResult`, making the error the sole turn-closer.

Source: tether#11 (opencode Interrupt) opus-review caveat. Pre-existing in both `claude_provider.go` and `opencode_provider.go`.

## Fix

`emit` now **blocks** terminal events (`isTerminal` = `EventResult` + `EventError`) until delivered, with a session-ctx escape; `EventText`/`tool_use`/`init`/`rate_limit` keep the non-blocking drop.

Why this can't hang: the sole consumer `Registry.fanOut` (`registry.go:443`) drains `Events()` **unconditionally until the channel closes** (no ctx check; `broadcast` is non-blocking per subscriber), so a blocking terminal send always makes progress. The ctx escape (`spawnCtx` for opencode; a new `ctx` field for cc) covers session teardown — it's the same ctx that binds the subprocess and triggers `closeEvents`, so on cancel `emit` returns and releases `eventsMu` before `closeEvents` needs the write lock (no deadlock).

## Tests

- `isTerminal` classification.
- Terminal **blocks-then-delivers** on a full buffer + **unblocks on ctx cancel** (both providers).
- `closeEvents`-vs-blocked-terminal-emit interleaving (a drainer mirrors `fanOut`) — pins deadlock-freedom.
- `closed`-is-noop; fixed a nil-`spawnCtx` trap in the test constructor.
- `GOWORK=off go build ./...` + `go test -race` (agent+session) + `vet` green; emit tests stable at 10× `-race`.

## Verification

- **Opus adversarial review: ACCEPT** — no reachable deadlock or goroutine leak (Spawn's only caller always starts `fanOut`; `Session.Close()` is dead code; teardown is 100% ctx-cancel).
- **Live-verified** with the real `claude` CLI: `TestClaudeStreaming_E2E` ran a full turn (19 streamed chunks), `EventResult` delivered, turn closed cleanly.

## Notes (non-blocking, from review)

All `EventError` are treated as must-deliver (no per-event terminal flag). The one non-terminal "busy" rejection already closed the spinner when delivered pre-fix, so reliable delivery changes reliability, not semantics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)