### PR TITLE
fix(server): accept port-omitted Origin on :443 in the origin guard (tether#18)

### DIFF
--- a/internal/server/mux.go
+++ b/internal/server/mux.go
@@ -199,15 +199,26 @@ func WithOriginGuard(port int, h http.Handler) http.Handler {
 
 // originAllowed returns true when origin matches one of the daemon's own HTTPS
 // origins (127.0.0.1, localhost, or TETHER_HOST at the given port).
+//
+// Browsers omit the port for the default HTTPS port (443), so a page served
+// from a :443 deployment sends same-origin requests with Origin "https://<host>"
+// (no ":443"). Accept both the explicit-port and the bare form on 443, mirroring
+// the OAuth-issuer normalization in Run() (lifecycle.go). Without this, every
+// non-safe-method request (login, wt-ticket) is rejected 403 on a :443 host.
 func originAllowed(origin string, port int) bool {
-	portSuffix := fmt.Sprintf(":%d", port)
+	suffixes := []string{fmt.Sprintf(":%d", port)}
+	if port == 443 {
+		suffixes = append(suffixes, "")
+	}
 	hosts := []string{"127.0.0.1", "localhost"}
 	if h := os.Getenv("TETHER_HOST"); h != "" {
 		hosts = append(hosts, h)
 	}
 	for _, h := range hosts {
-		if origin == "https://"+h+portSuffix {
-			return true
+		for _, suffix := range suffixes {
+			if origin == "https://"+h+suffix {
+				return true
+			}
 		}
 	}
 	return false

--- a/internal/server/mux_mcp_test.go
+++ b/internal/server/mux_mcp_test.go
@@ -39,3 +39,48 @@ func TestTokensAPI_RejectsCrossOriginPost(t *testing.T) {
 		t.Fatalf("Origin-absent POST: expected pass-through, got 403")
 	}
 }
+
+// TestOriginGuard_Port443OmitsDefaultPort pins tether#18: on a :443 deployment the
+// browser omits the default HTTPS port, so a same-origin POST sends Origin
+// "https://<host>" (no ":443"). That must be allowed — otherwise login and wt-ticket
+// (every WebTransport connection) 403 and the app is unusable. A non-default port
+// must still require the explicit ":<port>", and cross-origin is always rejected.
+func TestOriginGuard_Port443OmitsDefaultPort(t *testing.T) {
+	ok := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) { w.WriteHeader(http.StatusOK) })
+	post := func(port int, origin string) int {
+		req := httptest.NewRequest("POST", "/api/v1/auth/verify", strings.NewReader("{}"))
+		if origin != "" {
+			req.Header.Set("Origin", origin)
+		}
+		rr := httptest.NewRecorder()
+		server.WithOriginGuard(port, ok).ServeHTTP(rr, req)
+		return rr.Code
+	}
+
+	// :443 — both the port-omitted and explicit-:443 forms must pass.
+	if code := post(443, "https://127.0.0.1"); code == http.StatusForbidden {
+		t.Errorf("port 443, Origin \"https://127.0.0.1\" (no :443): expected pass, got 403")
+	}
+	if code := post(443, "https://127.0.0.1:443"); code == http.StatusForbidden {
+		t.Errorf("port 443, Origin \"https://127.0.0.1:443\": expected pass, got 403")
+	}
+	// :443 — cross-origin still rejected.
+	if code := post(443, "https://evil.example.com"); code != http.StatusForbidden {
+		t.Errorf("port 443, cross-origin: expected 403, got %d", code)
+	}
+	// :443 — http scheme is never same-origin for an https-only daemon.
+	if code := post(443, "http://127.0.0.1"); code != http.StatusForbidden {
+		t.Errorf("port 443, http scheme: expected 403, got %d", code)
+	}
+	// :443 — host-suffix lookalike must not match (comparison is exact host equality).
+	if code := post(443, "https://127.0.0.1.evil.com"); code != http.StatusForbidden {
+		t.Errorf("port 443, host-suffix lookalike: expected 403, got %d", code)
+	}
+	// Non-default port — the bare (port-omitted) origin must NOT be accepted; explicit must.
+	if code := post(8898, "https://127.0.0.1"); code != http.StatusForbidden {
+		t.Errorf("port 8898, Origin without port: expected 403 (no default-port leniency), got %d", code)
+	}
+	if code := post(8898, "https://127.0.0.1:8898"); code == http.StatusForbidden {
+		t.Errorf("port 8898, Origin \"https://127.0.0.1:8898\": expected pass, got 403")
+	}
+}


### PR DESCRIPTION
## Summary
- `originAllowed` only accepted `https://<host>:<port>`. Browsers **omit the default HTTPS port**, so on a `:443` deployment (`--acme-domain` public serving) same-origin browser POSTs send `Origin: https://<host>` (no `:443`) and were **403'd** by `WithOriginGuard` — breaking login (`POST /api/v1/auth/verify`) and `wt-ticket` (issued before **every** WebTransport connection: chat/events/shell/control). The app was unusable on 443.
- Fix: accept the port-omitted form when `port == 443`, mirroring the OAuth-issuer normalization already in `Run()` (`lifecycle.go`). Since `originAllowed` is also the WebTransport `CheckOrigin` (`server.go:71`), this **also repairs the WT handshake on :443**.
- Port 80 intentionally not special-cased (tether is https-only).

## wi
tether#18: WithOriginGuard rejects legitimate same-origin writes on port 443.

## Test plan
- [x] `TestOriginGuard_Port443OmitsDefaultPort`: `:443` bare + explicit forms pass; cross-origin / `http://` scheme / host-suffix-lookalike rejected; **non-default port still requires the explicit `:port`** (no default-port leniency leaks).
- [x] `GOWORK=off go build ./...` + `go test -race ./internal/server` + `vet` green.
- [x] **Live-verified on a real daemon bound to :443**: `POST /api/v1/auth/verify` with `Origin: https://127.0.0.1` (no `:443`) + valid token → **200** (was 403 pre-fix); cross-origin → **403** (guard intact); explicit `:443` → **200**.

## Notes
Found + fixed as the **end-to-end validation** of the new `fix_bug.tether.md` coding-scenario variant (polyforge-coding#13): this wi ran through that variant's full step graph (prepare_context → code_change → verify → code_review[deep, subagent] → review_fix → live_verify → commit_and_pr → await_ci), driven by the scenario, not by hand.

🤖 Generated with [Claude Code](https://claude.com/claude-code)