### PR TITLE
fix(auth): fail-closed static-asset exemption (tether#17)

### DIFF
--- a/internal/auth/middleware.go
+++ b/internal/auth/middleware.go
@@ -5,6 +5,7 @@ import (
 	"crypto/subtle"
 	"encoding/json"
 	"fmt"
+	"io/fs"
 	"log/slog"
 	"net/http"
 	"strings"
@@ -14,11 +15,26 @@ import (
 type State struct {
 	token  string
 	secret []byte
+	// staticFS is the embedded SPA dist (production). When set, static-asset
+	// cookie exemption is decided by real-file existence (fail-closed); when
+	// nil (dev mode, assets proxied to Vite) a suffix heuristic is used. See
+	// isStaticAsset (tether#17).
+	staticFS fs.FS
 }
 
 // NewState initialises auth from pre-loaded token and secret.
 func NewState(token string, secret []byte) *State {
 	return &State{token: token, secret: secret}
+}
+
+// WithStaticFS attaches the embedded SPA dist filesystem so static-asset
+// exemption is decided by real-file existence rather than a suffix heuristic.
+// Call only in production (embedded assets); leave unset in dev mode, where the
+// SPA is reverse-proxied to Vite and the dist FS does not describe live assets.
+// Returns s for chaining.
+func (s *State) WithStaticFS(fsys fs.FS) *State {
+	s.staticFS = fsys
+	return s
 }
 
 // Middleware wraps h, requiring a valid tether_session cookie on non-exempt routes.
@@ -177,18 +193,47 @@ func (s *State) isExempt(r *http.Request) bool {
 		p == "/oauth/token",
 		p == "/.well-known/oauth-authorization-server":
 		return true
-	// Static-asset suffixes (.js/.css/fonts/favicon/manifest) are exempt from
-	// the cookie check ONLY outside protected namespaces. The SPA and all its
-	// assets are served by the catch-all "/" handler (embed.FS) — never under
-	// /api, /wt, or /mcp. Gating on the suffix alone let a client-controlled
-	// trailing path segment (e.g. /api/v1/work/items/x.js) masquerade as a
-	// static asset and bypass cookie auth, reaching a handler that calls aihub
-	// with the daemon's server-side key (tether#16).
-	case !isProtectedNamespace(p) &&
-		hasSuffix(p, ".js", ".css", ".ico", ".png", ".svg", ".woff2", ".woff", ".ttf", ".webmanifest"):
+	// Static SPA assets are served by the catch-all "/" handler (embed.FS),
+	// never under /api, /wt, or /mcp. Exempt them from the cookie check — but
+	// fail-closed so a client-controlled trailing segment can't masquerade as
+	// an asset and reach a privileged handler with the daemon's server-side
+	// key (tether#16 / tether#17). See isStaticAsset.
+	case s.isStaticAsset(p):
 		return true
 	}
 	return false
+}
+
+// isStaticAsset reports whether p is exempt from the cookie check as a static
+// SPA asset. It NEVER exempts a protected namespace (/api,/wt,/mcp). In
+// production (staticFS set) a path is exempt only if it resolves to a real
+// embedded dist file — so any future non-/api privileged prefix (e.g.
+// /admin/x.js) that isn't a shipped asset stays auth-gated (fail-closed),
+// closing tether#16's latent fail-open where a suffix match alone sufficed
+// (tether#17). In dev (staticFS nil; assets are reverse-proxied to Vite and
+// not described by the embedded dist) it falls back to the static-suffix
+// heuristic, still gated behind isProtectedNamespace.
+func (s *State) isStaticAsset(p string) bool {
+	if isProtectedNamespace(p) {
+		return false
+	}
+	if s.staticFS != nil {
+		return staticFileExists(s.staticFS, p)
+	}
+	return hasSuffix(p, ".js", ".css", ".ico", ".png", ".svg", ".woff2", ".woff", ".ttf", ".webmanifest")
+}
+
+// staticFileExists reports whether URL path p maps to a regular file in fsys
+// (the embedded dist). fs paths are relative, slash-separated, with no leading
+// slash and no "." / ".." elements; fs.ValidPath rejects the traversal forms,
+// so an attacker can't escape the dist tree.
+func staticFileExists(fsys fs.FS, p string) bool {
+	name := strings.TrimPrefix(p, "/")
+	if name == "" || !fs.ValidPath(name) {
+		return false
+	}
+	info, err := fs.Stat(fsys, name)
+	return err == nil && !info.IsDir()
 }
 
 // isProtectedNamespace reports whether p lives under a namespace that must

--- a/internal/auth/middleware_test.go
+++ b/internal/auth/middleware_test.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"testing/fstest"
 
 	"github.com/piaobeizu/tether/internal/auth"
 )
@@ -219,6 +220,56 @@ func TestIsExempt_StaticSuffixOnlyOutsideProtected(t *testing.T) {
 		req := httptest.NewRequest("GET", p, nil)
 		if s.IsExemptForTest(req) {
 			t.Errorf("protected path %q must NOT be exempt via suffix", p)
+		}
+	}
+}
+
+// TestIsExempt_ProdExemptsOnlyRealDistFiles pins tether#17: in production
+// (staticFS set) a static-asset path is exempt ONLY if it resolves to a real
+// embedded dist file. This is fail-closed against a future non-/api privileged
+// prefix (e.g. /admin/x.js) that a mere suffix match would have exempted.
+func TestIsExempt_ProdExemptsOnlyRealDistFiles(t *testing.T) {
+	dist := fstest.MapFS{
+		"assets/index-abc.js":  {Data: []byte("x")},
+		"assets/index-abc.css": {Data: []byte("x")},
+		"icons/icon-192.png":   {Data: []byte("x")},
+		"manifest.webmanifest": {Data: []byte("x")},
+		"manifest.json":        {Data: []byte("x")},
+		"index.html":           {Data: []byte("x")},
+	}
+	s := auth.NewState("tok", []byte("0123456789abcdef0123456789abcdef")).WithStaticFS(dist)
+
+	exempt := []string{
+		"/assets/index-abc.js",
+		"/assets/index-abc.css",
+		"/icons/icon-192.png",
+		"/manifest.webmanifest",
+		// Behavior delta vs tether#16 (pin it): these real dist files are now
+		// exempt where suffix-mode did not list .html/.json. Both are public
+		// (the SPA shell is already served unauthenticated at /auth; manifest
+		// is PWA metadata), so exempting them leaks nothing.
+		"/index.html",
+		"/manifest.json",
+	}
+	notExempt := []string{
+		"/api/v1/work/items/x.js", // protected namespace — never exempt
+		"/admin/config.js",        // FUTURE non-/api privileged prefix: not a shipped asset → fail-closed
+		"/debug/pprof/heap.png",   // ditto
+		"/assets/missing.js",      // asset-shaped but not shipped
+		"/nope.png",               // root asset-shaped but absent
+		"/assets/../secret.js",    // traversal — fs.ValidPath rejects
+		"//api/v1/work/queue.js",  // double slash: residual leading slash after trim → ValidPath rejects
+		"/assets",                 // directory — fs.Stat IsDir
+		"/assets/",                // directory w/ trailing slash — ValidPath rejects
+	}
+	for _, p := range exempt {
+		if !s.IsExemptForTest(httptest.NewRequest("GET", p, nil)) {
+			t.Errorf("prod: %q should be exempt (real dist file)", p)
+		}
+	}
+	for _, p := range notExempt {
+		if s.IsExemptForTest(httptest.NewRequest("GET", p, nil)) {
+			t.Errorf("prod: %q must NOT be exempt", p)
 		}
 	}
 }

--- a/internal/server/lifecycle.go
+++ b/internal/server/lifecycle.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"io/fs"
 	"log/slog"
 	"net/http"
 	"os"
@@ -31,6 +32,7 @@ import (
 	"github.com/piaobeizu/tether/internal/session"
 	"github.com/piaobeizu/tether/internal/skill"
 	"github.com/piaobeizu/tether/internal/workspace"
+	"github.com/piaobeizu/tether/web"
 )
 
 // Config holds all server startup parameters.
@@ -264,6 +266,17 @@ func Run(cfg *Config) error {
 		return fmt.Errorf("auth secret: %w", err)
 	}
 	authState := auth.NewState(accessToken, jwtSecret)
+	// Production: decide static-asset cookie exemption by real-file existence
+	// in the embedded dist (fail-closed; tether#17). In dev mode the SPA is
+	// reverse-proxied to Vite, so the embedded dist doesn't describe live
+	// assets — leave staticFS unset and fall back to the suffix heuristic.
+	if cfg.DevFrontendURL == "" {
+		if distSub, err := fs.Sub(web.DistFS, "dist"); err == nil {
+			authState = authState.WithStaticFS(distSub)
+		} else {
+			slog.Warn("auth: embedded dist sub-FS failed; static exemption uses suffix heuristic", "err", err)
+		}
+	}
 
 	// Step 4d: open API token store for external MCP clients (v0.3.2).
 	apiTokensPath := cfg.APITokensPath


### PR DESCRIPTION
## What

Hardens the tether#16 fix. tether#16 gated the static-asset **suffix** exemption behind a denylist (`!isProtectedNamespace(p)` = not under `/api//wt//mcp`). That is **fail-open** for any *future* non-`/api` privileged prefix: if someone later adds `/admin/…` or `/debug/pprof/…`, then `/admin/x.js` becomes cookie-exempt again by suffix alone — silently re-opening tether#16's bug class with no failing test.

## Fix — fail-closed

In **production**, a static-asset path is exempt only if it **resolves to a real file in the embedded dist** (`fs.Stat` + `fs.ValidPath`). A path that isn't a shipped asset stays auth-gated regardless of suffix, so a future privileged prefix can't be masqueraded past auth.

- Injected via an optional `staticFS fs.FS` on `auth.State` (new `WithStaticFS` setter) → `NewState`'s signature and its 9 existing test callers are untouched.
- **Dev mode** (`--dev`; assets reverse-proxied to Vite, not described by the embedded dist): `staticFS` is nil → falls back to the suffix heuristic, still gated behind `isProtectedNamespace` — i.e. exactly the merged tether#16 behavior. Wired off the same `cfg.DevFrontendURL` that `newStaticHandler` uses for embed-vs-proxy, so auth-mode and serve-mode never diverge.
- `fs.ValidPath` rejects traversal (`..`), leading-slash residue (double-slash), trailing-slash/dir; `!IsDir()` rejects the `.`-root and directory paths. Percent-encoding is already decoded in `r.URL.Path` (same string the router matches), so there's no auth-vs-router normalization gap.

## Behavior delta vs tether#16

Prod now exempts a strict **subset** of tether#16's suffix exemptions, plus exactly `/index.html` and `/manifest.json` (both public — the SPA shell is already served unauthenticated at `/auth`; manifest is PWA metadata). Pinned by test.

## Tests

- `TestIsExempt_ProdExemptsOnlyRealDistFiles` (`fstest.MapFS`): real assets + `/index.html` + `/manifest.json` exempt; `/api/…`, future `/admin/…` + `/debug/…`, missing files, traversal, double-slash `//api/…`, and directory paths (`/assets`, `/assets/`) all NOT exempt.
- Existing suffix test now doubles as dev-mode (nil `staticFS`) coverage.
- `GOWORK=off` build (auth + server + `./cmd/tether`) + `go test -race` (auth + server) + `vet` green.

## Verification

- **Two independent reviews — both SHIP**: opus (adversarial security) confirmed strictly-safer-than-#16 with no bypass/over-block; fable (independent deep pass) found no blocking defects (traced `.`-root, `%2F`, dev/prod coupling, `WithStaticFS` concurrency).
- **Live-verified** on a real daemon (`:8801`): real assets → `200`; exploit `/api/v1/work/items/x.js` → `401`; **`/admin/config.js` → `302`** (the fail-closed win); absent asset `/assets/missing.js` → `302`.

Source: tether#16 opus review finding #1. Not exploitable today — preventive hardening.

🤖 Generated with [Claude Code](https://claude.com/claude-code)